### PR TITLE
"Don't close FDs" Part 2

### DIFF
--- a/src/app-config/export/EndpointConfig.js
+++ b/src/app-config/export/EndpointConfig.js
@@ -35,7 +35,10 @@ export class EndpointConfig extends NamedConfig {
   /** @type {string[]} The hostnames in question. */
   #hostnames;
 
-  /** @type {object} Physical interface to listen on. */
+  /**
+   * @type {object} Physical interface to listen on; this is the result of a
+   * call to {@link Uris#parseInterface}.
+   */
   #interface;
 
   /** @type {string} High-level protocol to speak. */

--- a/src/network-protocol/private/AsyncServer.js
+++ b/src/network-protocol/private/AsyncServer.js
@@ -63,7 +63,7 @@ export class AsyncServer {
    * closed in which case this method does nothing. This method async-returns
    * once the server has actually stopped listening for connections.
    */
-  static async close() {
+  async close() {
     await AsyncServer.serverClose(this.#serverSocket);
   }
 
@@ -73,6 +73,16 @@ export class AsyncServer {
    */
   async listen() {
     await AsyncServer.serverListen(this.#serverSocket, this.#interface);
+  }
+
+  /**
+   * Passthrough of `on()` to the underlying server socket.
+   *
+   * @param {string} eventName Event name.
+   * @param {function(...*)} listener Listener callback function.
+   */
+  on(eventName, listener) {
+    this.#serverSocket.on(eventName, listener);
   }
 
 

--- a/src/network-protocol/private/AsyncServer.js
+++ b/src/network-protocol/private/AsyncServer.js
@@ -5,9 +5,10 @@ import { Server, createServer as netCreateServer } from 'node:net';
 
 
 /**
- * Utility class for doing some of the lowest-level server socket manipulation.
+ * Utility class for doing some of the lowest-level server socket manipulation,
+ * in a way that is `async`-friendly.
  */
-export class SocketUtil {
+export class AsyncServer {
   /**
    * @type {object} "Prototype" of server socket creation options. See
    * `ProtocolWrangler` class doc for details.

--- a/src/network-protocol/private/TcpWrangler.js
+++ b/src/network-protocol/private/TcpWrangler.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { Server, Socket } from 'node:net';
+import { Socket } from 'node:net';
 import * as timers from 'node:timers/promises';
 
 import { Condition, PromiseUtil, Threadlet } from '@this/async';

--- a/src/network-protocol/private/TcpWrangler.js
+++ b/src/network-protocol/private/TcpWrangler.js
@@ -7,9 +7,9 @@ import * as timers from 'node:timers/promises';
 import { Condition, PromiseUtil, Threadlet } from '@this/async';
 import { FormatUtils, IntfLogger } from '@this/loggy';
 
+import { AsyncServer } from '#p/AsyncServer';
 import { IntfRateLimiter } from '#x/IntfRateLimiter';
 import { ProtocolWrangler } from '#x/ProtocolWrangler';
-import { SocketUtil } from '#p/SocketUtil';
 
 
 /**
@@ -52,7 +52,7 @@ export class TcpWrangler extends ProtocolWrangler {
     this.#logger           = options.logger ?? null;
     this.#interfaceOptions = options.interface;
     this.#rateLimiter      = options.rateLimiter ?? null;
-    this.#serverSocket     = SocketUtil.createServer(options.interface);
+    this.#serverSocket     = AsyncServer.createServer(options.interface);
 
     this.#loggableInfo = {
       interface: FormatUtils.networkInterfaceString(options.interface),
@@ -244,7 +244,7 @@ export class TcpWrangler extends ProtocolWrangler {
     // the stop request and then shut things down.
     await this.#runner.whenStopRequested();
 
-    await SocketUtil.serverClose(this.#serverSocket);
+    await AsyncServer.serverClose(this.#serverSocket);
     await this.#anySockets.whenFalse();
   }
 
@@ -253,7 +253,7 @@ export class TcpWrangler extends ProtocolWrangler {
    * {@link #runner}.
    */
   async #start() {
-    await SocketUtil.serverListen(this.#serverSocket, this.#interfaceOptions);
+    await AsyncServer.serverListen(this.#serverSocket, this.#interfaceOptions);
   }
 
 

--- a/src/network-protocol/private/TcpWrangler.js
+++ b/src/network-protocol/private/TcpWrangler.js
@@ -20,17 +20,14 @@ export class TcpWrangler extends ProtocolWrangler {
   /** @type {?IntfLogger} Logger to use, or `null` to not do any logging. */
   #logger;
 
-  /** @type {object} Server socket `interface` options. */
-  #interfaceOptions;
-
   /** @type {?IntfRateLimiter} Rate limiter service to use, if any. */
   #rateLimiter;
 
-  /** @type {Server} Server socket, per se. */
-  #serverSocket;
-
-  /** @type {object} Loggable info, minus any "active listening" info. */
-  #loggableInfo = {};
+  /**
+   * @type {AsyncServer} Underlying server socket, wrapped for `async`
+   * friendliness.
+   */
+  #asyncServer;
 
   /** @type {Condition} Are there currently any open sockets? */
   #anySockets = new Condition();
@@ -49,18 +46,12 @@ export class TcpWrangler extends ProtocolWrangler {
   constructor(options) {
     super(options);
 
-    this.#logger           = options.logger ?? null;
-    this.#interfaceOptions = options.interface;
-    this.#rateLimiter      = options.rateLimiter ?? null;
-    this.#serverSocket     = AsyncServer.createServer(options.interface);
+    this.#logger      = options.logger ?? null;
+    this.#rateLimiter = options.rateLimiter ?? null;
+    this.#asyncServer = new AsyncServer(options.interface, options.protocol);
 
-    this.#loggableInfo = {
-      interface: FormatUtils.networkInterfaceString(options.interface),
-      protocol:  options.protocol
-    };
-
-    this.#serverSocket.on('connection', (...args) => this.#handleConnection(...args));
-    this.#serverSocket.on('drop', (...args) => this.#handleDrop(...args));
+    this.#asyncServer.on('connection', (...args) => this.#handleConnection(...args));
+    this.#asyncServer.on('drop', (...args) => this.#handleDrop(...args));
   }
 
   /** @override */
@@ -75,14 +66,7 @@ export class TcpWrangler extends ProtocolWrangler {
 
   /** @override */
   _impl_loggableInfo() {
-    const address = this.#serverSocket.address();
-    const info    = { ...this.#loggableInfo };
-
-    if (address) {
-      info.listening = FormatUtils.networkInterfaceString(address);
-    }
-
-    return info;
+    return this.#asyncServer.loggableInfo;
   }
 
   /**
@@ -244,7 +228,7 @@ export class TcpWrangler extends ProtocolWrangler {
     // the stop request and then shut things down.
     await this.#runner.whenStopRequested();
 
-    await AsyncServer.serverClose(this.#serverSocket);
+    await this.#asyncServer.close();
     await this.#anySockets.whenFalse();
   }
 
@@ -253,7 +237,7 @@ export class TcpWrangler extends ProtocolWrangler {
    * {@link #runner}.
    */
   async #start() {
-    await AsyncServer.serverListen(this.#serverSocket, this.#interfaceOptions);
+    await this.#asyncServer.listen();
   }
 
 


### PR DESCRIPTION
This PR is the second bit of prep before fixing the problem wherein a server started with FD-specified interfaces can't be successfully reloaded. In this one, the previously-separated server socket utility functionality becomes a fully-fledged instantiable class. It made for some nice cleanup in `TcpWrangler`.