### PR TITLE
Memory monitor, and a bit of cleanup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+### v0.5.9 -- 2023-04-05
+
+Notable changes:
+
+* During reload (e.g. `kill -HUP`), endpoint sockets (server sockets) are no
+  longer immediately closed. Instead, they're held open for several seconds, and
+  the reloaded configuration is given an opportunity to take them over. This
+  makes it possible for endpoints that use incoming FDs to actually be reloaded.
+* New service `MemoryMonitor`, to induce graceful shutdown if memory usage goes
+  beyond defined limits, with an optional grace period to ignore transient
+  spikes.
+
 ### v0.5.8 -- 2023-03-29
 
 Notable changes:

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -277,6 +277,44 @@ the ones that are used by `save`:
 Note that at least one of the `on*` bindings need to be provided for a `save` to
 have any meaning.
 
+### `MemoryMonitor`
+
+A service which occasionally checks the system's memory usage, and will force a
+(hopefully) clean shutdown if memory usage is too high, with an optional grace
+period to allow momentary usage spikes. It accepts the following configuration
+bindings:
+
+* `checkSecs` &mdash; How often to check for memory usage being over the
+  defined limit, in seconds. Optional. Minimum `1` (which is frankly way too
+  often). Default `5 * 60` (once every five minutes).
+* `gracePeriodSecs` &mdash; Once a memory limit has been reached, how long, in
+  seconds, it is allowed to remain at or beyond the maximum before this service
+  takes action. `0` (or `null`) to not have a grace period at all. Default `0`.
+  **Note:**: When in the middle of a grace period, the service will check
+  memory usage more often than `checkSecs` so as not to miss a significant dip.
+* `maxHeapBytes` &mdash; How many bytes of heap is considered "over limit," or
+  `null` for no limit on this. The amount counted is `heapTotal + external` from
+  `process.memoryUsage()`. Defaults to `null`. **Note:** In order to catch
+  probably-unintentional misconfiguration, if a number, must be at least one
+  megabyte.
+* `maxRssBytes` &mdash; How many bytes of RSS is considered "over limit," or
+  `null` for no limit on this. Defaults to `null`. **Note:** In order to catch
+  probably-unintentional misconfiguration, if non-`null`, must be at least one
+  megabyte.
+
+```js
+const services = [
+  {
+    name:            'memory',
+    class:           'MemoryMonitor',
+    checkSecs:       5 * 60,
+    gracePeriodSecs: 60,
+    maxHeapBytes:    100 * 1024 * 1024,
+    maxRssBytes:     150 * 1024 * 1024
+  }
+];
+```
+
 ### `ProcessIdFile`
 
 A service which writes a simple text file containing the process ID (number) of

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -25,6 +25,14 @@ const hosts = [
 // Service definitions.
 const services = [
   {
+    name:            'memory',
+    class:           'MemoryMonitor',
+    checkSecs:       5 * 60,
+    gracePeriodSecs: 60,
+    maxHeapBytes:    100 * 1024 * 1024,
+    maxRssBytes:     150 * 1024 * 1024
+  },
+  {
     name:       'process',
     class:      'ProcessInfoFile',
     path:       `${RUN_DIR}/process.json`,

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -27,7 +27,7 @@ const services = [
   {
     name:            'memory',
     class:           'MemoryMonitor',
-    checkSecs:       5 * 60,
+    checkSecs:       10 * 60,
     gracePeriodSecs: 60,
     maxHeapBytes:    100 * 1024 * 1024,
     maxRssBytes:     150 * 1024 * 1024

--- a/src/builtin-services/export/BuiltinServices.js
+++ b/src/builtin-services/export/BuiltinServices.js
@@ -3,6 +3,7 @@
 
 import { BaseService } from '@this/app-framework';
 
+import { MemoryMonitor } from '#x/MemoryMonitor';
 import { ProcessIdFile } from '#x/ProcessIdFile';
 import { ProcessInfoFile } from '#x/ProcessInfoFile';
 import { RateLimiter } from '#x/RateLimiter';
@@ -21,6 +22,7 @@ export class BuiltinServices {
    */
   static getAll() {
     return [
+      MemoryMonitor,
       ProcessIdFile,
       ProcessInfoFile,
       RateLimiter,

--- a/src/builtin-services/export/MemoryMonitor.js
+++ b/src/builtin-services/export/MemoryMonitor.js
@@ -13,16 +13,16 @@ import { MustBe } from '@this/typey';
  *
  * * `{?number} checkSecs` -- How often to check things, in seconds, or `null`
  *   to use a default frequency. Defaults to `60` (once per minute).
- * * `{?number} maxHeapBytes` -- How large to allow the heap to get before
- *   initiating shutdown, or `null` for no limit on this. Defaults to `null`.
- *   The amount counted is `heapTotal + external` from `process.memoryUsage()`.
- * * `{?number} maxRss` -- How large to allow the RSS to get before initiating
- *   shutdown, or `null` for no limit on this. Defaults to `null`. The amount
- *   counted is `heapTotal + external` from `process.memoryUsage()`.
  * * `{?number} gracePeriodSecs` -- Once the maximum size has been reached, how
  *   long it must remain at or beyond the maximum before this service takes
  *   action, or `null` not to have a grace period at all (equivalent to `0`).
- *   Defaults to `null`.
+ *   When in the middle of a grace period, the system checks more often than
+ *   `checkSecs` so as not to miss a significant dip. Defaults to `null`.
+ * * `{?number} maxHeapBytes` -- How large to allow the heap to get before
+ *   initiating shutdown, or `null` for no limit on this. Defaults to `null`.
+ *   The amount counted is `heapTotal + external` from `process.memoryUsage()`.
+ * * `{?number} maxRssBytes` -- How large to allow the RSS to get before
+ *   initiating shutdown, or `null` for no limit on this. Defaults to `null`.
  */
 export class MemoryMonitor extends BaseService {
   // TODO
@@ -63,9 +63,23 @@ export class MemoryMonitor extends BaseService {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends ServiceConfig {
-    /** TODO */
+    /** @type {number} How often to check, in seconds. */
     #checkSecs;
-    // TODO
+
+    /** @type {number} Grace period before triggering an action, in seconds. */
+    #gracePeriodSecs;
+
+    /**
+     * @type {?number} Maximum allowed size of heap usage, in bytes, or `null`
+     * for no limit.
+     */
+    #maxHeapBytes;
+
+    /**
+     * @type {?number} Maximum allowed size of RSS, in bytes, or `null` for no
+     * limit.
+     */
+    #maxRssBytes;
 
     /**
      * Constructs an instance.
@@ -78,11 +92,32 @@ export class MemoryMonitor extends BaseService {
       // TODO
     }
 
-    /** @returns {?object} Configuration for connection rate limiting. */
-    get connections() {
+    /** @returns {number} How often to check, in seconds. */
+    get checkSecs() {
       return this.#checkSecs;
     }
 
-    // TODO
+    /**
+     * @returns {number} Grace period before triggering an action, in seconds.
+     */
+    get gracePeriodSecs() {
+      return this.#gracePeriodSecs;
+    }
+
+    /**
+     * @returns {?number} Maximum allowed size of heap usage, in bytes, or
+     * `null` for no limit.
+     */
+    get maxHeapBytes() {
+      return this.#maxHeapBytes;
+    }
+
+    /**
+     * @returns {?number} Maximum allowed size of RSS, in bytes, or `null` for
+     * no limit.
+     */
+    get maxRssBytes() {
+      return this.#maxRssBytes;
+    }
   };
 }

--- a/src/builtin-services/export/MemoryMonitor.js
+++ b/src/builtin-services/export/MemoryMonitor.js
@@ -1,0 +1,88 @@
+// Copyright 2022-2023 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { ServiceConfig } from '@this/app-config';
+import { BaseService } from '@this/app-framework';
+import { IntfLogger } from '@this/loggy';
+import { MustBe } from '@this/typey';
+
+
+/**
+ * Service which monitors the system's memory usage and can initiate shutdown
+ * before a memory problem becomes dire. Configuration object details:
+ *
+ * * `{?number} checkSecs` -- How often to check things, in seconds, or `null`
+ *   to use a default frequency. Defaults to `60` (once per minute).
+ * * `{?number} maxHeapBytes` -- How large to allow the heap to get before
+ *   initiating shutdown, or `null` for no limit on this. Defaults to `null`.
+ *   The amount counted is `heapTotal + external` from `process.memoryUsage()`.
+ * * `{?number} maxRss` -- How large to allow the RSS to get before initiating
+ *   shutdown, or `null` for no limit on this. Defaults to `null`. The amount
+ *   counted is `heapTotal + external` from `process.memoryUsage()`.
+ * * `{?number} gracePeriodSecs` -- Once the maximum size has been reached, how
+ *   long it must remain at or beyond the maximum before this service takes
+ *   action, or `null` not to have a grace period at all (equivalent to `0`).
+ *   Defaults to `null`.
+ */
+export class MemoryMonitor extends BaseService {
+  // TODO
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {ServiceConfig} config Configuration for this service.
+   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
+   */
+  constructor(config, logger) {
+    super(config, logger);
+
+    // TODO
+  }
+
+  /** @override */
+  async _impl_start(isReload_unused) {
+    // TODO
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // TODO
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @override */
+  static get CONFIG_CLASS() {
+    return this.#Config;
+  }
+
+  /**
+   * Configuration item subclass for this (outer) class.
+   */
+  static #Config = class Config extends ServiceConfig {
+    /** TODO */
+    #checkSecs;
+    // TODO
+
+    /**
+     * Constructs an instance.
+     *
+     * @param {object} config Configuration object.
+     */
+    constructor(config) {
+      super(config);
+
+      // TODO
+    }
+
+    /** @returns {?object} Configuration for connection rate limiting. */
+    get connections() {
+      return this.#checkSecs;
+    }
+
+    // TODO
+  };
+}

--- a/src/builtin-services/export/MemoryMonitor.js
+++ b/src/builtin-services/export/MemoryMonitor.js
@@ -1,9 +1,14 @@
 // Copyright 2022-2023 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { memoryUsage } from 'node:process';
+import { setTimeout } from 'node:timers/promises';
+
 import { ServiceConfig } from '@this/app-config';
 import { BaseService } from '@this/app-framework';
-import { IntfLogger } from '@this/loggy';
+import { Threadlet } from '@this/async';
+import { Moment } from '@this/data-values';
+import { Host } from '@this/host';
 import { MustBe } from '@this/typey';
 
 
@@ -12,7 +17,8 @@ import { MustBe } from '@this/typey';
  * before a memory problem becomes dire. Configuration object details:
  *
  * * `{?number} checkSecs` -- How often to check things, in seconds, or `null`
- *   to use a default frequency. Defaults to `60` (once per minute).
+ *   to use the default frequency. Minimum `1`. Defaults to `60` (once per
+ *   minute).
  * * `{?number} gracePeriodSecs` -- Once the maximum size has been reached, how
  *   long it must remain at or beyond the maximum before this service takes
  *   action, or `null` not to have a grace period at all (equivalent to `0`).
@@ -20,39 +26,135 @@ import { MustBe } from '@this/typey';
  *   `checkSecs` so as not to miss a significant dip. Defaults to `null`.
  * * `{?number} maxHeapBytes` -- How large to allow the heap to get before
  *   initiating shutdown, or `null` for no limit on this. Defaults to `null`.
+ *   In order to catch probably-unintentional misconfiguration, if non-`null`,
+ *   must be one megabyte or larger.
  *   The amount counted is `heapTotal + external` from `process.memoryUsage()`.
  * * `{?number} maxRssBytes` -- How large to allow the RSS to get before
- *   initiating shutdown, or `null` for no limit on this. Defaults to `null`.
+ *   initiating shutdown, or `null` for no limit on this. Defaults to `null`. In
+ *   order to catch probably-unintentional misconfiguration, if non-`null`, must
+ *   be one megabyte or larger.
  */
 export class MemoryMonitor extends BaseService {
-  // TODO
+  /** @type {Threadlet} Threadlet which runs this service. */
+  #runner = new Threadlet(() => this.#run());
 
   /**
-   * Constructs an instance.
-   *
-   * @param {ServiceConfig} config Configuration for this service.
-   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
+   * @type {?{ heap: number, rss: number, troubleAtMsec: ?number }} Last memory
+   * snapshot (including trouble indicator), if any.
    */
-  constructor(config, logger) {
-    super(config, logger);
+  #lastSnapshot = null;
 
-    // TODO
-  }
+  // Note: Default constructor is fine for this class.
 
   /** @override */
   async _impl_start(isReload_unused) {
-    // TODO
+    await this.#runner.start();
   }
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // TODO
+    await this.#runner.stop();
+  }
+
+  /**
+   * Takes a memory snapshot, including figuring out if we're in an "over limit"
+   * situation or not.
+   *
+   * @returns {object} The current snapshot.
+   */
+  #takeSnapshot() {
+    const rawUsage = memoryUsage();
+    const now      = Moment.fromMsec(Date.now());
+
+    // Note: Per Node docs, `external` includes the `arrayBuffers` value in it.
+    const usage = {
+      heap: rawUsage.heapUsed + rawUsage.external,
+      rss:  rawUsage.rss
+    };
+
+    this.logger?.usage(usage);
+
+    const snapshot = {
+      ...usage,
+      at:        now,
+      troubleAt: this.#lastSnapshot?.troubleAt ?? null,
+      actionAt:  this.#lastSnapshot?.actionAt ?? null
+    };
+
+    const { maxHeapBytes, maxRssBytes } = this.config;
+
+    if (   (maxHeapBytes && (snapshot.heap >= maxHeapBytes))
+        || (maxRssBytes  && (snapshot.rss  >= maxRssBytes))) {
+      if (!snapshot.troubleAt) {
+        // We just transitioned to an "over limit" situation.
+        const actionAt = now.addSecs(this.config.gracePeriodSecs);
+        snapshot.troubleAt = now;
+        snapshot.actionAt  = actionAt;
+        this.logger?.overLimit({ actionAt });
+      }
+    } else {
+      if (snapshot.troubleAt) {
+        // We just transitioned back to a "within limit" situation.
+        snapshot.troubleAt = null;
+        snapshot.actionAt  = null;
+        this.logger?.withinLimit();
+      }
+    }
+
+    this.#lastSnapshot = snapshot;
+    return snapshot;
+  }
+
+  /**
+   * Runs the service thread.
+   */
+  async #run() {
+    const checkMsec = this.config.checkSecs * 1000;
+
+    while (!this.#runner.shouldStop()) {
+      const snapshot = this.#takeSnapshot();
+
+      if (snapshot.actionAt && (snapshot.actionAt.atSecs < snapshot.at.atSecs)) {
+        this.logger?.takingAction();
+        // No `await`, because then the shutdown handler would end up deadlocked
+        // with the stopping of this threadlet.
+        Host.exit(1);
+        break;
+      }
+
+      let timeoutMsec = checkMsec;
+      if (snapshot.actionAt) {
+        const msecUntilAction = snapshot.actionAt.subtract(snapshot.at).secs * 1000;
+        const msecUntilCheck  = Math.max(
+          checkMsec,
+          Math.min(
+            msecUntilAction * MemoryMonitor.#TROUBLE_CHECK_FRACTION,
+            MemoryMonitor.#MIN_TROUBLE_CHECK_MSEC));
+        timeoutMsec = msecUntilCheck;
+      }
+
+      await this.#runner.raceWhenStopRequested([
+        setTimeout(timeoutMsec)
+      ]);
+    }
   }
 
 
   //
   // Static members
   //
+
+  /**
+   * @type {number} Minimum amount of time in msec between checks, when dealing
+   * with an "over limit" situation.
+   */
+  static #MIN_TROUBLE_CHECK_MSEC = 1000;
+
+  /**
+   * @type {number} Fraction of time between "now" and when action needs to
+   * happen, when the next check should take place in an "over limit" situation.
+   */
+  static #TROUBLE_CHECK_FRACTION = 0.25;
 
   /** @override */
   static get CONFIG_CLASS() {
@@ -89,7 +191,25 @@ export class MemoryMonitor extends BaseService {
     constructor(config) {
       super(config);
 
-      // TODO
+      const {
+        checkSecs       = null,
+        gracePeriodSecs = null,
+        maxHeapBytes    = null,
+        maxRssBytes     = null
+      } = config;
+
+      this.#checkSecs = (checkSecs === null)
+        ? 60
+        : MustBe.number(checkSecs, { finite: true, minInclusive: 1 });
+      this.#gracePeriodSecs = (gracePeriodSecs === null)
+        ? 0
+        : MustBe.number(gracePeriodSecs, { finite: true, minInclusive: 0 });
+      this.#maxHeapBytes = (maxHeapBytes === null)
+        ? null
+        : MustBe.number(maxHeapBytes, { finite: true, minInclusive: 1024 * 1024 });
+      this.#maxRssBytes = (maxRssBytes === null)
+        ? null
+        : MustBe.number(maxRssBytes, { finite: true, minInclusive: 1024 * 1024 });
     }
 
     /** @returns {number} How often to check, in seconds. */

--- a/src/builtin-services/export/MemoryMonitor.js
+++ b/src/builtin-services/export/MemoryMonitor.js
@@ -125,9 +125,9 @@ export class MemoryMonitor extends BaseService {
       let timeoutMsec = checkMsec;
       if (snapshot.actionAt) {
         const msecUntilAction = snapshot.actionAt.subtract(snapshot.at).secs * 1000;
-        const msecUntilCheck  = Math.max(
+        const msecUntilCheck  = Math.min(
           checkMsec,
-          Math.min(
+          Math.max(
             msecUntilAction * MemoryMonitor.#TROUBLE_CHECK_FRACTION,
             MemoryMonitor.#MIN_TROUBLE_CHECK_MSEC));
         timeoutMsec = msecUntilCheck;
@@ -154,7 +154,7 @@ export class MemoryMonitor extends BaseService {
    * @type {number} Fraction of time between "now" and when action needs to
    * happen, when the next check should take place in an "over limit" situation.
    */
-  static #TROUBLE_CHECK_FRACTION = 0.25;
+  static #TROUBLE_CHECK_FRACTION = 0.4;
 
   /** @override */
   static get CONFIG_CLASS() {

--- a/src/builtin-services/export/MemoryMonitor.js
+++ b/src/builtin-services/export/MemoryMonitor.js
@@ -19,20 +19,21 @@ import { MustBe } from '@this/typey';
  * * `{?number} checkSecs` -- How often to check things, in seconds, or `null`
  *   to use the default frequency. Minimum `1`. Defaults to `60` (once per
  *   minute).
- * * `{?number} gracePeriodSecs` -- Once the maximum size has been reached, how
- *   long it must remain at or beyond the maximum before this service takes
- *   action, or `null` not to have a grace period at all (equivalent to `0`).
- *   When in the middle of a grace period, the system checks more often than
- *   `checkSecs` so as not to miss a significant dip. Defaults to `null`.
- * * `{?number} maxHeapBytes` -- How large to allow the heap to get before
- *   initiating shutdown, or `null` for no limit on this. Defaults to `null`.
- *   In order to catch probably-unintentional misconfiguration, if non-`null`,
- *   must be one megabyte or larger.
+ * * `{?number} gracePeriodSecs` -- Once a memory limit has been reached, how
+ *   long it is allowed to remain at or beyond the maximum before this service
+ *   takes action, or `null` not to have a grace period at all (equivalent to
+ *   `0`). When in the middle of a grace period, the system checks more often
+ *   than `checkSecs` so as not to miss a significant dip. Defaults to `null`.
+ * * `{?number} maxHeapBytes` -- How many bytes of heap is considered "over
+ *   limit," or `null` for no limit on this. The amount counted is `heapTotal +
+ *   external` from `process.memoryUsage()`. Defaults to `null`. **Note:** In
+ *   order to catch probably-unintentional misconfiguration, if a number, must
+ *   be at least one megabyte.
  *   The amount counted is `heapTotal + external` from `process.memoryUsage()`.
- * * `{?number} maxRssBytes` -- How large to allow the RSS to get before
- *   initiating shutdown, or `null` for no limit on this. Defaults to `null`. In
+ * * `{?number} maxRssBytes` -- How many bytes of RSS is considered "over
+ *   limit," or `null` for no limit on this. Defaults to `null`. **Note:** In
  *   order to catch probably-unintentional misconfiguration, if non-`null`, must
- *   be one megabyte or larger.
+ *   be at least one megabyte.
  */
 export class MemoryMonitor extends BaseService {
   /** @type {Threadlet} Threadlet which runs this service. */
@@ -199,7 +200,7 @@ export class MemoryMonitor extends BaseService {
       } = config;
 
       this.#checkSecs = (checkSecs === null)
-        ? 60
+        ? 5 * 60
         : MustBe.number(checkSecs, { finite: true, minInclusive: 1 });
       this.#gracePeriodSecs = (gracePeriodSecs === null)
         ? 0

--- a/src/builtin-services/export/ProcessIdFile.js
+++ b/src/builtin-services/export/ProcessIdFile.js
@@ -9,7 +9,6 @@ import { FileServiceConfig } from '@this/app-config';
 import { BaseService } from '@this/app-framework';
 import { Threadlet } from '@this/async';
 import { ProcessUtil } from '@this/host';
-import { IntfLogger } from '@this/loggy';
 import { MustBe } from '@this/typey';
 
 

--- a/src/builtin-services/export/RequestLogger.js
+++ b/src/builtin-services/export/RequestLogger.js
@@ -22,9 +22,6 @@ import { IntfRequestLogger } from '@this/network-protocol';
  * @implements {IntfRequestLogger}
  */
 export class RequestLogger extends BaseService {
-  /** @type {string} Full path to the log file. */
-  #logFilePath;
-
   /** @type {?Rotator} File rotator to use, if any. */
   #rotator;
 
@@ -37,13 +34,12 @@ export class RequestLogger extends BaseService {
   constructor(config, logger) {
     super(config, logger);
 
-    this.#logFilePath = config.path;
-    this.#rotator     = config.rotate ? new Rotator(config, this.logger) : null;
+    this.#rotator = config.rotate ? new Rotator(config, this.logger) : null;
   }
 
   /** @override */
   async logCompletedRequest(line) {
-    await fs.appendFile(this.#logFilePath, `${line}\n`);
+    await fs.appendFile(this.config.path, `${line}\n`);
   }
 
   /** @override */

--- a/src/builtin-services/index.js
+++ b/src/builtin-services/index.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '#x/BuiltinServices';
+export * from '#x/MemoryMonitor';
 export * from '#x/ProcessIdFile';
 export * from '#x/ProcessInfoFile';
 export * from '#x/RateLimiter';

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -43,6 +43,17 @@ export class Moment {
   }
 
   /**
+   * Gets the sume `this + secs` as a new instance of this class.
+   *
+   * @param {number} secs Number of seconds to add.
+   * @returns {Moment} The summed result.
+   */
+  addSecs(secs) {
+    MustBe.number(secs, { finite: true });
+    return new Moment(this.#atSecs + secs);
+  }
+
+  /**
    * Gets the difference `this - other` as a {@link Duration}.
    *
    * @param {Moment} other Moment to subtract from this instance.

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -99,6 +99,17 @@ export class Moment {
   //
 
   /**
+   * Makes an instance of this class from a _millisecond_ time, such as might be
+   * returned from `Date.now()`.
+   *
+   * @param {number} atMsec The millisecond time.
+   * @returns {Moment} Corresponding instance of this class.
+   */
+  static fromMsec(atMsec) {
+    return new Moment(atMsec / 1000);
+  }
+
+  /**
    * Makes a friendly plain object representing a moment in time, which
    * represents both seconds since the Unix Epoch as well as a string indicating
    * the date-time in UTC.

--- a/src/data-values/tests/Moment.test.js
+++ b/src/data-values/tests/Moment.test.js
@@ -39,6 +39,19 @@ describe('.atSecs', () => {
   });
 });
 
+describe('addSecs()', () => {
+  test.each`
+  moment        | secs       | expected
+  ${12345}      | ${0}       | ${12345}
+  ${10000000}   | ${54321}   | ${10054321}
+  ${1600000000} | ${-999888} | ${1599000112}
+  `('works given ($moment, $secs)', ({ moment, secs, expected }) => {
+    const mobj   = new Moment(moment);
+    const result = mobj.addSecs(secs);
+    expect(result.atSecs).toBe(expected);
+  });
+});
+
 describe('subtract()', () => {
   test.each`
   m1          | m2           | expected

--- a/src/data-values/tests/Moment.test.js
+++ b/src/data-values/tests/Moment.test.js
@@ -101,3 +101,12 @@ ${'toString'}             | ${false}  | ${false}
     }
   });
 });
+
+describe('fromMsec()', () => {
+  test('produces an instance with 1/1000 the given value', () => {
+    for (let atMsec = -12345; atMsec < 1999988877; atMsec += 10000017) {
+      const result = Moment.fromMsec(atMsec);
+      expect(result.atSecs).toBe(atMsec / 1000);
+    }
+  });
+});

--- a/src/main-lactoserv/package.json
+++ b/src/main-lactoserv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@this/main-lactoserv",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "type": "module",
   "private": true,
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR adds a new service, `MemoryMonitor`, to… well… monitor memory. If memory usage goes beyond defined limits, the service will initiate (hopefully) graceful shutdown. The idea is that one configures the limits in the service to be lower than the actual `--max-old-space-size` (or similar), so that shutdown happens well before Node will give up and abruptly exit.

In addition, I took the opportunity here to tidy up the code of the other builtin services, just a bit.