### PR TITLE
Fix heap dump.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+### v0.5.10 -- 2023-04-17
+
+Notable changes:
+
+* Fixed heap snapshotting, which hadn't gotten adjusted to track event system
+  changes that had been made in v0.5.9.
+
 ### v0.5.9 -- 2023-04-05
 
 Notable changes:

--- a/doc/development.md
+++ b/doc/development.md
@@ -72,11 +72,14 @@ Recognized signals:
 * `SIGUSR1` -- Starts the Node inspector/debugger, listening on the usual port.
   (This is a standard signal recognized by Node. Just noting it here as a
   reminder or perhaps a TIL.)
-* `SIGUSR2` -- Produces a heap dump file. Look in the log for the file name.
+* `SIGUSR2` -- Produces a heap snapshot file. Look in the log for the file name.
   (Writes to the current directory if it is writable, and falls back to the
   value of environment variables `$HOME` or `$TMPDIR`, finally trying `/tmp` as
   a last-ditch effort. The file can be inspected using the "Memory" panel
-  available in the Chrome developer tools.
+  available in the Chrome developer tools. **Note:** Node documentation claims
+  that a process needs _additional_ memory of about the same size as the heap
+  being dumped; if the memory is not available you might find that your OS has
+  killed the process before it completes the snapshot.
 * `SIGINT` and `SIGTERM` -- Shuts down as cleanly as possible. (Note: `SIGINT`
   is usually what gets sent when you type `ctrl-C` in a console.)
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -73,8 +73,10 @@ Recognized signals:
   (This is a standard signal recognized by Node. Just noting it here as a
   reminder or perhaps a TIL.)
 * `SIGUSR2` -- Produces a heap dump file. Look in the log for the file name.
-  (Writes to the current directory if it is writable.) The file can be inspected
-  using the "Memory" panel available in the Chrome developer tools.
+  (Writes to the current directory if it is writable, and falls back to the
+  value of environment variables `$HOME` or `$TMPDIR`, finally trying `/tmp` as
+  a last-ditch effort. The file can be inspected using the "Memory" panel
+  available in the Chrome developer tools.
 * `SIGINT` and `SIGTERM` -- Shuts down as cleanly as possible. (Note: `SIGINT`
   is usually what gets sent when you type `ctrl-C` in a console.)
 

--- a/src/host/private/HeapDump.js
+++ b/src/host/private/HeapDump.js
@@ -6,7 +6,7 @@ import inspector from 'node:inspector';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
-import { EventSink, EventSource } from '@this/async';
+import { EventPayload, EventSink, EventSource } from '@this/async';
 import { Moment } from '@this/data-values';
 import { IntfLogger } from '@this/loggy';
 
@@ -44,7 +44,7 @@ export class HeapDump {
     let byteCount  = 0;
 
     const writeChunk = async (event) => {
-      const chunk = event.payload;
+      const [chunk] = event.payload.args;
 
       await handle.write(chunk);
 
@@ -68,7 +68,7 @@ export class HeapDump {
     sess.connect();
 
     sess.on('HeapProfiler.addHeapSnapshotChunk', async (msg) => {
-      source.emit(msg.params.chunk);
+      source.emit(new EventPayload('chunk', msg.params.chunk));
     });
 
     // TODO: Use 'node:inspector/promises' once this project starts requiring

--- a/src/main-lactoserv/package.json
+++ b/src/main-lactoserv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@this/main-lactoserv",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "type": "module",
   "private": true,
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR adjusts the heap snapshot code, to track recent changes to the event system. Something like 95% of the event-system-related code in this project is for logging, and this bit fell through the cracks. Oopsie!