### PR TITLE
Fix a leak of my own making

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+### v0.5.11 -- 2023-04-18
+
+Notable changes:
+
+* Fixed a promise-related leak introduced in the fix for the FD-socket-reload
+  issue.
+
 ### v0.5.10 -- 2023-04-17
 
 Notable changes:

--- a/scripts/run
+++ b/scripts/run
@@ -26,6 +26,8 @@ function usage {
     --inspect[=...]
       Passes this option to the `node` invocation, to enable interactive
       debugging.
+    --max-run-time-secs=<num>
+      Debugging option passed to the system.
     --out=<dir>
       Directory where built output goes. Defaults to `out` directly under the
       main product directory.
@@ -45,6 +47,7 @@ opt-value --var=action --init=run --enum='build clean run' do
 
 # Debugging options passed directly to the main `run` script.
 opt-toggle --var=earlyErrors early-errors
+opt-value --var=maxRunTimeSecs max-run-time-secs
 
 # Inspect?
 doInspect=0
@@ -102,9 +105,11 @@ fi
 if (( earlyErrors )); then
     extraOpts+=(--early-errors)
 fi
+if [[ ${maxRunTimeSecs} != '' ]]; then
+    extraOpts+=(--max-run-time-secs="${maxRunTimeSecs}")
+fi
 
 exec "${outRun}" \
     "${extraOpts[@]}" \
     --config="$(base-dir)/etc/example-setup/config/config.mjs" \
-    --max-run-time-secs="$(( 5 * 60 ))" \
     --log-to-stdout

--- a/src/async/export/EventSource.js
+++ b/src/async/export/EventSource.js
@@ -211,4 +211,19 @@ export class EventSource {
 
     return this.#currentEvent;
   }
+
+  /**
+   * Indicates whether or not a given (alleged) event is linked into the chain
+   * that ends at the head of this instance, or if it is the head itself. If the
+   * given `event` is not an instance of {@link LinkedEvent}, this method
+   * returns `false` (as opposed to throwing an error).
+   *
+   * @param {*} event (Alleged) event to check.
+   * @returns {boolean} `true` iff `event` is in fact an event instance and it
+   *   is either the head of this instance (the most-recently emitted event) or
+   *   it links to the head of this instance (either directly or indirectly).
+   */
+  isLinkedFrom(event) {
+    return this.#currentEvent.isLinkedFrom(event);
+  }
 }

