### PR TITLE
`Request` development and not-found handling

### DIFF
--- a/src/app-framework/export/BaseApplication.js
+++ b/src/app-framework/export/BaseApplication.js
@@ -162,35 +162,4 @@ export class BaseApplication extends BaseComponent {
 
     return resultMp.promise;
   }
-
-  /**
-   * Sets up a regular Express-style response object (that is wrapped by the
-   * given {@link Request}), such that a call to `end()` on it will in turn
-   * cause this method to async-return.
-   *
-   * This method is meant as a helper when wrapping Express middleware in a
-   * concrete instance of this class.
-   *
-   * @param {Request} request Request object.
-   * @returns {boolean} `true`, after `end()` was called.
-   */
-  static async whenEnded(request) {
-    const res = request.expressResponse;
-
-    if (res.writableEnded) {
-      // Already ended!
-      return true;
-    }
-
-    const origEnd  = res.end;
-    const resultMp = new ManualPromise();
-
-    res.end = (...args) => {
-      res.end = origEnd;
-      res.end(...args);
-      resultMp.resolve(true);
-    };
-
-    return resultMp.promise;
-  }
 }

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -9,6 +9,7 @@ import { ApplicationConfig, Files } from '@this/app-config';
 import { BaseApplication } from '@this/app-framework';
 import { FsUtil } from '@this/fs-util';
 import { IntfLogger } from '@this/loggy';
+import { MimeTypes } from '@this/net-util';
 import { DispatchInfo } from '@this/network-protocol';
 
 
