### PR TITLE
`Promise.race()`

### DIFF
--- a/src/app-framework/export/Warehouse.js
+++ b/src/app-framework/export/Warehouse.js
@@ -4,6 +4,7 @@
 import * as timers from 'node:timers/promises';
 
 import { WarehouseConfig } from '@this/app-config';
+import { PromiseUtil } from '@this/async';
 import { MustBe } from '@this/typey';
 
 import { BaseApplication } from '#x/BaseApplication';
@@ -103,13 +104,13 @@ export class Warehouse extends BaseControllable {
   async _impl_stop(willReload = false) {
     const endpointsStopped = this.#endpointManager.stop(willReload);
 
-    await Promise.race([
+    await PromiseUtil.race([
       endpointsStopped,
       timers.setTimeout(Warehouse.#ENDPOINT_STOP_GRACE_PERIOD_MSEC)
     ]);
 
     const applicationsStopped = this.#applicationManager.stop(willReload);
-    await Promise.race([
+    await PromiseUtil.race([
       applicationsStopped,
       timers.setTimeout(Warehouse.#APPLICATION_STOP_GRACE_PERIOD_MSEC)
     ]);

--- a/src/app-util/export/Rotator.js
+++ b/src/app-util/export/Rotator.js
@@ -249,9 +249,8 @@ export class Rotator {
         ? [timers.setTimeout(this.#checkMsec)]
         : [];
 
-      await Promise.race([
+      await this.#runner.raceWhenStopRequested([
         this.#rotateNow.whenTrue(),
-        this.#runner.whenStopRequested(),
         ...checkTimeout
       ]);
     }

--- a/src/async/export/EventSink.js
+++ b/src/async/export/EventSink.js
@@ -77,10 +77,7 @@ export class EventSink extends Threadlet {
       if (pass === 2) {
         // On the second pass, wait for something salient to happen. (On the
         // first pass, waiting would achieve nothing but inefficiency.)
-        await Promise.race([
-          this.#head.eventPromise,
-          this.whenStopRequested()
-        ]);
+        await this.raceWhenStopRequested([this.#head.eventPromise]);
       }
 
       if (!this.#draining && this.shouldStop()) {

--- a/src/async/export/PromiseUtil.js
+++ b/src/async/export/PromiseUtil.js
@@ -9,6 +9,13 @@ import { MustBe } from '@this/typey';
  */
 export class PromiseUtil {
   /**
+   * @type {WeakMap<object, {deferreds: Set<{resolve, reject}>, settled:
+   * boolean}>} Weak map, which maps values passed to {@link #race} to the data
+   * needed to resolve finished races involving those values.
+   */
+  static #raceMap = new WeakMap();
+
+  /**
    * Causes a rejected promise to be considered "handled." Can be passed
    * anything; this does nothing (other than waste a little time) when given a
    * non-promise or a fulfilled promise.
@@ -38,5 +45,87 @@ export class PromiseUtil {
     const result = Promise.reject(reason);
     this.handleRejection(result);
     return result;
+  }
+
+  /**
+   * Non-memory-leaking version of `Promise.race()`. The code here is based on
+   * an implementation by Brian Kim (first link below). See these bugs for more
+   * details:
+   *
+   * * <https://github.com/nodejs/node/issues/17469#issuecomment-685216777>
+   * * <https://bugs.chromium.org/p/v8/issues/detail?id=9858>
+   *
+   * @param {*[]} contenders Promises (or, degenerately, arbitrary objects) to
+   *   race.
+   * @returns {*} The resolved result from the first of `promises` to settle, if
+   *   the first to settle becomes resolved.
+   * @throws {*} The rejected result from the first of `promises` to settle, if
+   *   the first to settle becomes rejected.
+   */
+  static race(contenders) {
+    // This specific method body is covered by an "unlicense;" it is public
+    // domain to the extent possible.
+
+    const isPrimitive = (value) => {
+      return (value === null)
+        || ((typeof value !== 'object') && (typeof value !== 'function'));
+    };
+
+    let deferred;
+    const result = new Promise((resolve, reject) => {
+      deferred = { resolve, reject };
+      for (const contender of contenders) {
+        if (isPrimitive(contender)) {
+          // If the contender is a primitive, attempting to use it as a key in
+          // the weakmap would throw an error. Luckily, it is safe to call
+          // `Promise.resolve(contender).then` on a primitive value multiple
+          // times because the promise fulfills immediately.
+          Promise.resolve(contender).then(resolve, reject);
+          continue;
+        }
+
+        let record = this.#raceMap.get(contender);
+        if (record === undefined) {
+          record = { deferreds: new Set([deferred]), settled: false };
+          this.#raceMap.set(contender, record);
+          // This call to `then` happens once for the lifetime of the value.
+          Promise.resolve(contender).then(
+            (value) => {
+              for (const { resolve: recordResolve } of record.deferreds) {
+                recordResolve(value);
+              }
+
+              record.deferreds.clear();
+              record.settled = true;
+            },
+            (err) => {
+              for (const { reject: recordReject } of record.deferreds) {
+                recordReject(err);
+              }
+
+              record.deferreds.clear();
+              record.settled = true;
+            },
+          );
+        } else if (record.settled) {
+          // If the value has settled, it is safe to call
+          // `Promise.resolve(contender).then` on it.
+          Promise.resolve(contender).then(resolve, reject);
+        } else {
+          record.deferreds.add(deferred);
+        }
+      }
+    });
+
+    // The finally callback executes when any value settles, preventing any of
+    // the unresolved values from retaining a reference to the resolved value.
+    return result.finally(() => {
+      for (const contender of contenders) {
+        if (!isPrimitive(contender)) {
+          const record = this.#raceMap.get(contender);
+          record.deferreds.delete(deferred);
+        }
+      }
+    });
   }
 }

--- a/src/async/export/Threadlet.js
+++ b/src/async/export/Threadlet.js
@@ -105,10 +105,15 @@ export class Threadlet {
    * @throws {*} The rejected result of the promise that won the race.
    */
   async raceWhenStopRequested(promises) {
-    await PromiseUtil.race([
-      ...promises,
-      this.#runCondition.whenFalse()
-    ]);
+    const allProms = [...promises, this.#runCondition.whenFalse()];
+
+    if (allProms.length === 1) {
+      // No need to use `race()` if we turned out to get an empty argument
+      // (which can legit happen in practice).
+      await allProms[0];
+    } else {
+      await PromiseUtil.race(allProms);
+    }
 
     return this.shouldStop();
   }

--- a/src/async/export/Threadlet.js
+++ b/src/async/export/Threadlet.js
@@ -95,6 +95,25 @@ export class Threadlet {
   }
 
   /**
+   * Runs a `Promise.race()` between the result of {@link #whenStopRequested}
+   * and the given additional promises.
+   *
+   * @param {*[]} promises Array (or iterable in general) of promises to race.
+   * @returns {boolean} `true` iff this instance has been asked to stop
+   *  (as with {@link #shouldStop}), if the race was won by a non-rejected
+   *  promise.
+   * @throws {*} The rejected result of the promise that won the race.
+   */
+  async raceWhenStopRequested(promises) {
+    await PromiseUtil.race([
+      ...promises,
+      this.#runCondition.whenFalse()
+    ]);
+
+    return this.shouldStop();
+  }
+
+  /**
    * Starts this instance running, if it isn't already.  All processing in the
    * thread happens asynchronously with respect to the caller of this method.
    * The async-return value or exception thrown from this method is (in order):

--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -548,9 +548,8 @@ export class TokenBucket {
         const waitTime = this.#lastNow - info.startTime;
         info.doGrant(this.#requestGrantResult(got.grant, 'grant', waitTime));
       } else {
-        await Promise.race([
-          this.#waitUntil(got.waitUntil),
-          this.#waiterThread.whenStopRequested()
+        await this.#waiterThread.raceWhenStopRequested([
+          this.#waitUntil(got.waitUntil)
         ]);
       }
     }

--- a/src/async/tests/PromiseUtil.test.js
+++ b/src/async/tests/PromiseUtil.test.js
@@ -31,7 +31,7 @@ const wasHandled = async (promise) => {
   return !gotCalled;
 };
 
-describe('handleRejection', () => {
+describe('handleRejection()', () => {
   test('does indeed handle the rejection', async () => {
     const error = new Error('erroneous-monk');
     const prom  = Promise.reject(error);
@@ -41,7 +41,7 @@ describe('handleRejection', () => {
   });
 });
 
-describe('rejectAndHandle', () => {
+describe('rejectAndHandle()', () => {
   test('makes a rejected promise with the given reason', async () => {
     const error = new Error('erroneous-monk');
     const prom = PromiseUtil.rejectAndHandle(error);
@@ -55,4 +55,8 @@ describe('rejectAndHandle', () => {
     const prom  = PromiseUtil.rejectAndHandle(error);
     expect(await wasHandled(prom)).toBeTrue();
   });
+});
+
+describe('race()', () => {
+  // TODO
 });

--- a/src/async/tests/Threadlet.test.js
+++ b/src/async/tests/Threadlet.test.js
@@ -3,7 +3,7 @@
 
 import * as timers from 'node:timers/promises';
 
-import { PromiseState, PromiseUtil, Threadlet } from '@this/async';
+import { ManualPromise, PromiseState, PromiseUtil, Threadlet } from '@this/async';
 
 
 describe('constructor(function)', () => {
@@ -151,7 +151,111 @@ describe('isRunning()', () => {
 });
 
 describe('raceWhenStopRequested()', () => {
-  // TODO
+  test('when running, promptly returns `false` if there is an already-resolved argument', async () => {
+    let shouldRun = true;
+    const thread = new Threadlet(async () => {
+      while (shouldRun) {
+        await timers.setImmediate();
+      }
+    });
+
+    const runResult = thread.run();
+    const result    = thread.raceWhenStopRequested([Promise.resolve('boop')]);
+
+    expect(PromiseState.isSettled(result)).toBeFalse();
+    await timers.setImmediate();
+    expect(PromiseState.isSettled(result)).toBeTrue();
+    expect(await result).toBeFalse();
+
+    shouldRun = false;
+    await expect(runResult).toResolve();
+  });
+
+  test('when running, promptly throws if there is an already-rejected argument', async () => {
+    let shouldRun = true;
+    const thread = new Threadlet(async () => {
+      while (shouldRun) {
+        await timers.setImmediate();
+      }
+    });
+
+    const runResult = thread.run();
+    const rejected  = PromiseUtil.rejectAndHandle(new Error('oy!'));
+    const result    = thread.raceWhenStopRequested([rejected]);
+
+    PromiseUtil.handleRejection(result);
+    expect(PromiseState.isSettled(result)).toBeFalse();
+    await timers.setImmediate();
+    expect(PromiseState.isSettled(result)).toBeTrue();
+    await expect(result).toReject();
+
+    shouldRun = false;
+    await expect(runResult).toResolve();
+  });
+
+  test('when running, returns `false` when an argument becomes resolved', async () => {
+    let shouldRun = true;
+    const thread = new Threadlet(async () => {
+      while (shouldRun) {
+        await timers.setImmediate();
+      }
+    });
+
+    const runResult = thread.run();
+    const mp        = new ManualPromise();
+    const result    = thread.raceWhenStopRequested([mp.promise]);
+
+    expect(PromiseState.isSettled(result)).toBeFalse();
+    mp.resolve('boop');
+    await timers.setImmediate();
+    expect(PromiseState.isSettled(result)).toBeTrue();
+    expect(await result).toBeFalse();
+
+    shouldRun = false;
+    await expect(runResult).toResolve();
+  });
+
+  test('when running, throws when an argument becomes rejected', async () => {
+    let shouldRun = true;
+    const thread = new Threadlet(async () => {
+      while (shouldRun) {
+        await timers.setImmediate();
+      }
+    });
+
+    const runResult = thread.run();
+    const mp        = new ManualPromise();
+    const result    = thread.raceWhenStopRequested([mp.promise]);
+
+    PromiseUtil.handleRejection(result);
+    expect(PromiseState.isSettled(result)).toBeFalse();
+    mp.reject(new Error('eep!'));
+    await timers.setImmediate();
+    expect(PromiseState.isSettled(result)).toBeTrue();
+    await expect(result).toReject();
+
+    shouldRun = false;
+    await expect(runResult).toResolve();
+  });
+
+  test('when not running, promptly returns `true` when given no other arguments', async () => {
+    const thread = new Threadlet(() => null);
+    const result = thread.raceWhenStopRequested([]);
+
+    await timers.setImmediate();
+    expect(PromiseState.isSettled(result)).toBeTrue();
+    expect(await result).toBeTrue();
+  });
+
+  test('when not running, promptly returns `true` even given an unsettled argument', async () => {
+    const thread = new Threadlet(() => null);
+    const mp     = new ManualPromise();
+    const result = thread.raceWhenStopRequested([mp.promise]);
+
+    await timers.setImmediate();
+    expect(PromiseState.isSettled(result)).toBeTrue();
+    expect(await result).toBeTrue();
+  });
 });
 
 describe('run()', () => {

--- a/src/async/tests/Threadlet.test.js
+++ b/src/async/tests/Threadlet.test.js
@@ -150,6 +150,10 @@ describe('isRunning()', () => {
   });
 });
 
+describe('raceWhenStopRequested()', () => {
+  // TODO
+});
+
 describe('run()', () => {
   describe.each`
     useStartFunc | label

--- a/src/builtin-services/export/ProcessIdFile.js
+++ b/src/builtin-services/export/ProcessIdFile.js
@@ -155,10 +155,7 @@ export class ProcessIdFile extends BaseService {
         ? [timers.setTimeout(this.#updateSecs * 1000)]
         : [];
 
-      await Promise.race([
-        ...updateTimeout,
-        this.#runner.whenStopRequested()
-      ]);
+      await this.#runner.raceWhenStopRequested(updateTimeout);
     }
 
     await this.#updateFile(false);

--- a/src/builtin-services/export/ProcessInfoFile.js
+++ b/src/builtin-services/export/ProcessInfoFile.js
@@ -143,10 +143,7 @@ export class ProcessInfoFile extends BaseService {
         ? [timers.setTimeout(this.#updateSecs * 1000)]
         : [];
 
-      await Promise.race([
-        ...updateTimeout,
-        this.#runner.whenStopRequested()
-      ]);
+      await this.#runner.raceWhenStopRequested(updateTimeout);
     }
 
     await this.#stop();

--- a/src/host/export/KeepRunning.js
+++ b/src/host/export/KeepRunning.js
@@ -74,9 +74,8 @@ export class KeepRunning {
     // a timeout (or, alternatively, set a recurring timeout), and cancel it
     // (one way or another) when it's okay for the process to exit.
     while (!this.#thread.shouldStop()) {
-      await Promise.race([
-        timers.setTimeout(KeepRunning.#MSEC_PER_DAY),
-        this.#thread.whenStopRequested()
+      await this.#thread.raceWhenStopRequested([
+        timers.setTimeout(KeepRunning.#MSEC_PER_DAY)
       ]);
 
       const uptimeSecs = (Date.now() / 1000) - startedAtSecs;

--- a/src/main-lactoserv/private/UsualSystem.js
+++ b/src/main-lactoserv/private/UsualSystem.js
@@ -112,8 +112,7 @@ export class UsualSystem extends Threadlet {
         this.#reloadRequested.value = false;
       }
 
-      await Promise.race([
-        this.whenStopRequested(),
+      await this.raceWhenStopRequested([
         this.#reloadRequested.whenTrue()
       ]);
     }

--- a/src/network-protocol/private/Http2Wrangler.js
+++ b/src/network-protocol/private/Http2Wrangler.js
@@ -7,7 +7,7 @@ import * as timers from 'node:timers/promises';
 import express from 'express';
 import http2ExpressBridge from 'http2-express-bridge';
 
-import { Condition, Threadlet } from '@this/async';
+import { Condition, PromiseUtil, Threadlet } from '@this/async';
 import { IntfLogger } from '@this/loggy';
 
 import { TcpWrangler } from '#p/TcpWrangler';
@@ -213,7 +213,7 @@ export class Http2Wrangler extends TcpWrangler {
         break;
       }
 
-      await Promise.race([
+      await PromiseUtil.race([
         this.#anySessions.whenFalse(),
         timers.setTimeout(Http2Wrangler.#STOP_GRACE_PERIOD_MSEC)
       ]);

--- a/src/network-protocol/private/TcpWrangler.js
+++ b/src/network-protocol/private/TcpWrangler.js
@@ -4,7 +4,7 @@
 import { Server, Socket, createServer as netCreateServer } from 'node:net';
 import * as timers from 'node:timers/promises';
 
-import { Condition, Threadlet } from '@this/async';
+import { Condition, PromiseUtil, Threadlet } from '@this/async';
 import { FormatUtils, IntfLogger } from '@this/loggy';
 
 import { IntfRateLimiter } from '#x/IntfRateLimiter';
@@ -206,7 +206,7 @@ export class TcpWrangler extends ProtocolWrangler {
       logger?.closed();
     });
 
-    await Promise.race([
+    await PromiseUtil.race([
       closedCond.whenTrue(),
       timers.setTimeout(TcpWrangler.#SOCKET_TIMEOUT_CLOSE_GRACE_PERIOD_MSEC)
     ]);
@@ -219,7 +219,7 @@ export class TcpWrangler extends ProtocolWrangler {
     logger?.destroyingForcefully();
     socket.destroy();
 
-    await Promise.race([
+    await PromiseUtil.race([
       closedCond.whenTrue(),
       timers.setTimeout(TcpWrangler.#SOCKET_TIMEOUT_CLOSE_GRACE_PERIOD_MSEC)
     ]);


### PR DESCRIPTION
This PR imports and adapts the "safe `Promise.race()`" method, as written by Brian Kim (@brainkim), for use in this project. This is a workaround for a bug in V8 which causes perfectly cromulent uses of `Promise.race()` to leak memory (specifically, cases where a long-running system runs repeated races involving a long-unresolved promise). Links are included near the implementation, but FWIW see these for more detail:

* <https://github.com/nodejs/node/issues/17469#issuecomment-685216777>
* <https://bugs.chromium.org/p/v8/issues/detail?id=9858>

In this codebase, the upshot of the bug is that (almost?) every event that got logged was leaked, along with a bit of related "connective tissue."

Many many thanks to Brian for writing the code in question, and explaining the issue thoroughly.