### PR TITLE
Fix self-signed certs when used as the wildcard (for non-SNI)

### DIFF
--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -16,13 +16,13 @@ const RUN_DIR = `${VAR_DIR}/run`;
 // Host / certificate bindings.
 const hosts = [
   {
-    hostnames:   ['localhost'],
-    selfSigned:  true
+    hostnames:   ['localhost', '*.localhost'],
+    certificate: await readFile('localhost-cert.pem'),
+    privateKey:  await readFile('localhost-key.pem')
   },
   {
     hostnames:   ['*', '127.0.0.1', '::1'],
-    certificate: await readFile('localhost-cert.pem'),
-    privateKey:  await readFile('localhost-key.pem')
+    selfSigned:  true
   }
 ];
 

--- a/src/app-framework/export/HostManager.js
+++ b/src/app-framework/export/HostManager.js
@@ -6,6 +6,7 @@ import { SecureContext } from 'node:tls';
 import { HostConfig, Uris } from '@this/app-config';
 import { TreePathKey, TreePathMap } from '@this/collections';
 import { IntfLogger } from '@this/loggy';
+import { IntfHostManager } from '@this/network-protocol';
 
 import { HostItem } from '#p/HostItem';
 import { ThisModule } from '#p/ThisModule';
@@ -16,6 +17,8 @@ import { ThisModule } from '#p/ThisModule';
  * network-available endpoints associated with particular names, certificates,
  * and private keys. The main thing offered by this class is the association
  * between hostnames and TLS contexts.
