### PR TITLE
More fd prep, with event system yak shave.

### DIFF
--- a/src/app-framework/export/NetworkEndpoint.js
+++ b/src/app-framework/export/NetworkEndpoint.js
@@ -83,8 +83,8 @@ export class NetworkEndpoint extends BaseComponent {
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
-    await this.#wrangler.start();
+  async _impl_start(isReload) {
+    await this.#wrangler.start(isReload);
   }
 
   /**
@@ -93,8 +93,8 @@ export class NetworkEndpoint extends BaseComponent {
    *
    * @override
    */
-  async _impl_stop(willReload_unused) {
-    await this.#wrangler.stop();
+  async _impl_stop(willReload) {
+    await this.#wrangler.stop(willReload);
   }
 
   /**

--- a/src/async/export/EventPayload.js
+++ b/src/async/export/EventPayload.js
@@ -1,0 +1,62 @@
+// Copyright 2022-2023 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { MustBe } from '@this/typey';
+
+
+/**
+ * Standard minimal event payload.
+ */
+export class EventPayload {
+  /** @type {string} Event "type." */
+  #type;
+
+  /** @type {*[]} Event arguments. */
+  #args;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {string} type "Type" of the instance, e.g. think of this as
+   *   something like a constructor class name if event payloads could be
+   *   "invoked."
+   * @param {...*} args Arbitrary arguments of the instance, whose meaning
+   *   depends on the type.
+   */
+  constructor(type, ...args) {
+    this.#type = MustBe.string(type);
+    this.#args = Object.freeze([...args]);
+  }
+
+  /** @returns {*[]} Event arguments, whose meaning depends on {@link #type}. */
+  get args() {
+    return this.#args;
+  }
+
+  /** @returns {string} Event "type." */
+  get type() {
+    return this.#type;
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @type {string} Default event type to use for "kickoff" instances. */
+  static #KICKOFF_TYPE = 'kickoff';
+
+  /**
+   * Constructs a minimal instance of this class, suitable for use as the
+   * payload for a "kickoff" event passed to the {@link EventSource}
+   * constructor.
+   *
+   * @param {?string} [type = null] Type to use for the instance, or `null` to
+   *   use a default.
+   * @returns {EventPayload} A minimal instance for "kickoff."
+   */
+  static makeKickoffInstance(type = null) {
+    type ??= this.#KICKOFF_TYPE;
+    return new EventPayload(type ?? this.#KICKOFF_TYPE);
+  }
+}

--- a/src/async/export/EventSource.js
+++ b/src/async/export/EventSource.js
@@ -3,6 +3,7 @@
 
 import { MustBe } from '@this/typey';
 
+import { EventPayload } from '#x/EventPayload';
 import { LinkedEvent } from '#x/LinkedEvent';
 
 
@@ -74,7 +75,9 @@ export class EventSource {
    *   (remember), not including the current (most-recently emitted) event.
    *   Must be a whole number or positive infinity.
    * @param {?LinkedEvent} [options.kickoffEvent = null] "Kickoff" event, or
-   *   `null` to use the default of a direct instance of {@link LinkedEvent}.
+   *   `null` to use the default of a direct instance of {@link LinkedEvent}
+   *   which holds the result of a call to {@link
+   *   EventPayload#makeKickoffInstance}.
    */
   constructor(options) {
     const kickoffEvent = options?.kickoffEvent ?? null;
@@ -89,7 +92,7 @@ export class EventSource {
     }
 
     this.#keepCount     = keepCount;
-    this.#earliestEvent = kickoffEvent ?? new LinkedEvent('chain-head');
+    this.#earliestEvent = kickoffEvent ?? new LinkedEvent(EventPayload.makeKickoffInstance());
     this.#currentEvent  = this.#earliestEvent;
     this.#emitNext      = this.#currentEvent.emitter;
   }

--- a/src/async/export/EventSource.js
+++ b/src/async/export/EventSource.js
@@ -84,9 +84,8 @@ export class EventSource {
       MustBe.instanceOf(kickoffEvent, LinkedEvent);
     }
 
-    if (!(   (Number.isSafeInteger(keepCount) && (keepCount >= 0))
-          || (keepCount === Number.POSITIVE_INFINITY))) {
-      throw new Error('Invalid value for `keepCount`.');
+    if (keepCount !== Number.POSITIVE_INFINITY) {
+      MustBe.number(keepCount, { safeInteger: true });
     }
 
     this.#keepCount     = keepCount;

--- a/src/async/export/EventSource.js
+++ b/src/async/export/EventSource.js
@@ -1,6 +1,8 @@
 // Copyright 2022-2023 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { MustBe } from '@this/typey';
+
 import { LinkedEvent } from '#x/LinkedEvent';
 
 
@@ -77,6 +79,10 @@ export class EventSource {
   constructor(options) {
     const kickoffEvent = options?.kickoffEvent ?? null;
     const keepCount    = options?.keepCount ?? 0;
+
+    if (kickoffEvent !== null) {
+      MustBe.instanceOf(kickoffEvent, LinkedEvent);
+    }
 
     if (!(   (Number.isSafeInteger(keepCount) && (keepCount >= 0))
           || (keepCount === Number.POSITIVE_INFINITY))) {

--- a/src/async/export/LinkedEvent.js
+++ b/src/async/export/LinkedEvent.js
@@ -75,6 +75,15 @@ export class LinkedEvent {
   }
 
   /**
+   * @returns {*[]} The event's argument list, as defined by the {@link
+   * #payload}. This just passes through to `.args` on the payload, and
+   * guarantees the return type.
+   */
+  get args() {
+    return MustBe.array(this.#payload.args);
+  }
+
+  /**
    * Gets a function which emits the next event -- that is, which causes {@link
    * #nextNow} to become known and thus appends a new event to the chain -- and
    * then returns the emitter function for the next-next event.

--- a/src/async/export/LinkedEvent.js
+++ b/src/async/export/LinkedEvent.js
@@ -7,6 +7,10 @@ import { EventOrPromise } from '#p/EventOrPromise';
 import { ManualPromise } from '#x/ManualPromise';
 
 
+// TODO: This class should enforce same-classness on payloads on the chain, and
+// then we should drop having subclasses of `LinkedEvent` be a thing (because
+// that's all they were doing.)
+
 /**
  * Promise-chained event. Each instance becomes chained (linked, as in a linked
  * list) to the next event which gets emitted by the same source. The chain is

--- a/src/async/index.js
+++ b/src/async/index.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '#x/Condition';
+export * from '#x/EventPayload';
 export * from '#x/EventSink';
 export * from '#x/EventSource';
 export * from '#x/EventTracker';

--- a/src/async/tests/EventSource.test.js
+++ b/src/async/tests/EventSource.test.js
@@ -3,7 +3,7 @@
 
 import * as timers from 'node:timers/promises';
 
-import { EventSource, LinkedEvent, PromiseState } from '@this/async';
+import { EventPayload, EventSource, LinkedEvent, PromiseState } from '@this/async';
 
 
 // For testing subclass scenarios.
@@ -11,21 +11,21 @@ class ZanyEvent extends LinkedEvent {
   // This space intentionally left blank.
 }
 
-const payload1 = { type: 'wacky' };
-const payload2 = { type: 'zany' };
-const payload3 = { type: 'questionable' };
+const payload1 = new EventPayload('wacky');
+const payload2 = new EventPayload('zany');
+const payload3 = new EventPayload('questionable');
 
 describe.each`
-  label                             | argFn                                           | cls             | keepCount
-  ${''}                             | ${() => []}                                     | ${LinkedEvent} | ${0}
-  ${'null'}                         | ${() => [null]}                                 | ${LinkedEvent} | ${0}
-  ${'undefined'}                    | ${() => [undefined]}                            | ${LinkedEvent} | ${0}
-  ${'{ keepCount: 0 }'}             | ${() => [{ keepCount: 0 }]}                     | ${LinkedEvent} | ${0}
-  ${'{ keepCount: 1 }'}             | ${() => [{ keepCount: 1 }]}                     | ${LinkedEvent} | ${1}
-  ${'{ keepCount: 10 }'}            | ${() => [{ keepCount: 10 }]}                    | ${LinkedEvent} | ${10}
-  ${'{ keepCount: +inf }'}          | ${() => [{ keepCount: Infinity }]}              | ${LinkedEvent} | ${Infinity}
-  ${'{ kickoffEvent: null }'}       | ${() => [{ kickoffEvent: null }]}               | ${LinkedEvent} | ${0}
-  ${'{ kickoffEvent: <subclass> }'} | ${() => [{ kickoffEvent: new ZanyEvent('x') }]} | ${ZanyEvent}    | ${0}
+  label                             | argFn                                                | cls             | keepCount
+  ${''}                             | ${() => []}                                          | ${LinkedEvent} | ${0}
+  ${'null'}                         | ${() => [null]}                                      | ${LinkedEvent} | ${0}
+  ${'undefined'}                    | ${() => [undefined]}                                 | ${LinkedEvent} | ${0}
+  ${'{ keepCount: 0 }'}             | ${() => [{ keepCount: 0 }]}                          | ${LinkedEvent} | ${0}
+  ${'{ keepCount: 1 }'}             | ${() => [{ keepCount: 1 }]}                          | ${LinkedEvent} | ${1}
+  ${'{ keepCount: 10 }'}            | ${() => [{ keepCount: 10 }]}                         | ${LinkedEvent} | ${10}
+  ${'{ keepCount: +inf }'}          | ${() => [{ keepCount: Infinity }]}                   | ${LinkedEvent} | ${Infinity}
+  ${'{ kickoffEvent: null }'}       | ${() => [{ kickoffEvent: null }]}                    | ${LinkedEvent} | ${0}
+  ${'{ kickoffEvent: <subclass> }'} | ${() => [{ kickoffEvent: new ZanyEvent(payload1) }]} | ${ZanyEvent}    | ${0}
 `('constructor($label)', ({ argFn, cls, keepCount }) => {
   test('trivially succeeds', () => {
     expect(() => new EventSource(...argFn())).not.toThrow();
@@ -164,7 +164,7 @@ describe.each`
         testCounts.shift();
         await checkCount(i, source[prop]);
       }
-      events.push(source.emit({ count: i }));
+      events.push(source.emit(new EventPayload('count', i)));
       if (doTest) {
         await checkCount(i + 1, source[prop]);
       }

--- a/src/async/tests/LinkedEvent.test.js
+++ b/src/async/tests/LinkedEvent.test.js
@@ -3,12 +3,12 @@
 
 import * as timers from 'node:timers/promises';
 
-import { LinkedEvent, ManualPromise, PromiseState } from '@this/async';
+import { EventPayload, LinkedEvent, ManualPromise, PromiseState } from '@this/async';
 
 
-const payload1 = { type: 'wacky' };
-const payload2 = { type: 'zany' };
-const payload3 = { type: 'questionable' };
+const payload1 = new EventPayload('wacky');
+const payload2 = new EventPayload('zany');
+const payload3 = new EventPayload('questionable');
 
 describe.each`
   label                   | args
@@ -227,6 +227,18 @@ describe('.emitter', () => {
     expect(() => emitter(payload2)).toThrow();
     expect(() => emitter(payload2)).toThrow();
   });
+
+  test('returns a function which requires the payload to be an `instanceof` this class\'s payload', () => {
+    class SomePayload extends EventPayload {
+      // This space intentionally left blank.
+    }
+
+    const event   = new LinkedEvent(new SomePayload('beep', 1, 2, 3));
+    const emitter = event.emitter;
+
+    expect(() => emitter(new EventPayload('blorp'))).toThrow();
+    expect(() => emitter(new SomePayload('blorp'))).not.toThrow();
+  });
 });
 
 describe('.nextNow', () => {
@@ -358,6 +370,16 @@ describe('withPayload()', () => {
     const result2 = event.withPayload(payload2);
     expect(() => result2.emitter).toThrow();
   });
+
+  test('fails if the given payload does not match the class of the existing payload', () => {
+    class SomePayload extends EventPayload {
+      // This space intentionally left blank.
+    }
+
+    const event = new LinkedEvent(new SomePayload('boop'));
+    expect(() => event.withPayload(payload1)).toThrow();
+    expect(() => event.withPayload(new SomePayload('bop'))).not.toThrow();
+  });
 });
 
 describe('withPushedHead()', () => {
@@ -392,6 +414,16 @@ describe('withPushedHead()', () => {
     const event2  = new LinkedEvent(payload1, new LinkedEvent(payload3));
     const result2 = event2.withPushedHead(payload2);
     expect(() => result2.emitter).toThrow();
+  });
+
+  test('fails if the given payload does not match the class of the existing payload', () => {
+    class SomePayload extends EventPayload {
+      // This space intentionally left blank.
+    }
+
+    const event = new LinkedEvent(new SomePayload('boop'));
+    expect(() => event.withPushedHead(payload1)).toThrow();
+    expect(() => event.withPushedHead(new SomePayload('bop'))).not.toThrow();
   });
 });
 

--- a/src/async/tests/LinkedEvent.test.js
+++ b/src/async/tests/LinkedEvent.test.js
@@ -189,6 +189,15 @@ describe('constructor(payload, next: Promise) -- invalid resolution', () => {
   });
 });
 
+describe('.args', () => {
+  test('is the `args` (by content) of the payload from construction', async () => {
+    const args  = ['bleep', 'bloop', 1, 2, 3];
+    const event = new LinkedEvent(new EventPayload('x', ...args));
+
+    expect(event.args).toStrictEqual(args);
+  });
+});
+
 describe('.emitter', () => {
   test('returns something the first time it is called', () => {
     const event = new LinkedEvent(payload1);

--- a/src/loggy/export/LogRecord.js
+++ b/src/loggy/export/LogRecord.js
@@ -8,6 +8,7 @@ import { MustBe } from '@this/typey';
 
 import { LogTag } from '#x/LogTag';
 
+// TODO: Rename this to `LogPayload` and make it inherit from `EventPayload`.
 
 /**
  * The thing which is logged; it is the payload class for events used by this

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -65,6 +65,12 @@ export class ProtocolWrangler {
   /** @type {boolean} Has initialization been finished? */
   #initialized = false;
 
+  /**
+   * @type {boolean} Is a system reload in progress (either during start or
+   * stop)?
+   */
+  #reloading = false;
+
 
   /**
    * Constructs an instance.
@@ -111,9 +117,11 @@ export class ProtocolWrangler {
    * the high-level application. This method async-returns once the instance has
    * actually gotten started.
    *
+   * @param {boolean} isReload Is this action due to an in-process reload?
    * @throws {Error} Thrown if there was any trouble starting up.
    */
-  async start() {
+  async start(isReload) {
+    this.#reloading = isReload;
     this.#initialize();
     return this.#runner.start();
   }
@@ -125,9 +133,12 @@ export class ProtocolWrangler {
    * If this instance wasn't running in the first place, this method does
    * nothing.
    *
+   * @param {boolean} willReload Is this action due to an in-process reload
+   *   being requested?
    * @throws {Error} Whatever problem occurred during running.
    */
-  async stop() {
+  async stop(willReload) {
+    this.#reloading = willReload;
     return this.#runner.stop();
   }
 

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -159,9 +159,10 @@ export class ProtocolWrangler {
    * async-return once the stack really is ready.
    *
    * @abstract
+   * @param {boolean} isReload Is this action due to an in-process reload?
    */
-  async _impl_applicationStart() {
-    Methods.abstract();
+  async _impl_applicationStart(isReload) {
+    Methods.abstract(isReload);
   }
 
   /**
@@ -171,9 +172,11 @@ export class ProtocolWrangler {
    * async-return once the stack really is stopped.
    *
    * @abstract
+   * @param {boolean} willReload Is this action due to an in-process reload
+   *   being requested?
    */
-  async _impl_applicationStop() {
-    Methods.abstract();
+  async _impl_applicationStop(willReload) {
+    Methods.abstract(willReload);
   }
 
   /**
@@ -202,9 +205,10 @@ export class ProtocolWrangler {
    * should only async-return once the socket is really listening.
    *
    * @abstract
+   * @param {boolean} isReload Is this action due to an in-process reload?
    */
-  async _impl_serverSocketStart() {
-    Methods.abstract();
+  async _impl_serverSocketStart(isReload) {
+    Methods.abstract(isReload);
   }
 
   /**
@@ -212,9 +216,11 @@ export class ProtocolWrangler {
    * This should only async-return once the socket is truly stopped / closed.
    *
    * @abstract
+   * @param {boolean} willReload Is this action due to an in-process reload
+   *   being requested?
    */
-  async _impl_serverSocketStop() {
-    Methods.abstract();
+  async _impl_serverSocketStop(willReload) {
+    Methods.abstract(willReload);
   }
 
   /**
@@ -506,8 +512,8 @@ export class ProtocolWrangler {
     // We do these in parallel, because there can be mutual dependencies, e.g.
     // the application might need to see the server stopping _and_ vice versa.
     await Promise.all([
-      this._impl_serverSocketStop(),
-      this._impl_applicationStop()
+      this._impl_serverSocketStop(this.#reloading),
+      this._impl_applicationStop(this.#reloading)
     ]);
 
     if (this.#logger) {
@@ -524,8 +530,8 @@ export class ProtocolWrangler {
       this.#logger.starting(this._impl_loggableInfo());
     }
 
-    await this._impl_applicationStart();
-    await this._impl_serverSocketStart();
+    await this._impl_applicationStart(this.#reloading);
+    await this._impl_serverSocketStart(this.#reloading);
 
     if (this.#logger) {
       this.#logger.started(this._impl_loggableInfo());

--- a/src/network-protocol/private/AsyncServer.js
+++ b/src/network-protocol/private/AsyncServer.js
@@ -53,11 +53,6 @@ export class AsyncServer {
     };
   }
 
-  /** @returns {Server} The underlying server socket instance. */
-  get serverSocket() {
-    return this.#serverSocket;
-  }
-
   /**
    * Passthrough of `on()` to the underlying server socket.
    *

--- a/src/network-protocol/private/AsyncServer.js
+++ b/src/network-protocol/private/AsyncServer.js
@@ -59,11 +59,45 @@ export class AsyncServer {
   }
 
   /**
+   * Passthrough of `on()` to the underlying server socket.
+   *
+   * @param {string} eventName Event name.
+   * @param {function(...*)} listener Listener callback function.
+   */
+  on(eventName, listener) {
+    this.#serverSocket.on(eventName, listener);
+  }
+
+  /**
+   * Starts this instance.
+   *
+   * @param {boolean} isReload Is this action due to an in-process reload?
+   */
+  async start(isReload) {
+    MustBe.boolean(isReload);
+
+    await this.#listen();
+  }
+
+  /**
+   * Stops this this instance. This method returns when the instance is fully
+   * stopped.
+   *
+   * @param {boolean} willReload Is this action due to an in-process reload
+   *   being requested?
+   */
+  async stop(willReload) {
+    MustBe.boolean(willReload);
+
+    await this.#close();
+  }
+
+  /**
    * Performs a `close()` on the underlying {@link Server}, unless it is already
    * closed in which case this method does nothing. This method async-returns
    * once the server has actually stopped listening for connections.
    */
-  async close() {
+  async #close() {
     const serverSocket = this.#serverSocket;
 
     if (!serverSocket.listening) {
@@ -105,7 +139,7 @@ export class AsyncServer {
    * Performs a `listen()` on the underlying {@link Server}. This method
    * async-returns once the server is actually listening.
    */
-  async listen() {
+  async #listen() {
     const serverSocket = this.#serverSocket;
 
     // This `await new Promise` arrangement is done to get the `listen()` call
@@ -137,16 +171,6 @@ export class AsyncServer {
 
       serverSocket.listen(AsyncServer.#extractListenOptions(this.#interface));
     });
-  }
-
-  /**
-   * Passthrough of `on()` to the underlying server socket.
-   *
-   * @param {string} eventName Event name.
-   * @param {function(...*)} listener Listener callback function.
-   */
-  on(eventName, listener) {
-    this.#serverSocket.on(eventName, listener);
   }
 
 

--- a/src/network-protocol/private/AsyncServer.js
+++ b/src/network-protocol/private/AsyncServer.js
@@ -26,10 +26,7 @@ export class AsyncServer {
   #serverSocket = null;
 
   /** @type {EventSource} Event source for `connection` and `drop` events. */
-  #eventSource = new EventSource({
-    // TODO: Should be able to say `kickoffPayload`.
-    kickoffEvent: new LinkedEvent(EventPayload.makeKickoffInstance())
-  });
+  #eventSource = new EventSource();
 
   /**
    * @type {Promise<LinkedEvent>} Promise for the next event which will need

--- a/src/network-protocol/private/Http2Wrangler.js
+++ b/src/network-protocol/private/Http2Wrangler.js
@@ -65,12 +65,12 @@ export class Http2Wrangler extends TcpWrangler {
   }
 
   /** @override */
-  async _impl_applicationStart() {
+  async _impl_applicationStart(isReload_unused) {
     this.#runner.run();
   }
 
   /** @override */
-  async _impl_applicationStop() {
+  async _impl_applicationStop(willReload_unused) {
     return this.#runner.stop();
   }
 

--- a/src/network-protocol/private/HttpWrangler.js
+++ b/src/network-protocol/private/HttpWrangler.js
@@ -42,12 +42,12 @@ export class HttpWrangler extends TcpWrangler {
   }
 
   /** @override */
-  async _impl_applicationStart() {
+  async _impl_applicationStart(isReload_unused) {
     // Nothing to do in this case.
   }
 
   /** @override */
-  async _impl_applicationStop() {
+  async _impl_applicationStop(willReload_unused) {
     this.#protocolServer.close();
     this.#protocolServer.closeIdleConnections();
 

--- a/src/network-protocol/private/HttpsWrangler.js
+++ b/src/network-protocol/private/HttpsWrangler.js
@@ -42,12 +42,12 @@ export class HttpsWrangler extends TcpWrangler {
   }
 
   /** @override */
-  async _impl_applicationStart() {
+  async _impl_applicationStart(isReload_unused) {
     // Nothing to do in this case.
   }
 
   /** @override */
-  async _impl_applicationStop() {
+  async _impl_applicationStop(willReload_unused) {
     this.#protocolServer.close();
     this.#protocolServer.closeIdleConnections();
 

--- a/src/network-protocol/private/TcpWrangler.js
+++ b/src/network-protocol/private/TcpWrangler.js
@@ -55,12 +55,12 @@ export class TcpWrangler extends ProtocolWrangler {
   }
 
   /** @override */
-  async _impl_serverSocketStart() {
+  async _impl_serverSocketStart(isReload_unused) {
     return this.#runner.start();
   }
 
   /** @override */
-  async _impl_serverSocketStop() {
+  async _impl_serverSocketStop(willReload_unused) {
     return this.#runner.stop();
   }
 


### PR DESCRIPTION
This PR consists of more work to make it easier (ultimately) to implement the FD-socket-reload fix. As part of it, introduced a second use of the event system (after logging), which necessitated (or at least strongly suggested the utility of) doing a bit of an overhaul on aforementioned event system.