--- a/src/async/export/LinkedEvent.js
+++ b/src/async/export/LinkedEvent.js
@@ -164,6 +164,35 @@ export class LinkedEvent {
   }
 
   /**
+   * Indicates whether or not a given (alleged) event either _is_ this instance
+   * or links to this instance, either directly or indirectly. If the given
+   * `event` is not an instance of this class, this method returns `false` (as
+   * opposed to throwing an error).
+   *
+   * @param {*} event (Alleged) event to check.
+   * @returns {boolean} `true` iff `event` is either this instance or it links
+   *   to this instance (either directly or indirectly).
+   */
+  isLinkedFrom(event) {
+    if (this === event) {
+      return true;
+    } else if (!(event instanceof LinkedEvent)) {
+      return false;
+    }
+
+    let at = event.#next;
+    while (at) {
+      const eventNow = at.eventNow;
+      if (eventNow === this) {
+        return true;
+      }
+      at = eventNow?.#next;
+    }
+
+    return false;
+  }
+
+  /**
    * Constructs a new instance which is set up to be at the head of an event
    * chain which continues with _this_ instance's next event, but with a
    * different payload. Put another way, this method constructs a replacement

--- a/src/async/export/PromiseUtil.js
+++ b/src/async/export/PromiseUtil.js
@@ -162,8 +162,9 @@ export class PromiseUtil {
   }
 
   /**
-   * Adds a new race contender to {@link #raceMap}. This method is called once
-   * ever per contender, even when that contender is involved in multiple races.
+   * Helper for {@link #race}, which adds a new race contender to the {@link
+   * #raceMap}. This method is called once ever per contender, even when that
+   * contender is involved in multiple races.
    *
    * **Note:** This method (a) is separate from {@link #race} (that is, the code
    * isn't just inlined at the sole call site) and (b) does not accept any

--- a/src/async/tests/LinkedEvent.test.js
+++ b/src/async/tests/LinkedEvent.test.js
@@ -339,6 +339,55 @@ describe('.type', () => {
   });
 });
 
+describe('isLinkedFrom()', () => {
+  test.each`
+  value
+  ${null}
+  ${undefined}
+  ${false}
+  ${1234}
+  ${'florp'}
+  ${new Map()}
+  `('returns `false` given a non-event $value', (value) => {
+    const event = new LinkedEvent(payload1);
+    expect(event.isLinkedFrom(value)).toBeFalse();
+  });
+
+  test('returns `false` given an event that is not linked to the instance', () => {
+    const event1 = new LinkedEvent(payload1);
+    const event2 = new LinkedEvent(payload2);
+    expect(event1.isLinkedFrom(event2)).toBeFalse();
+  });
+
+  test('returns `true` given the instance itself', () => {
+    const event = new LinkedEvent(payload1);
+    expect(event.isLinkedFrom(event)).toBeTrue();
+  });
+
+  test('returns `true` given an event that directly links to the instance', () => {
+    const event2 = new LinkedEvent(payload2);
+    const event1 = new LinkedEvent(payload1, event2);
+    expect(event2.isLinkedFrom(event1)).toBeTrue();
+  });
+
+  test('returns `false` given an event an event that _is linked to_ the instance', () => {
+    const event2 = new LinkedEvent(payload2);
+    const event1 = new LinkedEvent(payload1, event2);
+    expect(event1.isLinkedFrom(event2)).toBeFalse();
+  });
+
+  test('returns `true` given an event that indirectly links to the instance', () => {
+    const last   = new LinkedEvent(payload1);
+    const events = [last];
+
+    for (let i = 0; i < 20; i++) {
+      events.unshift(new LinkedEvent(payload1, events[0]));
+    }
+
+    expect(last.isLinkedFrom(events[0])).toBeTrue();
+  });
+});
+
 describe('withPayload()', () => {
   test('produces an instance with the indicated payload', () => {
     const event  = new LinkedEvent(payload1);

--- a/src/main-lactoserv/package.json
+++ b/src/main-lactoserv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@this/main-lactoserv",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "type": "module",
   "private": true,
   "license": "Apache-2.0",

--- a/src/main-lactoserv/private/Debugging.js
+++ b/src/main-lactoserv/private/Debugging.js
@@ -105,22 +105,21 @@ export class Debugging {
         remainingSecs = 60;
       }
 
-      let warningFreqSecs = 10;
-      let extraSecs       = remainingSecs % warningFreqSecs;
+      const WARNING_FREQ_SECS = 10;
 
       while (remainingSecs > 0) {
         logger.timeRemaining({ seconds: remainingSecs });
 
-        const secs = extraSecs + warningFreqSecs;
-        await timers.setTimeout(secs * 1000);
-        remainingSecs -= secs;
-        extraSecs = 0;
-
-        if (remainingSecs <= 5) {
-          warningFreqSecs = 1;
-        } else if (remainingSecs <= 10) {
-          warningFreqSecs = 5;
+        let waitSecs = 1;
+        if (remainingSecs >= (WARNING_FREQ_SECS * 2)) {
+          waitSecs = WARNING_FREQ_SECS + (remainingSecs % WARNING_FREQ_SECS);
+        } else if (remainingSecs >= WARNING_FREQ_SECS) {
+          const HALF_FREQ_SECS = Math.trunc(WARNING_FREQ_SECS / 2);
+          waitSecs = HALF_FREQ_SECS + (remainingSecs % HALF_FREQ_SECS);
         }
+
+        await timers.setTimeout(waitSecs * 1000);
+        remainingSecs -= waitSecs;
       }
 
       logger.timerExpired({ seconds: maxRunTimeSecs });


### PR DESCRIPTION
Not exactly due to `Promise.race()` this time, but not _not_ because of it in a way…

This PR fixes a leak I introduced when I split out connection-accepting into a helper class. The `accept()` call was set up to be cancelable, which e.g. ends up getting activated during reload or clean shutdown. The problem is that the definition of `race()` is that the _value_ of the race winner is returned, not the _promise_ which won the race, and this code needs to know the latter. A janky solution (which I didn't use) would have been to do an `instanceof` on the winner, the jankiness being that that would make the code brittle with respect to uncontrolled choices by its clients with regards to what the cancellation promise might resolve to. I ended up writing this:

```js
let canceled = false;

if (cancelPromise) {
  (async () => {
    try {
      await cancelPromise;
    } finally {
      canceled = true;
    }
  })();
}
```

...so that if the race ended due to cancellation the code would trivially know via a local variable check. This all seemed innocuous enough at the time, but — oops! — this is exactly analogous to the bug in the built-in `race()` code: If `cancelPromise` effectively-never resolves, then every time this code is called, we leak a new promise waiting for that would-be resolution.

Instead of going back to the janky solution — which I admit would have worked — I opted to do something _else_ non-brittle: The code in question now checks the _other_ contender of the race; if the race result is definitely an event that got emitted by the internally-controlled source, then it was definitely _not_ a cancellation.

If there were a `Promise.race()` variant that returned the _promise_ that won (and perhaps also indicated the resolution), then I would have used that. I considered writing just that for this PR but ended up deciding that it was more trouble than it was worth, at least for now.