+ *
+ * @implements {IntfHostManager}
  */
 export class HostManager {
   /**
@@ -41,25 +44,13 @@ export class HostManager {
     }
   }
 
-  /**
-   * Finds the TLS {@link SecureContext} to use, based on the given hostname.
-   *
-   * @param {string} name Hostname to look for, which may be a partial or full
-   *   wildcard.
-   * @returns {?SecureContext} The associated {@link SecureContext}, or `null`
-   *   if no hostname match is found.
-   */
+  /** @override */
   async findContext(name) {
     const item = this.#findItem(name, true);
     return item ? await item.getSecureContext() : null;
   }
 
-  /**
-   * Gets options suitable for use with `http2.createSecureServer()` and the
-   * like, such that this instance will be used to find certificates and keys.
-   *
-   * @returns {object} Options for secure server/context construction.
-   */
+  /** @override */
   async getSecureServerOptions() {
     const result = {
       SNICallback: (serverName, cb) => this.sniCallback(serverName, cb)

--- a/src/app-framework/export/HostManager.js
+++ b/src/app-framework/export/HostManager.js
@@ -42,29 +42,6 @@ export class HostManager {
   }
 
   /**
-   * Finds the configuration info (cert/key pair) associated with the given
-   * hostname. The return value is suitable for use in options passed to Node
-   * `TLS` functions / methods.
-   *
-   * @param {string} name Hostname to look for, which may be a partial or full
-   *   wildcard.
-   * @returns {?{cert: string, key: string}} Configuration info, or `null` if no
-   *  hostname match is found.
-   */
-  findConfig(name) {
-    const item = this.#findItem(name, true);
-
-    if (!item) {
-      return null;
-    }
-
-    return Object.freeze({
-      cert: item.config.certificate,
-      key:  item.config.privateKey
-    });
-  }
-
-  /**
    * Finds the TLS {@link SecureContext} to use, based on the given hostname.
    *
    * @param {string} name Hostname to look for, which may be a partial or full

--- a/src/app-framework/export/HostManager.js
+++ b/src/app-framework/export/HostManager.js
@@ -61,7 +61,7 @@ export class HostManager {
    * @returns {object} Options for secure server/context construction.
    */
   async getSecureServerOptions() {
-    let result = {
+    const result = {
       SNICallback: (serverName, cb) => this.sniCallback(serverName, cb)
     };
 

--- a/src/app-framework/export/HostManager.js
+++ b/src/app-framework/export/HostManager.js
@@ -42,22 +42,6 @@ export class HostManager {
   }
 
   /**
-   * @returns {object} Options suitable for use with
-   * `http2.createSecureServer()` and the like, such that this instance will be
-   * used to find certificates and keys.
-   */
-  get secureServerOptions() {
-    // The `key` and `cert` bound in the result of this getter are for cases
-    // when the (network) client doesn't invoke the server-name extension.
-    // Hence, it's the wildcard... if available.
-    const wildcard = this.findConfig('*') ?? {};
-
-    const sniCallback = (serverName, cb) => this.sniCallback(serverName, cb);
-
-    return { ...wildcard, SNICallback: sniCallback };
-  }
-
-  /**
    * Finds the configuration info (cert/key pair) associated with the given
    * hostname. The return value is suitable for use in options passed to Node
    * `TLS` functions / methods.
@@ -91,6 +75,23 @@ export class HostManager {
   async findContext(name) {
     const item = this.#findItem(name, true);
     return item ? await item.getSecureContext() : null;
+  }
+
+  /**
+   * Gets options suitable for use with `http2.createSecureServer()` and the
+   * like, such that this instance will be used to find certificates and keys.
+   *
+   * @returns {object} Options for secure server/context construction.
+   */
+  async getSecureServerOptions() {
+    // The `key` and `cert` bound in the result of this getter are for cases
+    // when the (network) client doesn't invoke the server-name extension.
+    // Hence, it's the wildcard... if available.
+    const wildcard = this.findConfig('*') ?? {};
+
+    const sniCallback = (serverName, cb) => this.sniCallback(serverName, cb);
+
+    return { ...wildcard, SNICallback: sniCallback };
   }
 
   /**

--- a/src/app-framework/export/NetworkEndpoint.js
+++ b/src/app-framework/export/NetworkEndpoint.js
@@ -68,7 +68,7 @@ export class NetworkEndpoint extends BaseComponent {
       interface: iface,
       ...(
         hostManager
-          ? { hosts: hostManager.secureServerOptions }
+          ? { hostManager, hosts: hostManager.secureServerOptions }
           : {})
     };
 

--- a/src/app-framework/export/NetworkEndpoint.js
+++ b/src/app-framework/export/NetworkEndpoint.js
@@ -68,7 +68,7 @@ export class NetworkEndpoint extends BaseComponent {
       interface: iface,
       ...(
         hostManager
-          ? { hostManager, hosts: hostManager.secureServerOptions }
+          ? { hostManager }
           : {})
     };
 

--- a/src/app-framework/export/NetworkEndpoint.js
+++ b/src/app-framework/export/NetworkEndpoint.js
@@ -24,12 +24,6 @@ import { ThisModule } from '#p/ThisModule';
  */
 export class NetworkEndpoint extends BaseComponent {
   /**
-   * @type {HostManager} Host manager with bindings for all valid hostnames for
-   * this instance.
-   */
-  #hostManager;
-
-  /**
    * @type {TreePathMap<TreePathMap<BaseApplication>>} Map from hostnames to
    * map from paths to applications. See {@link #makeMountMap} for details.
    */
@@ -63,8 +57,7 @@ export class NetworkEndpoint extends BaseComponent {
 
     super(config, ThisModule.logger.endpoint[name]);
 
-    this.#hostManager = hostManager;
-    this.#mountMap    = NetworkEndpoint.#makeMountMap(mounts, applicationMap);
+    this.#mountMap = NetworkEndpoint.#makeMountMap(mounts, applicationMap);
 
     const wranglerOptions = {
       rateLimiter,
@@ -74,8 +67,8 @@ export class NetworkEndpoint extends BaseComponent {
       protocol,
       interface: iface,
       ...(
-        this.#hostManager
-          ? { hosts: this.#hostManager.secureServerOptions }
+        hostManager
+          ? { hosts: hostManager.secureServerOptions }
           : {})
     };
 

--- a/src/app-framework/private/HostItem.js
+++ b/src/app-framework/private/HostItem.js
@@ -18,16 +18,22 @@ export class HostItem {
   #config;
 
   /**
-   * @type {?tls.SecureContext} TLS context representing this instance's info,
-   * if it is in fact ready.
+   * @type {?{certificate: string, privateKey: string}} The certificate and
+   * for this instance, if known.
    */
-  #secureContext = null;
+  #parameters = null;
 
   /**
-   * @type {Promise<tls.SecureContext>} Promise for {@link #secureContext}, if
-   * it is not yet resolved.
+   * @type {Promise} Promise for value of {@link #parameters}, if it is not yet
+   * (effectively) resolved.
    */
-  #scPromise = null;
+  #parametersPromise = null;
+
+  /**
+   * @type {?tls.SecureContext} TLS context representing this instance's info,
+   * lazily initialized.
+   */
+  #secureContext = null;
 
   /**
    * Constructs an instance.
@@ -40,16 +46,13 @@ export class HostItem {
     this.#config = config;
 
     if (selfSigned) {
-      this.#scPromise = HostItem.#makeSelfSignedContext(config);
+      this.#parametersPromise = HostItem.#makeSelfSignedParameters(config);
       (async () => {
-        this.#secureContext = await this.#scPromise;
-        this.#scPromise     = null;
+        this.#parameters        = await this.#parametersPromise;
+        this.#parametersPromise = null;
       })();
     } else {
-      this.#secureContext = tls.createSecureContext({
-        cert: certificate,
-        key:  privateKey
-      });
+      this.#parameters = { certificate, privateKey };
     }
   }
 
@@ -59,13 +62,32 @@ export class HostItem {
   }
 
   /**
-   * Gets the TLS context. Note: This is `async` and not just a getter, because
-   * in some cases the context is only generated asynchronously.
+   * Gets the TLS context. **Note:** This is `async` and not just a getter,
+   * because in some cases the context can only be generated asynchronously.
    *
    * @returns {tls.SecureContext} The TLS context.
    */
   async getSecureContext() {
-    return this.#secureContext ?? await this.#scPromise;
+    if (!this.#secureContext) {
+      const params = await this.getParameters();
+      this.#secureContext = tls.createSecureContext({
+        cert: params.certificate,
+        key:  params.privateKey
+      });
+    }
+
+    return this.#secureContext;
+  }
+
+  /**
+   * Gets the resolved parameters -- specifically, the certificate and key --
+   * for this instance. **Note:** This is `async` and not just a getter, because
+   * in some cases the context is only generated asynchronously.
+   *
+   * @returns {{certificate: string, privateKey: string}} The parameters.
+   */
+  async getParameters() {
+    return this.#parameters ?? await this.#parametersPromise;
   }
 
 
@@ -74,18 +96,13 @@ export class HostItem {
   //
 
   /**
-   * Creates a TLS context with a newly-generated self-signed certificate and
-   * corresponding key.
-   *
-   * @param {HostConfig} config Parsed configuration item.
-   * @returns {tls.SecureContext} Constructed context.
-   */
-  static async #makeSelfSignedContext(config) {
-    // TODO: If a certificate made this way is offered as the catch-all for
-    // when SNI isn't used, and an incoming request is for an IP address (not a
-    // DNS name), then the server will silently fail (but not crash). Unclear
-    // what's going on. Probably needs to be sorted out.
-
+  * Makes the parameters for a newly-generated self-signed certificate and
+  * corresponding key.
+  *
+  * @param {HostConfig} config Parsed configuration item.
+  * @returns {{certificate: string, privateKey: string}} The parameters.
+  */
+  static async #makeSelfSignedParameters(config) {
     const altNames = [];
     for (let i = 0; i < config.hostnames.length; i++) {
       const name = config.hostnames[i];
@@ -121,9 +138,9 @@ export class HostItem {
       config:     certConfig
     });
 
-    return tls.createSecureContext({
-      cert: pemResult.certificate,
-      key:  pemResult.clientKey
-    });
+    return {
+      certificate: pemResult.certificate,
+      privateKey:  pemResult.clientKey
+    };
   }
 }

--- a/src/app-framework/private/HostItem.js
+++ b/src/app-framework/private/HostItem.js
@@ -96,12 +96,12 @@ export class HostItem {
   //
 
   /**
-  * Makes the parameters for a newly-generated self-signed certificate and
-  * corresponding key.
-  *
-  * @param {HostConfig} config Parsed configuration item.
-  * @returns {{certificate: string, privateKey: string}} The parameters.
-  */
+   * Makes the parameters for a newly-generated self-signed certificate and
+   * corresponding key.
+   *
+   * @param {HostConfig} config Parsed configuration item.
+   * @returns {{certificate: string, privateKey: string}} The parameters.
+   */
   static async #makeSelfSignedParameters(config) {
     const altNames = [];
     for (let i = 0; i < config.hostnames.length; i++) {

--- a/src/network-protocol/export/IntfHostManager.js
+++ b/src/network-protocol/export/IntfHostManager.js
@@ -1,0 +1,37 @@
+// Copyright 2022-2023 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { SecureContext } from 'node:tls';
+
+import { Methods } from '@this/typey';
+
+
+/**
+ * Interface for "host managers" as needed by this module. These are responsible
+ * for looking up hostnames and reporting back secure context information.
+ *
+ * @interface
+ */
+export class IntfHostManager {
+  /**
+   * Finds the TLS {@link SecureContext} to use, based on the given hostname.
+   *
+   * @param {string} name Hostname to look for, which may be a partial or full
+   *   wildcard.
+   * @returns {?SecureContext} The associated {@link SecureContext}, or `null`
+   *   if no hostname match is found.
+   */
+  async findContext(name) {
+    Methods.abstract(name);
+  }
+
+  /**
+   * Gets options suitable for use with `http2.createSecureServer()` and the
+   * like, such that this instance will be used to find certificates and keys.
+   *
+   * @returns {object} Options for secure server/context construction.
+   */
+  async getSecureServerOptions() {
+    Methods.abstract();
+  }
+}

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -81,10 +81,6 @@ export class ProtocolWrangler {
    * Constructs an instance.
    *
    * @param {object} options Construction options.
-   * @param {object} options.hosts Value returned from {@link
-   *   HostManager#secureServerOptions}, if this instance is (possibly) expected
-   *   to need to use certificates (etc.). Ignored for instances which don't do
-   *   that sort of thing.
    * @param {object} options.hostManager Host manager to use. Ignored for
    *   instances which don't do need to do host-based security (certs, etc.).
    * @param {IntfRateLimiter} options.rateLimiter Rate limiter to use. If not

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -35,6 +35,11 @@ export class ProtocolWrangler {
   /** @type {?IntfLogger} Logger to use, or `null` to not do any logging. */
   #logger;
 
+  /**
+   * @type {?HostManager} Optional host manager; only needed for some protocols.
+   */
+  #hostManager;
+
   /** @type {?IntfRateLimiter} Rate limiter service to use, if any. */
   #rateLimiter;
 
@@ -80,6 +85,8 @@ export class ProtocolWrangler {
    *   HostManager#secureServerOptions}, if this instance is (possibly) expected
    *   to need to use certificates (etc.). Ignored for instances which don't do
    *   that sort of thing.
+   * @param {object} options.hostManager Host manager to use. Ignored for
+   *   instances which don't do need to do host-based security (certs, etc.).
    * @param {IntfRateLimiter} options.rateLimiter Rate limiter to use. If not
    *   specified, the instance won't do rate limiting.
    * @param {function(object, object)} options.requestHandler Request handler,
@@ -101,9 +108,16 @@ export class ProtocolWrangler {
    *     practice for HTTP2 (and is at least _useful_ in other contexts).
    */
   constructor(options) {
-    const { logger, rateLimiter, requestHandler, requestLogger } = options;
+    const {
+      hostManager,
+      logger,
+      rateLimiter,
+      requestHandler,
+      requestLogger
+    } = options;
 
     this.#logger         = logger ?? null;
+    this.#hostManager    = hostManager ?? null;
     this.#rateLimiter    = rateLimiter ?? null;
     this.#requestHandler = MustBe.callableFunction(requestHandler);
     this.#logHelper      = requestLogger
@@ -221,6 +235,11 @@ export class ProtocolWrangler {
    */
   async _impl_serverSocketStop(willReload) {
     Methods.abstract(willReload);
+  }
+
+  /** @returns {?HostManager} The host manager, if any. */
+  get _prot_hostManager() {
+    return this.#hostManager;
   }
 
   /**

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -13,6 +13,7 @@ import { ProductInfo } from '@this/host';
 import { IntfLogger } from '@this/loggy';
 import { Methods, MustBe } from '@this/typey';
 
+import { IntfHostManager } from '#x/IntfHostManager';
 import { IntfRateLimiter } from '#x/IntfRateLimiter';
 import { IntfRequestLogger } from '#x/IntfRequestLogger';
 import { RequestLogHelper } from '#p/RequestLogHelper';
@@ -36,7 +37,8 @@ export class ProtocolWrangler {
   #logger;
 
   /**
-   * @type {?HostManager} Optional host manager; only needed for some protocols.
+   * @type {?IntfHostManager} Optional host manager; only needed for some
+   * protocols.
    */
   #hostManager;
 
@@ -245,7 +247,7 @@ export class ProtocolWrangler {
     Methods.abstract(willReload);
   }
 
-  /** @returns {?HostManager} The host manager, if any. */
+  /** @returns {?IntfHostManager} The host manager, if any. */
   get _prot_hostManager() {
     return this.#hostManager;
   }

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -136,7 +136,7 @@ export class ProtocolWrangler {
    */
   async start(isReload) {
     this.#reloading = isReload;
-    this.#initialize();
+    await this.#initialize();
     await this.#runner.start();
   }
 
@@ -154,6 +154,18 @@ export class ProtocolWrangler {
   async stop(willReload) {
     this.#reloading = willReload;
     await this.#runner.stop();
+  }
+
+  /**
+   * Initializes the instance. After this is called and (asynchronously)
+   * returns, both {@link #_impl_application} and {@link #_impl_server} should
+   * work without error. This can get called more than once; the second and
+   * subsequent times should be considered a no-op.
+   *
+   * @abstract
+   */
+  async _impl_initialize() {
+    Methods.abstract();
   }
 
   /**
@@ -456,10 +468,12 @@ export class ProtocolWrangler {
    * only after it's finished that we can grab the objects that it's responsible
    * for creating.
    */
-  #initialize() {
+  async #initialize() {
     if (this.#initialized) {
       return;
     }
+
+    await this._impl_initialize();
 
     const application = this._impl_application();
     const server      = this._impl_server();

--- a/src/network-protocol/index.js
+++ b/src/network-protocol/index.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2023 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+export * from '#x/IntfHostManager';
 export * from '#x/IntfRateLimiter';
 export * from '#x/IntfRequestLogger';
 export * from '#x/ProtocolWrangler';

--- a/src/network-protocol/private/Http2Wrangler.js
+++ b/src/network-protocol/private/Http2Wrangler.js
@@ -69,8 +69,9 @@ export class Http2Wrangler extends TcpWrangler {
   /** @override */
   async _impl_initialize() {
     if (!this.#protocolServer) {
+      const hostOptions = await this._prot_hostManager.getSecureServerOptions();
       const serverOptions = {
-        ...(this._prot_hostManager.secureServerOptions),
+        ...hostOptions,
         allowHTTP1: true
       };
 

--- a/src/network-protocol/private/Http2Wrangler.js
+++ b/src/network-protocol/private/Http2Wrangler.js
@@ -67,7 +67,7 @@ export class Http2Wrangler extends TcpWrangler {
   }
 
   /** @override */
-  _impl_server() {
+  async _impl_initialize() {
     if (!this.#protocolServer) {
       const serverOptions = {
         ...(this._prot_hostManager.secureServerOptions),
@@ -77,7 +77,10 @@ export class Http2Wrangler extends TcpWrangler {
       this.#protocolServer = http2.createSecureServer(serverOptions);
       this.#protocolServer.on('session', (session) => this.#addSession(session));
     }
+  }
 
+  /** @override */
+  _impl_server() {
     return this.#protocolServer;
   }
 

--- a/src/network-protocol/private/Http2Wrangler.js
+++ b/src/network-protocol/private/Http2Wrangler.js
@@ -25,7 +25,7 @@ export class Http2Wrangler extends TcpWrangler {
   #application;
 
   /** @type {?http2.Http2Server} High-level protocol server. */
-  #protocolServer;
+  #protocolServer = null;
 
   /** @type {Condition} Are there currently any sessions? */
   #anySessions = new Condition();
@@ -46,17 +46,9 @@ export class Http2Wrangler extends TcpWrangler {
 
     this.#logger = options.logger?.http2 ?? null;
 
-    const serverOptions = {
-      ...options.hosts,
-      allowHTTP1: true
-    };
-
     // Express needs to be wrapped in order for it to use HTTP2.
     this.#application = http2ExpressBridge(express);
     this.#application.use('/', (req, res, next) => this.#tweakResponse(req, res, next));
-
-    this.#protocolServer = http2.createSecureServer(serverOptions);
-    this.#protocolServer.on('session', (session) => this.#addSession(session));
   }
 
   /** @override */
@@ -76,6 +68,16 @@ export class Http2Wrangler extends TcpWrangler {
 
   /** @override */
   _impl_server() {
+    if (!this.#protocolServer) {
+      const serverOptions = {
+        ...(this._prot_hostManager.secureServerOptions),
+        allowHTTP1: true
+      };
+
+      this.#protocolServer = http2.createSecureServer(serverOptions);
+      this.#protocolServer.on('session', (session) => this.#addSession(session));
+    }
+
     return this.#protocolServer;
   }
 

--- a/src/network-protocol/private/HttpWrangler.js
+++ b/src/network-protocol/private/HttpWrangler.js
@@ -56,6 +56,11 @@ export class HttpWrangler extends TcpWrangler {
   }
 
   /** @override */
+  async _impl_initialize() {
+    // Nothing needed here.
+  }
+
+  /** @override */
   _impl_server() {
     return this.#protocolServer;
   }

--- a/src/network-protocol/private/HttpsWrangler.js
+++ b/src/network-protocol/private/HttpsWrangler.js
@@ -57,8 +57,8 @@ export class HttpsWrangler extends TcpWrangler {
   /** @override */
   async _impl_initialize() {
     if (!this.#protocolServer) {
-      this.#protocolServer =
-        https.createServer(this._prot_hostManager.secureServerOptions);
+      const hostOptions = await this._prot_hostManager.getSecureServerOptions();
+      this.#protocolServer = https.createServer(hostOptions);
     }
   }
 

--- a/src/network-protocol/private/HttpsWrangler.js
+++ b/src/network-protocol/private/HttpsWrangler.js
@@ -21,7 +21,7 @@ export class HttpsWrangler extends TcpWrangler {
   #application;
 
   /** @type {?https.Server} High-level protocol server. */
-  #protocolServer;
+  #protocolServer = null;
 
   /**
    * Constructs an instance.
@@ -31,9 +31,8 @@ export class HttpsWrangler extends TcpWrangler {
   constructor(options) {
     super(options);
 
-    this.#logger         = options.logger?.https ?? null;
-    this.#application    = express();
-    this.#protocolServer = https.createServer(options.hosts);
+    this.#logger      = options.logger?.https ?? null;
+    this.#application = express();
   }
 
   /** @override */
@@ -57,6 +56,11 @@ export class HttpsWrangler extends TcpWrangler {
 
   /** @override */
   _impl_server() {
+    if (!this.#protocolServer) {
+      this.#protocolServer =
+        https.createServer(this._prot_hostManager.secureServerOptions);
+    }
+
     return this.#protocolServer;
   }
 }

--- a/src/network-protocol/private/HttpsWrangler.js
+++ b/src/network-protocol/private/HttpsWrangler.js
@@ -55,12 +55,15 @@ export class HttpsWrangler extends TcpWrangler {
   }
 
   /** @override */
-  _impl_server() {
+  async _impl_initialize() {
     if (!this.#protocolServer) {
       this.#protocolServer =
         https.createServer(this._prot_hostManager.secureServerOptions);
     }
+  }
 
+  /** @override */
+  _impl_server() {
     return this.#protocolServer;
   }
 }


### PR DESCRIPTION
This PR fixes a bug which caused a wildcard hostname configured as `selfSigned` (that is, the system automatically generates a self-signed certificate for them) to fail to get its certificate registered with the TLS context. It boiled down to an assumption which had been rendered incorrect when `selfSigned` was introduced (last PR), namely that a `HostItem`'s `.config` always contained the certificate and key to use.

This PR fixes issue #201 (whose description turned out not to describe the actual bug).