@@ -40,6 +41,12 @@ export class StaticFiles extends BaseApplication {
   /** @type {function(...*)} "Middleware" handler function for this instance. */
   #staticMiddleware;
 
+  /** @type {?string} MIME type of the not-found file, if known. */
+  #notFoundType = null;
+
+  /** @type {?Buffer} Contents of the not-found file, if known. */
+  #notFoundContents = null;
+
   /**
    * Constructs an instance.
    *
@@ -62,10 +69,8 @@ export class StaticFiles extends BaseApplication {
     const resolved = await this.#resolvePath(dispatch);
 
     if (!resolved) {
-      if (this.#notFoundPath) {
-        request.expressResponse.status(404)
-          .sendFile(this.#notFoundPath, StaticFiles.#SEND_OPTIONS);
-        return await request.whenResponseDone();
+      if (this.#notFoundType) {
+        return request.notFound(this.#notFoundType, this.#notFoundContents);
       } else {
         return false;
       }
@@ -94,16 +99,21 @@ export class StaticFiles extends BaseApplication {
 
   /** @override */
   async _impl_start(isReload_unused) {
-    const { notFoundPath, siteDirectory } = this.config;
+    const siteDirectory = this.#siteDirectory;
 
     if (!await FsUtil.directoryExists(siteDirectory)) {
       throw new Error(`Not found or not a directory: ${siteDirectory}`);
     }
 
+    const notFoundPath = this.#notFoundPath;
+
     if (notFoundPath) {
       if (!await FsUtil.fileExists(notFoundPath)) {
         throw new Error(`Not found or not a file: ${notFoundPath}`);
       }
+
+      this.#notFoundType     = MimeTypes.typeFromExtension(notFoundPath);
+      this.#notFoundContents = await fs.readFile(notFoundPath);
     }
   }
 

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -65,7 +65,7 @@ export class StaticFiles extends BaseApplication {
       if (this.#notFoundPath) {
         request.expressResponse.status(404)
           .sendFile(this.#notFoundPath, StaticFiles.#SEND_OPTIONS);
-        return await BaseApplication.whenEnded(request);
+        return await request.whenResponseDone();
       } else {
         return false;
       }

--- a/src/main-lactoserv/package-lock.json
+++ b/src/main-lactoserv/package-lock.json
@@ -12,6 +12,7 @@
         "express": "^4.18.2",
         "http2-express-bridge": "^1.0.7",
         "lodash": "^4.17.21",
+        "mime": "^4.0.1",
         "pem": "^1.14.8",
         "statuses": "^2.0.1",
         "yargs": "^17.6.0"
@@ -426,6 +427,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/http2-express-bridge/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/http2-express-bridge/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -552,14 +564,17 @@
       }
     },
     "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.1.tgz",
+      "integrity": "sha512-5lZ5tyrIfliMXzFtkYyekWbtRXObT9OWa8IwQ5uxTBDHucNNwniRqo0yInflj+iYi5CBa6qxadGzGarDfuEOxA==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
       "bin": {
-        "mime": "cli.js"
+        "mime": "bin/cli.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=16"
       }
     },
     "node_modules/mime-db": {
@@ -749,6 +764,17 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/send/node_modules/ms": {

--- a/src/net-util/export/MimeTypes.js
+++ b/src/net-util/export/MimeTypes.js
@@ -1,0 +1,57 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import mime from 'mime';
+
+import { MustBe } from '@this/typey';
+
+
+/**
+ * Utilities for wrangling MIME types / content types.
+ *
+ * **Note:** This is mostly just a wrapper around an external package, mainly to
+ * keep the dependency details from "infecting" the rest of the system.
+ */
+export class MimeTypes {
+  /**
+   * Gets the MIME type for the given extension (no dot or just initial dot in
+   * the given string) or extension of the given file path (dot in the middle of
+   * the string). This returns `'application/octet-stream'` if nothing better
+   * can be determined.
+   *
+   * @param {string} extensionOrPath File extension or path.
+   * @returns {string} The MIME type.
+   */
+  static typeFromExtension(extensionOrPath) {
+    MustBe.string(extensionOrPath);
+
+    const result = mime.getType(extensionOrPath);
+
+    return result ?? 'application/octet-stream';
+  }
+
+  /**
+   * Returns the given string if it is a known MIME type, or uses {@link
+   * #typeForExtension} if it looks like a simple extension value (string of
+   * less than 10 characters with no dot or slash). If it is an extension that
+   * is unrecognized, this returns `'application/octet-stream'`. This throws an
+   * an error in other cases.
+   *
+   * @param {string} extensionOrType File extension or MIME type.
+   * @returns {string} The MIME type.
+   */
+  static typeFromExtensionOrType(extensionOrType) {
+    MustBe.string(extensionOrType);
+
+    if (/[./]/.test(extensionOrType)) {
+      const found = mime.getExtension(extensionOrType);
+      if (!found) {
+        throw new Error(`Unknown MIME type: ${extensionOrType}`);
+      }
+      return extensionOrType;
+    } else {
+      const found = mime.getType(extensionOrType);
+      return found ?? 'application/octet-stream';
+    }
+  }
+}

--- a/src/net-util/export/MimeTypes.js
+++ b/src/net-util/export/MimeTypes.js
@@ -31,8 +31,8 @@ export class MimeTypes {
   }
 
   /**
-   * Returns the given string if it is a known MIME type, or uses {@link
-   * #typeForExtension} if it looks like a simple extension value (string of
+   * Returns the given string if it is a known MIME type, or acts like {@link
+   * #typeFromExtension} if it looks like a simple extension value (string of
    * less than 10 characters with no dot or slash). If it is an extension that
    * is unrecognized, this returns `'application/octet-stream'`. This throws an
    * an error in other cases.

--- a/src/net-util/index.js
+++ b/src/net-util/index.js
@@ -1,4 +1,5 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+export * from '#x/MimeTypes';
 export * from '#x/Uris';

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -13,6 +13,7 @@
 
   "dependencies": {
     "@this/collections": "*",
-    "@this/typey": "*"
+    "@this/typey": "*",
+    "mime": "^4.0.1"
   }
 }

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -489,6 +489,10 @@ export class ProtocolWrangler {
     // permanently.
     application.set('env', 'production');
 
+    // Don't generate etags automatically. Particular apps -- e.g., notably
+    // `StaticFiles`, might still choose to generate them, though.
+    application.set('etag fn', false);
+
     // This means paths `/foo` and `/foo/` are different.
     application.set('strict routing', true);
 

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -267,26 +267,32 @@ export class Request {
    * Issues a "not found" (status `404`) response, with optional body. If no
    * body is provided, a simple default plain-text body is used. The response
    * includes the single content/cache-related header `Cache-Control: no-store,
-   * must-revalidate`.
+   * must-revalidate`. If the request method is `HEAD`, this will _not_ send the
+   * body as part of the response.
    *
    * @param {string} [type] Content type for the body. Must be valid if `body`
    *   is passed as non-`null`.
-   * @param {string} [body] Body content.
+   * @param {string|Buffer} [body] Body content.
    * @returns {boolean} `true` when the response is completed.
    */
   notFound(type = null, body = null) {
+    const STATUS = 404;
+
     if (body) {
       MustBe.string(type);
-      MustBe.string(body);
+      if (!(body instanceof Buffer)) {
+        MustBe.string(body);
+      }
     } else {
       type = 'text/plain';
-      body = 'Not found:\n'
-        + `  ${this.urlString}\n`;
+      body =
+        `${STATUS} ${statuses(STATUS)}:\n` +
+        `  ${this.urlString}\n`;
     }
 
     const res = this.#expressResponse;
 
-    res.status(404);
+    res.status(STATUS);
     res.contentType(type);
     res.set('Cache-Control', 'no-store, must-revalidate');
     res.send(body);

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -264,6 +264,37 @@ export class Request {
   }
 
   /**
+   * Issues a "not found" (status `404`) response, with optional body. If no
+   * body is provided, a simple default plain-text body is used. The response
+   * includes the single content/cache-related header `Cache-Control: no-store,
+   * must-revalidate`.
+   *
+   * @param {string} [type] Content type for the body. Must be valid if `body`
+   *   is passed as non-`null`.
+   * @param {string} [body] Body content.
+   * @returns {boolean} `true` when the response is completed.
+   */
+  notFound(type = null, body = null) {
+    if (body) {
+      MustBe.string(type);
+      MustBe.string(body);
+    } else {
+      type = 'text/plain';
+      body = 'Not found:\n'
+        + `  ${this.urlString}\n`;
+    }
+
+    const res = this.#expressResponse;
+
+    res.status(404);
+    res.contentType(type);
+    res.set('Cache-Control', 'no-store, must-revalidate');
+    res.send(body);
+
+    return this.whenResponseDone();
+  }
+
+  /**
    * Issues a redirect response, with a standard response message and plain text
    * body. The response message depends on the status code.
    *
@@ -277,7 +308,7 @@ export class Request {
    *
    * @param {string} target Possibly-relative target URL.
    * @param {number} [status] Status code.
-   * @returns {boolean} `true` when the response is complete.
+   * @returns {boolean} `true` when the response is completed.
    */
   redirect(target, status = 302) {
     // Note: This method avoids using `express.Response.redirect()` (a) to avoid
@@ -322,11 +353,55 @@ export class Request {
    * as such no additional response-related methods will work.
    *
    * @param {number} [status] Status code.
-   * @returns {boolean} `true` when the response is complete.
+   * @returns {boolean} `true` when the response is completed.
    */
   redirectBack(status = 302) {
     const target = this.#expressRequest.header('referrer') ?? '/';
     return this.redirect(target, status);
+  }
+
+  /**
+   * Returns when the underlying response has been closed successfully or has
+   * errored. Returns `true` for a normal close, or throws whatever error the
+   * response reports.
+   *
+   * @returns {boolean} `true` when closed without error.
+   * @throws {Error} Any error reported by the underlying response object.
+   */
+  async whenResponseDone() {
+    const res = this.#expressResponse;
+
+    function makeProperError(error) {
+      return (error instanceof Error)
+        ? error
+        : new Error(`non-error object: ${error}`);
+    }
+
+    if (res.closed || res.destroyed) {
+      const error = res.errored;
+      if (error) {
+        throw makeProperError(error);
+      }
+      return true;
+    }
+
+    const resultMp = new ManualPromise();
+
+    res.once('error', (error) => {
+      if (error) {
+        resultMp.reject(makeProperError(error));
+      } else {
+        resultMp.resolve(true);
+      }
+    });
+
+    res.once('close', () => {
+      if (!resultMp.isSettled()) {
+        resultMp.resolve(true);
+      }
+    });
+
+    return resultMp;
   }
 
   /**

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -383,7 +383,7 @@ export class Request {
         : new Error(`non-error object: ${error}`);
     }
 
-    if (res.closed || res.destroyed) {
+    if (res.closed || res.destroyed || res.writableEnded) {
       const error = res.errored;
       if (error) {
         throw makeProperError(error);
@@ -407,7 +407,7 @@ export class Request {
       }
     });
 
-    return resultMp;
+    return resultMp.promise;
   }
 
   /**


### PR DESCRIPTION
This PR adds and tweaks stuff in `Request`, so as to make it reasonable for `StaticFiles` to call on it to produce a not-found (status `404`) response. This includes a bit more peeling back of the Express onion, with the addition of a `MimeTypes` class which uses the current version of the `mime` package (as opposed to Express 4, which is stuck multiple major versions in the past SMDH).