### PR TITLE
Another turn of the "socket timeout" crank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+### v0.5.6 -- 2023-03-21
+
+Notable changes:
+
+* A more holistic attempt at doing socket timeouts.
+
 ### v0.5.5 -- 2023-03-20
 
 Notable changes:

--- a/src/builtin-services/private/RateLimitedStream.js
+++ b/src/builtin-services/private/RateLimitedStream.js
@@ -109,9 +109,9 @@ export class RateLimitedStream {
     inner.on('error', (error) => this.#onError(error));
 
     if (isReadable) {
-      // Note: Adding the `readable` listener (as is done here) causes the
-      // stream to become "paused" (that is, it won't spontaneously emit `data`
-      // events).
+      // Note: Adding a listener for the `readable` event (as is done here)
+      // causes the stream to become "paused" (that is, it won't spontaneously
+      // emit `data` events).
       inner.on('end',      () => this.#readableOnEnd());
       inner.on('readable', () => this.#readableOnReadable());
     }

--- a/src/builtin-services/private/RateLimitedStream.js
+++ b/src/builtin-services/private/RateLimitedStream.js
@@ -117,6 +117,10 @@ export class RateLimitedStream {
     }
 
     if (isSocket) {
+      inner.on('timeout', () => this.#outerStream.emit('timeout'));
+    }
+
+    if (isSocket) {
       return new RateLimitedStream.#SocketWrapper(this);
     } else if (isReadable) {
       return new RateLimitedStream.#DuplexWrapper(this);

--- a/src/builtin-services/private/RateLimitedStream.js
+++ b/src/builtin-services/private/RateLimitedStream.js
@@ -101,22 +101,24 @@ export class RateLimitedStream {
    * @returns {Duplex|Writable} The wrapper.
    */
   #createWrapper() {
-    const inner     = this.#innerStream;
-    const hasReader = inner instanceof Readable;
+    const inner    = this.#innerStream;
+    const isReader = inner instanceof Readable;
+    const isSocket = inner instanceof Socket;
 
     inner.on('close', () => this.#writableOnClose());
     inner.on('error', (error) => this.#onError(error));
 
-    if (hasReader) {
-      // Note: Adding the `readable` listener causes the stream to become
-      // "paused" (that is, it won't spontaneously emit `data` events).
+    if (isReader) {
+      // Note: Adding the `readable` listener (as is done here) causes the
+      // stream to become "paused" (that is, it won't spontaneously emit `data`
+      // events).
       inner.on('end',      () => this.#readableOnEnd());
       inner.on('readable', () => this.#readableOnReadable());
     }
 
-    if (inner instanceof Socket) {
+    if (isSocket) {
       return new RateLimitedStream.#SocketWrapper(this);
-    } else if (inner instanceof Readable) {
+    } else if (isReadable) {
       return new RateLimitedStream.#DuplexWrapper(this);
     } else {
       return new RateLimitedStream.#WritableWrapper(this);

--- a/src/builtin-services/private/RateLimitedStream.js
+++ b/src/builtin-services/private/RateLimitedStream.js
@@ -101,14 +101,14 @@ export class RateLimitedStream {
    * @returns {Duplex|Writable} The wrapper.
    */
   #createWrapper() {
-    const inner    = this.#innerStream;
-    const isReader = inner instanceof Readable;
-    const isSocket = inner instanceof Socket;
+    const inner      = this.#innerStream;
+    const isReadable = inner instanceof Readable;
+    const isSocket   = inner instanceof Socket;
 
     inner.on('close', () => this.#writableOnClose());
     inner.on('error', (error) => this.#onError(error));
 
-    if (isReader) {
+    if (isReadable) {
       // Note: Adding the `readable` listener (as is done here) causes the
       // stream to become "paused" (that is, it won't spontaneously emit `data`
       // events).

--- a/src/builtin-services/private/RateLimitedStream.js
+++ b/src/builtin-services/private/RateLimitedStream.js
@@ -338,6 +338,23 @@ export class RateLimitedStream {
     get remotePort() {
       return this.#outerThis.#innerStream.remotePort;
     }
+
+    /**
+     * @returns {number} The idle-timeout time, in msec. `0` indicates that
+     * timeout is disabled.
+     */
+    get timeout() {
+      return this.#outerThis.#innerStream.timeout;
+    }
+
+    /**
+     * @param {number} timeoutMsec The new idle-timeout time, in msec. `0`
+     * indicates that timeout is disabled.
+     */
+    set timeout(timeoutMsec) {
+      MustBe.number(timeoutMsec, { finite: true, minInclusive: 0 });
+      this.#outerThis.#innerStream.timeout = timeoutMsec;
+    }
   };
 
   /**

--- a/src/main-lactoserv/package.json
+++ b/src/main-lactoserv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@this/main-lactoserv",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "private": true,
   "license": "Apache-2.0",

--- a/src/network-protocol/private/Http2Wrangler.js
+++ b/src/network-protocol/private/Http2Wrangler.js
@@ -125,6 +125,9 @@ export class Http2Wrangler extends TcpWrangler {
     // reference, except the reference had gotten `null`ed out). So, with that
     // as context, if -- as we do here -- we tell the session to close as soon
     // as we see the underlying socket go away, there's no internal HTTP2 error.
+    // Salient issues in Node:
+    //   * <https://github.com/nodejs/node/issues/35695>
+    //   * <https://github.com/nodejs/node/issues/46094>
     ctx.socket.on('close', () => {
       if (!session.closed) {
         session.close();

--- a/src/network-protocol/private/Http2Wrangler.js
+++ b/src/network-protocol/private/Http2Wrangler.js
@@ -57,23 +57,6 @@ export class Http2Wrangler extends TcpWrangler {
 
     this.#protocolServer = http2.createSecureServer(serverOptions);
     this.#protocolServer.on('session', (session) => this.#addSession(session));
-
-    // Explicitly set the default socket timeout, as doing this _might_
-    // mitigate a memory leak as noted in
-    // <https://github.com/nodejs/node/issues/42710>. As of this writing, there
-    // _is_ a memory leak of some sort in this project, and the working
-    // hypothesis is that setting this timeout will suffice as a fix /
-    // workaround (depending on one's perspective).
-    // **Note:** `server.setTimeout(msec)` and `server.timeout = msec` do the
-    // same thing (though the former can be used with an extra argument to
-    // set up a callback at the same time).
-    this.#protocolServer.timeout = Http2Wrangler.#SOCKET_TIMEOUT_MSEC;
-
-    // TODO: Either remove this entirely, if it turns out that the server
-    // timeout is useless (for us), or add something useful here.
-    this.#protocolServer.on('timeout', () => {
-      this.#logger?.serverTimeout();
-    });
   }
 
   /** @override */
@@ -254,10 +237,4 @@ export class Http2Wrangler extends TcpWrangler {
    * before considering it "timed out" and telling it to close.
    */
   static #SESSION_TIMEOUT_MSEC = 1 * 60 * 1000; // One minute.
-
-  /**
-   * @type {number} How long in msec to wait before considering a socket
-   * "timed out."
-   */
-  static #SOCKET_TIMEOUT_MSEC = 3 * 60 * 1000; // Three minutes.
 }

--- a/src/network-protocol/private/HttpWrangler.js
+++ b/src/network-protocol/private/HttpWrangler.js
@@ -34,18 +34,6 @@ export class HttpWrangler extends TcpWrangler {
     this.#logger         = options.logger?.http ?? null;
     this.#application    = express();
     this.#protocolServer = http.createServer();
-
-    // Explicitly set the default socket timeout, as doing this _might_ help
-    // prevent memory leaks. See the longer comment in the `Http2Wrangler`
-    // constructor for details. The bug noted there is HTTP2-specific, but the
-    // possibility of socket leakage seems like it could easily happen here too.
-    this.#protocolServer.timeout = HttpWrangler.#SOCKET_TIMEOUT_MSEC;
-
-    // TODO: Either remove this entirely, if it turns out that the server
-    // timeout is useless (for us), or add something useful here.
-    this.#protocolServer.on('timeout', () => {
-      this.#logger?.serverTimeout();
-    });
   }
 
   /** @override */
@@ -71,15 +59,4 @@ export class HttpWrangler extends TcpWrangler {
   _impl_server() {
     return this.#protocolServer;
   }
-
-
-  //
-  // Static members
-  //
-
-  /**
-   * @type {number} How long in msec to wait before considering a socket
-   * "timed out."
-   */
-  static #SOCKET_TIMEOUT_MSEC = 3 * 60 * 1000; // Three minutes.
 }

--- a/src/network-protocol/private/HttpsWrangler.js
+++ b/src/network-protocol/private/HttpsWrangler.js
@@ -34,18 +34,6 @@ export class HttpsWrangler extends TcpWrangler {
     this.#logger         = options.logger?.https ?? null;
     this.#application    = express();
     this.#protocolServer = https.createServer(options.hosts);
-
-    // Explicitly set the default socket timeout, as doing this _might_ help
-    // prevent memory leaks. See the longer comment in the `Http2Wrangler`
-    // constructor for details. The bug noted there is HTTP2-specific, but the
-    // possibility of socket leakage seems like it could easily happen here too.
-    this.#protocolServer.timeout = HttpsWrangler.#SOCKET_TIMEOUT_MSEC;
-
-    // TODO: Either remove this entirely, if it turns out that the server
-    // timeout is useless (for us), or add something useful here.
-    this.#protocolServer.on('timeout', () => {
-      this.#logger?.serverTimeout();
-    });
   }
 
   /** @override */
@@ -71,15 +59,4 @@ export class HttpsWrangler extends TcpWrangler {
   _impl_server() {
     return this.#protocolServer;
   }
-
-
-  //
-  // Static members
-  //
-
-  /**
-   * @type {number} How long in msec to wait before considering a socket
-   * "timed out."
-   */
-  static #SOCKET_TIMEOUT_MSEC = 3 * 60 * 1000; // Three minutes.
 }

--- a/src/network-protocol/private/TcpWrangler.js
+++ b/src/network-protocol/private/TcpWrangler.js
@@ -139,6 +139,13 @@ export class TcpWrangler extends ProtocolWrangler {
     this.#sockets.add(socket);
     this.#anySockets.value = true;
 
+    // Note: Doing a socket timeout is a good idea in general. But beyond that,
+    // as of this writing, there's a bug in Node which causes it to consistently
+    // leak memory when sockets aren't proactively timed out, see issue #42710
+    // <https://github.com/nodejs/node/issues/42710>. We have observed memory
+    // leakage consistent with the issue in this project, and the working
+    // hypothesis is that setting this timeout will suffice as a fix /
+    // workaround (depending on one's perspective).
     socket.timeout = TcpWrangler.#SOCKET_TIMEOUT_MSEC;
     socket.on('timeout', async () => {
       this.#handleTimeout(socket, connLogger);

--- a/src/network-protocol/private/TcpWrangler.js
+++ b/src/network-protocol/private/TcpWrangler.js
@@ -146,8 +146,7 @@ export class TcpWrangler extends ProtocolWrangler {
     // leakage consistent with the issue in this project, and the working
     // hypothesis is that setting this timeout will suffice as a fix /
     // workaround (depending on one's perspective).
-    socket.timeout = TcpWrangler.#SOCKET_TIMEOUT_MSEC;
-    socket.on('timeout', async () => {
+    socket.setTimeout(TcpWrangler.#SOCKET_TIMEOUT_MSEC, () => {
       this.#handleTimeout(socket, connLogger);
     });
 

--- a/src/network-protocol/private/TcpWrangler.js
+++ b/src/network-protocol/private/TcpWrangler.js
@@ -209,7 +209,7 @@ export class TcpWrangler extends ProtocolWrangler {
 
     await Promise.race([
       closedCond.whenTrue(),
-      timers.setTimeout(TcpWrangler.SOCKET_TIMEOUT_CLOSE_GRACE_PERIOD_MSEC)
+      timers.setTimeout(TcpWrangler.#SOCKET_TIMEOUT_CLOSE_GRACE_PERIOD_MSEC)
     ]);
 
     if (socket.destroyed) {
@@ -222,7 +222,7 @@ export class TcpWrangler extends ProtocolWrangler {
 
     await Promise.race([
       closedCond.whenTrue(),
-      timers.setTimeout(TcpWrangler.SOCKET_TIMEOUT_CLOSE_GRACE_PERIOD_MSEC)
+      timers.setTimeout(TcpWrangler.#SOCKET_TIMEOUT_CLOSE_GRACE_PERIOD_MSEC)
     ]);
 
     if (socket.destroyed) {

--- a/src/network-protocol/private/TcpWrangler.js
+++ b/src/network-protocol/private/TcpWrangler.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as net from 'node:net';
+import { Server, Socket, createServer as netCreateServer } from 'node:net';
 import * as timers from 'node:timers/promises';
 
 import { Condition, Threadlet } from '@this/async';
@@ -22,7 +22,7 @@ export class TcpWrangler extends ProtocolWrangler {
   /** @type {?IntfRateLimiter} Rate limiter service to use, if any. */
   #rateLimiter;
 
-  /** @type {net.Server} Server socket, per se. */
+  /** @type {Server} Server socket, per se. */
   #serverSocket;
 
   /** @type {object} Server socket `listen()` options. */
@@ -55,7 +55,7 @@ export class TcpWrangler extends ProtocolWrangler {
 
     this.#logger        = options.logger ?? null;
     this.#rateLimiter   = options.rateLimiter ?? null;
-    this.#serverSocket  = net.createServer(serverOptions);
+    this.#serverSocket  = netCreateServer(serverOptions);
     this.#listenOptions = listenOptions;
     this.#loggableInfo  = {
       interface: FormatUtils.networkInterfaceString(options.interface),
@@ -98,7 +98,7 @@ export class TcpWrangler extends ProtocolWrangler {
    * manually. This is a relatively small price to pay for getting to be able to
    * have visibility on the actual network traffic.
    *
-   * @param {net.Socket} socket Socket for the newly-opened connection.
+   * @param {Socket} socket Socket for the newly-opened connection.
    * @param {...*} rest Any other arguments that happened to be be part of the
    *   `connection` event.
    */
@@ -187,7 +187,7 @@ export class TcpWrangler extends ProtocolWrangler {
   /**
    * Handles a timed out socket.
    *
-   * @param {net.Socket} socket The socket that timed out.
+   * @param {Socket} socket The socket that timed out.
    * @param {?IntfLogger} logger Logger to use, if any.
    */
   async #handleTimeout(socket, logger) {

--- a/src/network-protocol/private/TcpWrangler.js
+++ b/src/network-protocol/private/TcpWrangler.js
@@ -187,7 +187,7 @@ export class TcpWrangler extends ProtocolWrangler {
   /**
    * Handles a timed out socket.
    *
-   * @param {Socket} socket The socket that timed out.
+   * @param {net.Socket} socket The socket that timed out.
    * @param {?IntfLogger} logger Logger to use, if any.
    */
   async #handleTimeout(socket, logger) {
@@ -358,7 +358,7 @@ export class TcpWrangler extends ProtocolWrangler {
   /**
    * Trims down and "fixes" `options` using the given prototype. This is used
    * to convert from our incoming `interface` form to what's expected by Node's
-   * `net.server`.
+   * `Server` creation methods.
    *
    * @param {object} options Original options.
    * @param {object} proto The "prototype" for what bindings to keep.


### PR DESCRIPTION
This PR reworks the last couple days' worth of effort to do something useful when connected sockets time out.

Notably, during the course of this work, I ran into another case of the `null...finishWrite` exception. Existing Node bugs (the latter was filed by me):

* <https://github.com/nodejs/node/issues/35695>
* <https://github.com/nodejs/node/issues/46094>
