### PR TITLE
Rename `LogRecord` to `LogPayload`.

### DIFF
--- a/src/loggy/export/BaseLoggingEnvironment.js
+++ b/src/loggy/export/BaseLoggingEnvironment.js
@@ -42,7 +42,7 @@ export class BaseLoggingEnvironment {
     MustBe.string(type);
 
     // `+1` to omit the frame for this method.
-    const record = this.#makeRecordUnchecked(omitCount + 1, tag, type, ...args);
+    const record = this.#makePayloadUnchecked(omitCount + 1, tag, type, ...args);
     this._impl_logRecord(record);
   }
 
@@ -88,13 +88,13 @@ export class BaseLoggingEnvironment {
    * @param {...*} args Event arguments.
    * @returns {LogPayload} The constructed payload.
    */
-  makeRecord(omitCount, tag, type, ...args) {
+  makePayload(omitCount, tag, type, ...args) {
     MustBe.number(omitCount, { minInclusive: 0, safeInteger: true });
     MustBe.instanceOf(tag, LogTag);
     MustBe.string(type);
 
     // `+1` to omit the frame for this method.
-    return this.#makeRecordUnchecked(omitCount + 1, tag, type, ...args);
+    return this.#makePayloadUnchecked(omitCount + 1, tag, type, ...args);
   }
 
   /**
@@ -179,7 +179,7 @@ export class BaseLoggingEnvironment {
   }
 
   /**
-   * Like {@link #makeRecord}, except without any argument checking, so that
+   * Like {@link #makePayload}, except without any argument checking, so that
    * intra-class callers don't have to have redundant checks.
    *
    * @param {number} omitCount The number of caller frames to omit from the
@@ -189,7 +189,7 @@ export class BaseLoggingEnvironment {
    * @param {...*} args Event arguments.
    * @returns {LogPayload} The constructed payload.
    */
-  #makeRecordUnchecked(omitCount, tag, type, ...args) {
+  #makePayloadUnchecked(omitCount, tag, type, ...args) {
     const now       = this.now();
     const fixedArgs = this.#dataConverter.encode(args);
 

--- a/src/loggy/export/BaseLoggingEnvironment.js
+++ b/src/loggy/export/BaseLoggingEnvironment.js
@@ -47,17 +47,17 @@ export class BaseLoggingEnvironment {
   }
 
   /**
-   * Logs a pre-constructed {@link #LogPayload}. Typically, this ends up emitting
-   * a {@link #LogEvent} from an event source of some sort (which is, for
-   * example, what the standard concrete subclass of this class does), but it is
-   * not _necessarily_ what happens (that is, it depends on the concrete
+   * Logs a pre-constructed {@link #LogPayload}. Typically, this ends up
+   * emitting a {@link #LogEvent} from an event source of some sort (which is,
+   * for example, what the standard concrete subclass of this class does), but
+   * it is not _necessarily_ what happens (that is, it depends on the concrete
    * subclass).
    *
-   * @param {LogPayload} record The record to log.
+   * @param {LogPayload} payload What to log.
    */
-  logRecord(record) {
-    MustBe.instanceOf(record, LogPayload);
-    this._impl_logRecord(record);
+  logRecord(payload) {
+    MustBe.instanceOf(payload, LogPayload);
+    this._impl_logRecord(payload);
   }
 
   /**
@@ -86,7 +86,7 @@ export class BaseLoggingEnvironment {
    * @param {LogTag} tag The record tag.
    * @param {string} type Event type.
    * @param {...*} args Event arguments.
-   * @returns {LogPayload} The constructed record.
+   * @returns {LogPayload} The constructed payload.
    */
   makeRecord(omitCount, tag, type, ...args) {
     MustBe.number(omitCount, { minInclusive: 0, safeInteger: true });
@@ -139,10 +139,10 @@ export class BaseLoggingEnvironment {
    * with `record` as the payload.
    *
    * @abstract
-   * @param {LogPayload} record The record to log.
+   * @param {LogPayload} payload What to log.
    */
-  _impl_logRecord(record) {
-    Methods.abstract(record);
+  _impl_logRecord(payload) {
+    Methods.abstract(payload);
   }
 
   /**
@@ -187,7 +187,7 @@ export class BaseLoggingEnvironment {
    * @param {LogTag} tag The record tag.
    * @param {string} type Event type.
    * @param {...*} args Event arguments.
-   * @returns {LogPayload} The constructed record.
+   * @returns {LogPayload} The constructed payload.
    */
   #makeRecordUnchecked(omitCount, tag, type, ...args) {
     const now       = this.now();

--- a/src/loggy/export/BaseLoggingEnvironment.js
+++ b/src/loggy/export/BaseLoggingEnvironment.js
@@ -136,7 +136,7 @@ export class BaseLoggingEnvironment {
   /**
    * Outputs the given record to its ultimate destination. For example, the
    * standard concrete implementation of this method emits a {@link #LogEvent}
-   * with `record` as the payload.
+   * with `payload` as the payload.
    *
    * @abstract
    * @param {LogPayload} payload What to log.

--- a/src/loggy/export/BaseLoggingEnvironment.js
+++ b/src/loggy/export/BaseLoggingEnvironment.js
@@ -4,7 +4,7 @@
 import { Converter, ConverterConfig, Moment, StackTrace } from '@this/data-values';
 import { Methods, MustBe } from '@this/typey';
 
-import { LogRecord } from '#x/LogRecord';
+import { LogPayload } from '#x/LogPayload';
 import { LogTag } from '#x/LogTag';
 
 
@@ -25,7 +25,7 @@ export class BaseLoggingEnvironment {
   // Note: The default constructor is fine here.
 
   /**
-   * Logs a {@link #LogRecord}, which is constructed from the arguments passed
+   * Logs a {@link #LogPayload}, which is constructed from the arguments passed
    * to this method along with a timestamp and stack trace as implemented by the
    * concrete subclass. The so-constructed record is then emitted, as if by
    * {@link #logRecord}, see which for further details.
@@ -47,16 +47,16 @@ export class BaseLoggingEnvironment {
   }
 
   /**
-   * Logs a pre-constructed {@link #LogRecord}. Typically, this ends up emitting
+   * Logs a pre-constructed {@link #LogPayload}. Typically, this ends up emitting
    * a {@link #LogEvent} from an event source of some sort (which is, for
    * example, what the standard concrete subclass of this class does), but it is
    * not _necessarily_ what happens (that is, it depends on the concrete
    * subclass).
    *
-   * @param {LogRecord} record The record to log.
+   * @param {LogPayload} record The record to log.
    */
   logRecord(record) {
-    MustBe.instanceOf(record, LogRecord);
+    MustBe.instanceOf(record, LogPayload);
     this._impl_logRecord(record);
   }
 
@@ -73,7 +73,7 @@ export class BaseLoggingEnvironment {
   }
 
   /**
-   * Makes a `LogRecord` instance, processing arguments as needed for the
+   * Makes a `LogPayload` instance, processing arguments as needed for the
    * ultimate destination.
    *
    * For example and in particular, non-JSON-encodable values may want to be
@@ -86,7 +86,7 @@ export class BaseLoggingEnvironment {
    * @param {LogTag} tag The record tag.
    * @param {string} type Event type.
    * @param {...*} args Event arguments.
-   * @returns {LogRecord} The constructed record.
+   * @returns {LogPayload} The constructed record.
    */
   makeRecord(omitCount, tag, type, ...args) {
     MustBe.number(omitCount, { minInclusive: 0, safeInteger: true });
@@ -139,7 +139,7 @@ export class BaseLoggingEnvironment {
    * with `record` as the payload.
    *
    * @abstract
-   * @param {LogRecord} record The record to log.
+   * @param {LogPayload} record The record to log.
    */
   _impl_logRecord(record) {
     Methods.abstract(record);
@@ -187,7 +187,7 @@ export class BaseLoggingEnvironment {
    * @param {LogTag} tag The record tag.
    * @param {string} type Event type.
    * @param {...*} args Event arguments.
-   * @returns {LogRecord} The constructed record.
+   * @returns {LogPayload} The constructed record.
    */
   #makeRecordUnchecked(omitCount, tag, type, ...args) {
     const now       = this.now();
@@ -196,7 +196,7 @@ export class BaseLoggingEnvironment {
     // `+1` to omit the frame for this method.
     const trace = this.makeStackTrace(omitCount + 1);
 
-    return new LogRecord(now, tag, type, fixedArgs, trace);
+    return new LogPayload(now, tag, type, fixedArgs, trace);
   }
 
 

--- a/src/loggy/export/BaseLoggingEnvironment.js
+++ b/src/loggy/export/BaseLoggingEnvironment.js
@@ -19,7 +19,7 @@ import { LogTag } from '#x/LogTag';
  * sanity checks in both directions.
  */
 export class BaseLoggingEnvironment {
-  /** @type {Converter} Data converter to use for encoding record arguments. */
+  /** @type {Converter} Data converter to use for encoding payload arguments. */
   #dataConverter = new Converter(ConverterConfig.makeLoggingInstance());
 
   // Note: The default constructor is fine here.
@@ -27,7 +27,7 @@ export class BaseLoggingEnvironment {
   /**
    * Logs a {@link #LogPayload}, which is constructed from the arguments passed
    * to this method along with a timestamp and stack trace as implemented by the
-   * concrete subclass. The so-constructed record is then emitted, as if by
+   * concrete subclass. The so-constructed payload is then emitted, as if by
    * {@link #logPayload}, see which for further details.
    *
    * @param {number} omitCount The number of caller frames to omit from the
@@ -83,7 +83,7 @@ export class BaseLoggingEnvironment {
    *
    * @param {number} omitCount The number of caller frames to omit from the
    *   stack trace.
-   * @param {LogTag} tag The record tag.
+   * @param {LogTag} tag The payload tag.
    * @param {string} type Event type.
    * @param {...*} args Event arguments.
    * @returns {LogPayload} The constructed payload.
@@ -134,7 +134,7 @@ export class BaseLoggingEnvironment {
   }
 
   /**
-   * Outputs the given record to its ultimate destination. For example, the
+   * Outputs the given payload to its ultimate destination. For example, the
    * standard concrete implementation of this method emits a {@link #LogEvent}
    * with `payload` as the payload.
    *
@@ -184,7 +184,7 @@ export class BaseLoggingEnvironment {
    *
    * @param {number} omitCount The number of caller frames to omit from the
    *   stack trace.
-   * @param {LogTag} tag The record tag.
+   * @param {LogTag} tag The payload tag.
    * @param {string} type Event type.
    * @param {...*} args Event arguments.
    * @returns {LogPayload} The constructed payload.

--- a/src/loggy/export/BaseLoggingEnvironment.js
+++ b/src/loggy/export/BaseLoggingEnvironment.js
@@ -28,7 +28,7 @@ export class BaseLoggingEnvironment {
    * Logs a {@link #LogPayload}, which is constructed from the arguments passed
    * to this method along with a timestamp and stack trace as implemented by the
    * concrete subclass. The so-constructed record is then emitted, as if by
-   * {@link #logRecord}, see which for further details.
+   * {@link #logPayload}, see which for further details.
    *
    * @param {number} omitCount The number of caller frames to omit from the
    *   stack trace.
@@ -42,8 +42,8 @@ export class BaseLoggingEnvironment {
     MustBe.string(type);
 
     // `+1` to omit the frame for this method.
-    const record = this.#makePayloadUnchecked(omitCount + 1, tag, type, ...args);
-    this._impl_logRecord(record);
+    const payload = this.#makePayloadUnchecked(omitCount + 1, tag, type, ...args);
+    this._impl_logPayload(payload);
   }
 
   /**
@@ -55,9 +55,9 @@ export class BaseLoggingEnvironment {
    *
    * @param {LogPayload} payload What to log.
    */
-  logRecord(payload) {
+  logPayload(payload) {
     MustBe.instanceOf(payload, LogPayload);
-    this._impl_logRecord(payload);
+    this._impl_logPayload(payload);
   }
 
   /**
@@ -141,7 +141,7 @@ export class BaseLoggingEnvironment {
    * @abstract
    * @param {LogPayload} payload What to log.
    */
-  _impl_logRecord(payload) {
+  _impl_logPayload(payload) {
     Methods.abstract(payload);
   }
 

--- a/src/loggy/export/IntfLogger.js
+++ b/src/loggy/export/IntfLogger.js
@@ -19,7 +19,7 @@ import { LogTag } from '#x/LogTag';
  * `logger.someName(1, 2, 'three')` logs the structured message `someName(1, 2,
  * 'three')` to whatever source the logger is attached to. The method name --
  * called the "event type" in this context -- along with the arguments and other
- * context from the logger instance become part of a `LogRecord` in a
+ * context from the logger instance become part of a `LogPayload` in a
  * `LogEvent`.
  *
  * Every logger has a "tag" which gets associated with each event logged through

--- a/src/loggy/export/LogEvent.js
+++ b/src/loggy/export/LogEvent.js
@@ -10,9 +10,9 @@ import { LogTag } from '#x/LogTag';
 
 
 /**
- * Event subclass that holds {@link LogPayload}s as their payloads. It exists for
- * convenience (to avoid having to dig into the payload), for (a little bit of)
- * type safety, and for documentation.
+ * Event subclass that holds {@link LogPayload}s as their payloads. It exists
+ * for convenience (to avoid having to dig into the payload), for (a little bit
+ * of type safety, and for documentation.
  */
 export class LogEvent extends LinkedEvent {
   /**

--- a/src/loggy/export/LogEvent.js
+++ b/src/loggy/export/LogEvent.js
@@ -5,12 +5,12 @@ import { EventSource, LinkedEvent } from '@this/async';
 import { StackTrace } from '@this/data-values';
 import { MustBe } from '@this/typey';
 
-import { LogRecord } from '#x/LogRecord';
+import { LogPayload } from '#x/LogPayload';
 import { LogTag } from '#x/LogTag';
 
 
 /**
- * Event subclass that holds {@link LogRecord}s as their payloads. It exists for
+ * Event subclass that holds {@link LogPayload}s as their payloads. It exists for
  * convenience (to avoid having to dig into the payload), for (a little bit of)
  * type safety, and for documentation.
  */
@@ -18,12 +18,12 @@ export class LogEvent extends LinkedEvent {
   /**
    * Constructs an instance.
    *
-   * @param {LogRecord} payload The event payload.
+   * @param {LogPayload} payload The event payload.
    * @param {?LogEvent|Promise<LogEvent>} [next = null] The next event in the
    *   chain or promise for same, if already known.
    */
   constructor(payload, next) {
-    MustBe.instanceOf(payload, LogRecord);
+    MustBe.instanceOf(payload, LogPayload);
     super(payload, next);
   }
 
@@ -68,7 +68,7 @@ export class LogEvent extends LinkedEvent {
    * @returns {LogEvent} A minimal instance for "kickoff."
    */
   static makeKickoffInstance(tag = null, type = null) {
-    const payload = LogRecord.makeKickoffInstance(tag, type);
+    const payload = LogPayload.makeKickoffInstance(tag, type);
     return new LogEvent(payload);
   }
 

--- a/src/loggy/export/LogPayload.js
+++ b/src/loggy/export/LogPayload.js
@@ -9,13 +9,13 @@ import { MustBe } from '@this/typey';
 
 import { LogTag } from '#x/LogTag';
 
-// TODO: Rename this to `LogPayload`.
-
 /**
- * The thing which is logged; it is the payload class for events used by this
- * module.
+ * The thing which is logged; it is the payload class used for events
+ * constructed by this module. It includes the same basic event properties as
+ * {@link EventPayload} (which it inherits from), to which it adds a few
+ * logging-specific properties.
  */
-export class LogRecord extends EventPayload {
+export class LogPayload extends EventPayload {
   /** @type {Moment} Moment in time that this instance represents. */
   #when;
 
@@ -85,7 +85,7 @@ export class LogRecord extends EventPayload {
    * @returns {Struct} Encoded form.
    */
   [BaseConverter.ENCODE]() {
-    return new Struct(LogRecord, {
+    return new Struct(LogPayload, {
       when:  this.#when,
       tag:   this.#tag,
       stack: this.#stack,
@@ -114,7 +114,7 @@ export class LogRecord extends EventPayload {
       }
 
       // TODO: Evaluate whether `util.inspect()` is sufficient.
-      parts.push(util.inspect(a, LogRecord.#HUMAN_INSPECT_OPTIONS));
+      parts.push(util.inspect(a, LogPayload.#HUMAN_INSPECT_OPTIONS));
     }
 
     parts.push(')');
@@ -153,11 +153,11 @@ export class LogRecord extends EventPayload {
    *   a default.
    * @param {?string} [type = null] Type to use for the instance, or `null` to
    *   use a default.
-   * @returns {LogRecord} A minimal instance for "kickoff."
+   * @returns {LogPayload} A minimal instance for "kickoff."
    */
   static makeKickoffInstance(tag = null, type = null) {
     tag  ??= this.#KICKOFF_TAG;
     type ??= this.#KICKOFF_TYPE;
-    return new LogRecord(this.#KICKOFF_MOMENT, tag, type, Object.freeze([]));
+    return new LogPayload(this.#KICKOFF_MOMENT, tag, type, Object.freeze([]));
   }
 }

--- a/src/loggy/export/StdLoggingEnvironment.js
+++ b/src/loggy/export/StdLoggingEnvironment.js
@@ -39,8 +39,8 @@ export class StdLoggingEnvironment extends BaseLoggingEnvironment {
   }
 
   /** @override */
-  _impl_logRecord(record) {
-    this.#source.emit(record);
+  _impl_logPayload(payload) {
+    this.#source.emit(payload);
   }
 
   /** @override */

--- a/src/loggy/export/TextFileSink.js
+++ b/src/loggy/export/TextFileSink.js
@@ -9,7 +9,7 @@ import { BaseConverter, Converter, ConverterConfig } from '@this/data-values';
 import { MustBe } from '@this/typey';
 
 import { LogEvent } from '#x/LogEvent';
-import { LogRecord } from '#x/LogRecord';
+import { LogPayload } from '#x/LogPayload';
 
 
 /**
@@ -21,7 +21,7 @@ export class TextFileSink extends EventSink {
   #filePath;
 
   /**
-   * @type {function(LogRecord): Buffer|string} Function to convert an event
+   * @type {function(LogPayload): Buffer|string} Function to convert an event
    * into writable form.
    */
   #formatter;
@@ -55,7 +55,7 @@ export class TextFileSink extends EventSink {
   /**
    * Formats and writes the indicated record or "first write" marker.
    *
-   * @param {?LogRecord} record Record to write, or `null` to write a "first
+   * @param {?LogPayload} record Record to write, or `null` to write a "first
    *   write" marker.
    */
   async #writeRecord(record) {
@@ -98,7 +98,7 @@ export class TextFileSink extends EventSink {
     new Converter(ConverterConfig.makeLoggingInstance({ freeze: false }));
 
   /**
-   * @type {Map<string, function(LogRecord): Buffer|string>} Map from names to
+   * @type {Map<string, function(LogPayload): Buffer|string>} Map from names to
    * corresponding formatter methods.
    */
   static #FORMATTERS = new Map(Object.entries({
@@ -119,7 +119,7 @@ export class TextFileSink extends EventSink {
   /**
    * Formatter `human`, which converts to human-oriented text.
    *
-   * @param {?LogRecord} record Record to convert, or `null` if this is to be
+   * @param {?LogPayload} record Record to convert, or `null` if this is to be
    *   a "first write" marker.
    * @returns {string} Converted form.
    */
@@ -135,7 +135,7 @@ export class TextFileSink extends EventSink {
   /**
    * Formatter `json`, which converts to JSON text.
    *
-   * @param {?LogRecord} record Record to convert, or `null` if this is to be
+   * @param {?LogPayload} record Record to convert, or `null` if this is to be
    *   a "first write" marker.
    * @returns {?string} Converted form, or `null` if nothing is to be written.
    */

--- a/src/loggy/export/TextFileSink.js
+++ b/src/loggy/export/TextFileSink.js
@@ -58,7 +58,7 @@ export class TextFileSink extends EventSink {
    * @param {?LogPayload} payload What to write, or `null` to write a "first
    *   write" marker.
    */
-  async #writeRecord(payload) {
+  async #writePayload(payload) {
     // `?? null` to force it to be a function call and not a method call on
     // `this`.
     const text = (this.#formatter ?? null)(payload);
@@ -77,12 +77,12 @@ export class TextFileSink extends EventSink {
   async #process(event) {
     if (!this.#everWritten) {
       if (!/^[/]dev[/]std(err|out)$/.test(this.#filePath)) {
-        await this.#writeRecord(null);
+        await this.#writePayload(null);
       }
       this.#everWritten = true;
     }
 
-    await this.#writeRecord(event.payload);
+    await this.#writePayload(event.payload);
   }
 
 

--- a/src/loggy/export/TextFileSink.js
+++ b/src/loggy/export/TextFileSink.js
@@ -91,7 +91,7 @@ export class TextFileSink extends EventSink {
   //
 
   /**
-   * @type {Converter} Data converter to use for encoding record arguments,
+   * @type {Converter} Data converter to use for encoding payload arguments,
    * specifically for the `json` format.
    */
   static #CONVERTER_FOR_JSON =
@@ -102,8 +102,8 @@ export class TextFileSink extends EventSink {
    * corresponding formatter methods.
    */
   static #FORMATTERS = new Map(Object.entries({
-    human: (record) => this.#formatHuman(record),
-    json:  (record) => this.#formatJson(record)
+    human: (payload) => this.#formatHuman(payload),
+    json:  (payload) => this.#formatJson(payload)
   }));
 
   /**
@@ -147,7 +147,7 @@ export class TextFileSink extends EventSink {
     // What's going on: We assume that the `args` payload is already
     // sufficiently encoded (because that would have / should have happened
     // synchronously while logging), but we want to generically encode
-    // everything else. So, we do a top-level encode of the record, tweak it,
+    // everything else. So, we do a top-level encode of the payload, tweak it,
     // let the normal encode mechanism do it's thing, and then tweak it back.
 
     const encodedPayload = payload[BaseConverter.ENCODE]();

--- a/src/loggy/export/TextFileSink.js
+++ b/src/loggy/export/TextFileSink.js
@@ -53,15 +53,15 @@ export class TextFileSink extends EventSink {
   }
 
   /**
-   * Formats and writes the indicated record or "first write" marker.
+   * Formats and writes the indicated payload or "first write" marker.
    *
-   * @param {?LogPayload} record Record to write, or `null` to write a "first
+   * @param {?LogPayload} payload What to write, or `null` to write a "first
    *   write" marker.
    */
-  async #writeRecord(record) {
+  async #writeRecord(payload) {
     // `?? null` to force it to be a function call and not a method call on
     // `this`.
-    const text = (this.#formatter ?? null)(record);
+    const text = (this.#formatter ?? null)(payload);
 
     if (text !== null) {
       const finalText = text.endsWith('\n') ? text : `${text}\n`;
@@ -119,28 +119,28 @@ export class TextFileSink extends EventSink {
   /**
    * Formatter `human`, which converts to human-oriented text.
    *
-   * @param {?LogPayload} record Record to convert, or `null` if this is to be
+   * @param {?LogPayload} payload Payload to convert, or `null` if this is to be
    *   a "first write" marker.
    * @returns {string} Converted form.
    */
-  static #formatHuman(record) {
-    if (record === null) {
+  static #formatHuman(payload) {
+    if (payload === null) {
       // This is a "page break" written to non-console files.
       return `\n\n${'- '.repeat(38)}-\n\n\n`;
     }
 
-    return record.toHuman();
+    return payload.toHuman();
   }
 
   /**
    * Formatter `json`, which converts to JSON text.
    *
-   * @param {?LogPayload} record Record to convert, or `null` if this is to be
+   * @param {?LogPayload} payload Payload to convert, or `null` if this is to be
    *   a "first write" marker.
    * @returns {?string} Converted form, or `null` if nothing is to be written.
    */
-  static #formatJson(record) {
-    if (record === null) {
+  static #formatJson(payload) {
+    if (payload === null) {
       return null;
     }
 
@@ -150,11 +150,11 @@ export class TextFileSink extends EventSink {
     // everything else. So, we do a top-level encode of the record, tweak it,
     // let the normal encode mechanism do it's thing, and then tweak it back.
 
-    const encodedRecord = record[BaseConverter.ENCODE]();
-    const objToEncode   = { ...encodedRecord.options, args: null };
-    const encoded       = this.#CONVERTER_FOR_JSON.encode(objToEncode);
+    const encodedPayload = payload[BaseConverter.ENCODE]();
+    const objToEncode    = { ...encodedPayload.options, args: null };
+    const encoded        = this.#CONVERTER_FOR_JSON.encode(objToEncode);
 
-    encoded.args = encodedRecord.options.args;
+    encoded.args = encodedPayload.options.args;
     return JSON.stringify(encoded);
 
     //const finalObj      = { ...encoded, args: encodedRecord.options.args };

--- a/src/loggy/index.js
+++ b/src/loggy/index.js
@@ -6,7 +6,7 @@ export * from '#x/FormatUtils';
 export * from '#x/IdGenerator';
 export * from '#x/IntfLogger';
 export * from '#x/LogEvent';
-export * from '#x/LogRecord';
+export * from '#x/LogPayload';
 export * from '#x/LogTag';
 export * from '#x/Loggy';
 export * from '#x/StdLoggingEnvironment';


### PR DESCRIPTION
This PR renames `LogRecord` to `LogPayload` (to be consistent with base class `EventPayload`), and does all the follow-on name harmonization.