### PR TITLE
`Request` API for sending files, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and to enable straightforward custom applications.
 * Can run multiple network endpoints, each serving a different set of high-level
   applications.
 * Several built-in applications:
-  * Static file server (uses `Express.static`).
+  * Static file server (uses `express.response.sendFile()`).
   * Redirect server.
   * More to come! TODO!
 * Path-hierarchy specificity-based endpoint configuration, for endpoints that
@@ -55,7 +55,7 @@ and to enable straightforward custom applications.
   * Uses Node's standard library for low-level networking and protocol
     implementation (TCP, TLS, HTTP*).
   * Uses Express for protocol handling on top of what Node provides (but with a
-    bit of custom routing, see above).
+    different routing implementation; see above).
   * Only modest use of external module dependencies (via `npm`).
 * Built to be installed as a normal POSIX-ish service (though _without_ Node
   bundled into the installation).

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -239,6 +239,28 @@ const applications = [
 ];
 ```
 
+There are a few notable things which _aren't_ configurable for this application.
+These may be configurable in a future version, if there is sufficient and
+reasonable demand:
+
+* Caching:
+  * The `Last-Modified`, `ETag`, and `Cache-Control` response headers are sent.
+  * The `max-age` property of the `Cache-Control` response header is _not_
+    configurable.
+  * Conditional request headers are honored.
+* Ranges:
+  * The `Accept-Ranges` response header is sent.
+  * Range request headers are honored.
+* Directory responses:
+  * "Naked" directory paths (i.e. ones that do not end with a slash) are
+    redirected to the same path with a final slash appended.
+  * Directory paths are responded to with the contents of a file called
+    `index.html` in that directory.
+* The bodies of error and other non-content responses, other than `404`s, are
+  not configurable.
+* No files under the `siteDirectory` are filtered out and treated as not found.
+  Notably, dot files are served.
+
 ## Built-in Services
 
 **Note about file names:** Several of the services accept a file path as a

--- a/src/app-framework/export/BaseApplication.js
+++ b/src/app-framework/export/BaseApplication.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ApplicationConfig } from '@this/app-config';
-import { ManualPromise } from '@this/async';
 import { BaseLoggingEnvironment, IntfLogger } from '@this/loggy';
 import { DispatchInfo, IntfRequestHandler, Request } from '@this/network-protocol';
 import { Methods } from '@this/typey';
@@ -93,73 +92,5 @@ export class BaseApplication extends BaseComponent {
   /** @override */
   static get CONFIG_CLASS() {
     return ApplicationConfig;
-  }
-
-  /**
-   * Calls through to a regular Express-style middleware function, converting
-   * its `next()` usage to the `async` style used by this system. Because
-   * Express doesn't offer a straightforward way to tell when a request has
-   * definitely been handled, this method uses a couple different tactics to try
-   * to suss it out, but it _might_ end up being flaky in some cases. (No actual
-   * flakiness has been observed as of this writing, but it's definitely
-   * something to watch out for).
-   *
-   * This method is meant as a helper when wrapping Express middleware in a
-   * concrete instance of this class.
-   *
-   * @param {Request} request Request object.
-   * @param {DispatchInfo} dispatch Dispatch information.
-   * @param {function(object, object, function(?string|object))} middleware
-   *   Express-style middleware function.
-   * @returns {boolean} Was the request handled? This is the result request
-   *   handling as defined by {@link IntfRequestHandler#handleRequest}.
-   */
-  static async callMiddleware(request, dispatch, middleware) {
-    const { expressRequest: req, expressResponse: res } = request;
-    const resultMp = new ManualPromise();
-    const origEnd  = res.end;
-
-    // "Spy" on `res.end`, so we can async-return when appropriate.
-    res.end = (...args) => {
-      res.end = origEnd;
-      res.end(...args);
-
-      req.baseUrl = baseUrl;
-      req.url     = url;
-
-      if (!resultMp.isSettled()) {
-        resultMp.resolve(true);
-      }
-    };
-
-    // Hook up a `next()` which cleans up the "spy" on `res` and causes this
-    // method to return.
-    const next = (arg = null) => {
-      res.end = origEnd;
-      if ((arg === null) || (arg === 'route')) {
-        resultMp.resolve(false);
-      } else if (arg instanceof Error) {
-        resultMp.reject(arg);
-      } else {
-        resultMp.reject(new Error(`Strange value passed to \`next()\`: ${arg}`));
-      }
-    };
-
-    // Modify the request, to insert the dispatch information (this system
-    // normally doesn't mess with incoming request objects), but Express
-    // middleware _does_ expect dispatch-related bits to be set), and then
-    // restore it on the way back out.
-    const { baseUrl, url } = req;
-
-    req.baseUrl = dispatch.baseString;
-    req.url     = dispatch.extraString;
-
-    try {
-      middleware(req, res, next);
-    } catch (e) {
-      resultMp.reject(e);
-    }
-
-    return resultMp.promise;
   }
 }

--- a/src/app-framework/export/NetworkEndpoint.js
+++ b/src/app-framework/export/NetworkEndpoint.js
@@ -120,8 +120,12 @@ export class NetworkEndpoint extends BaseComponent {
         extra:       dispatch.extraString
       });
 
-      if (await application.handleRequest(request, dispatch)) {
-        return true;
+      try {
+        if (await application.handleRequest(request, dispatch)) {
+          return true;
+        }
+      } catch (e) {
+        request.logger?.applicationError(e);
       }
     }
 

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -73,13 +73,6 @@ export class StaticFiles extends BaseApplication {
       const redirectTo = resolved.redirect;
       return request.redirect(redirectTo, 301);
     } else if (resolved.path) {
-      // TODO: In the short term, use Express's `res.sendFile()`, or use NPM
-      // package `send` directly. In the long term, do what those things do (in
-      // all cases it bottoms out at the `send` package) but even more directly.
-      // Notably, it handles all of: content type calculation, HEAD requests,
-      // conditional requests, ranges, and etags. For some of those, it will
-      // probably be fine to just peel back the onion a bit and use what `send`
-      // uses, much of which is more stuff from Express / PillarJS.
       const result =
         await request.sendFile(resolved.path, StaticFiles.#SEND_OPTIONS);
 

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -3,8 +3,6 @@
 
 import fs from 'node:fs/promises';
 
-import express from 'express';
-
 import { ApplicationConfig, Files } from '@this/app-config';
 import { BaseApplication } from '@this/app-framework';
 import { FsUtil } from '@this/fs-util';
@@ -38,9 +36,6 @@ export class StaticFiles extends BaseApplication {
   /** @type {string} Absolute path to the base directory of files to serve. */
   #siteDirectory;
 
-  /** @type {function(...*)} "Middleware" handler function for this instance. */
-  #staticMiddleware;
-
   /** @type {?string} MIME type of the not-found file, if known. */
   #notFoundType = null;
 
@@ -58,10 +53,8 @@ export class StaticFiles extends BaseApplication {
 
     const { notFoundPath, siteDirectory } = config;
 
-    this.#notFoundPath     = notFoundPath;
-    this.#siteDirectory    = siteDirectory;
-    this.#staticMiddleware =
-      express.static(siteDirectory, StaticFiles.#SEND_OPTIONS);
+    this.#notFoundPath  = notFoundPath;
+    this.#siteDirectory = siteDirectory;
   }
 
   /** @override */
@@ -88,7 +81,7 @@ export class StaticFiles extends BaseApplication {
       // probably be fine to just peel back the onion a bit and use what `send`
       // uses, much of which is more stuff from Express / PillarJS.
       const result =
-        await BaseApplication.callMiddleware(request, dispatch, this.#staticMiddleware);
+        await request.sendFile(resolved.path, StaticFiles.#SEND_OPTIONS);
 
       return result;
     } else {
@@ -185,6 +178,16 @@ export class StaticFiles extends BaseApplication {
             ? dispatch.base.path
             : parts;
           return { redirect: `${source[source.length - 1]}/` };
+        } else {
+          // It's a proper directory reference. Look for the index file.
+          const indexPath  = `${fullPath}/index.html`;
+          const indexStats = await fs.stat(indexPath);
+          if (indexStats.isDirectory()) {
+            // Weird case, to be clear!
+            this.logger?.indexIsDirectory(indexPath);
+            return null;
+          }
+          return { path: indexPath, stats: indexStats };
         }
       } else if (endSlash) {
         // Non-directory with a slash. Not accepted per class contract.
@@ -208,7 +211,7 @@ export class StaticFiles extends BaseApplication {
 
   /** @type {object} File sending/serving configuration options. */
   static #SEND_OPTIONS = Object.freeze({
-    maxAge: 5 * 60 * 1000 // 5 minutes.
+    maxAgeMsec: 5 * 60 * 1000 // 5 minutes.
   });
 
   /** @override */

--- a/src/network-protocol/export/ExpressLegacy.js
+++ b/src/network-protocol/export/ExpressLegacy.js
@@ -1,0 +1,87 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { ManualPromise } from '@this/async';
+
+import { DispatchInfo } from '#x/DispatchInfo';
+import { IntfRequestHandler } from '#x/IntfRequestHandler';
+import { Request } from '#x/Request';
+
+
+/**
+ * Utilities for working with Express middleware. This class is meant to work
+ * correctly, though it is not particularly aimed at efficiency.
+ */
+export class ExpressLegacy {
+  /**
+   * Calls through to a regular Express-style middleware function, converting
+   * its `next()` usage to the `async` style used by this system. Because
+   * Express doesn't offer a straightforward way to tell when a request has
+   * definitely been handled, this method uses a couple different tactics to try
+   * to suss it out, but it _might_ end up being flaky in some cases. (No actual
+   * flakiness has been observed as of this writing, but it's definitely
+   * something to watch out for).
+   *
+   * This method is meant as a helper when wrapping Express middleware in a
+   * concrete instance of this class.
+   *
+   * @param {Request} request Request object.
+   * @param {DispatchInfo} dispatch Dispatch information.
+   * @param {function(object, object, function(?string|object))} middleware
+   *   Express-style middleware function.
+   * @returns {boolean} Was the request handled? This is the result request
+   *   handling as defined by {@link IntfRequestHandler#handleRequest}.
+   */
+  static async callMiddleware(request, dispatch, middleware) {
+    const { expressRequest: req, expressResponse: res } = request;
+    const resultMp = new ManualPromise();
+    const origEnd  = res.end;
+
+    // "Spy" on `res.end`, so we can async-return when appropriate.
+    res.end = (...args) => {
+      res.end = origEnd;
+      res.end(...args);
+
+      req.baseUrl = baseUrl;
+      req.url     = url;
+
+      if (!resultMp.isSettled()) {
+        resultMp.resolve(true);
+      }
+    };
+
+    // Hook up a `next()` which cleans up the "spy" on `res` and causes this
+    // method to return.
+    const next = (arg = null) => {
+      res.end = origEnd;
+      if ((arg === null) || (arg === 'route')) {
+        resultMp.resolve(false);
+      } else if (arg instanceof Error) {
+        resultMp.reject(arg);
+      } else {
+        resultMp.reject(new Error(`Strange value passed to \`next()\`: ${arg}`));
+      }
+    };
+
+    // Modify the request, to insert the dispatch information (this system
+    // normally doesn't mess with incoming request objects), but Express
+    // middleware _does_ expect dispatch-related bits to be set), and then
+    // restore it on the way back out.
+    const { baseUrl, url } = req;
+
+    req.baseUrl = dispatch.baseString;
+    req.url     = dispatch.extraString;
+
+    try {
+      middleware(req, res, next);
+    } catch (e) {
+      resultMp.reject(e);
+    }
+
+    await resultMp.promise;
+
+    // Only return when the response actually gets completed from the
+    // perspective of the original `request`.
+    return request.whenResponseDone();
+  }
+}

--- a/src/network-protocol/export/ExpressLegacy.js
+++ b/src/network-protocol/export/ExpressLegacy.js
@@ -78,10 +78,14 @@ export class ExpressLegacy {
       resultMp.reject(e);
     }
 
-    await resultMp.promise;
+    const result = await resultMp.promise;
 
-    // Only return when the response actually gets completed from the
-    // perspective of the original `request`.
-    return request.whenResponseDone();
+    if (result) {
+      // Only return when the response actually gets completed from the
+      // perspective of the original `request`.
+      await request.whenResponseDone();
+    }
+
+    return result;
   }
 }

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -392,6 +392,17 @@ export class Request {
       maxAge:   maxAgeMsec
     };
 
+    // TODO: Stop using Express's `response.sendFile()`, as part of the
+    // long-term aim to stop using Express at all. In the short term, switch
+    // to the `send` package (which is what Express bottoms out at here). In the
+    // long term, do what `send` does, but even more directly (among other
+    // reasons, so we can use our style of logging in it and so we don't have to
+    // translate between callback and promise call styles). Things that we'll
+    // have to deal with include _at least_: HEAD requests, conditional
+    // requests, ranges, etags, and maybe more. For some of those, it will
+    // probably be fine to just use the same packages `send` does, much of which
+    // is more stuff from Express / PillarJS.
+
     const doneMp = new ManualPromise();
     res.sendFile(path, sendOpts, (err) => {
       if (err instanceof Error) {

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -307,33 +307,11 @@ export class Request {
     // towards dropping Express entirely as a dependency.
 
     MustBe.string(target);
-    MustBe.number(status,
-      { safeInteger: true, minInclusive: 100, maxInclusive: 599 });
 
-    const res = this.#expressResponse;
-    const message =
-      `${status} ${statuses(status)}\n` +
-      'Redirecting to:\n' +
-      `  ${target}\n`;
-
-    res.status(status);
-    res.set('Location', target);
-    res.contentType('text/plain');
-    res.send(message);
-
-    const resultMp = new ManualPromise();
-    res.once('error', (e) => {
-      if (!resultMp.isSettled()) {
-        resultMp.reject(e);
-      }
+    return this.#sendNonContentResponse(status, {
+      bodyExtra: `  ${target}\n`,
+      headers:   { 'Location': target }
     });
-    res.once('finish', () => {
-      if (!resultMp.isSettled()) {
-        resultMp.resolve(true);
-      }
-    });
-
-    return resultMp.promise;
   }
 
   /**

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -529,7 +529,7 @@ export class Request {
    *   `options.bodyExtra`.
    * @param {?string} [options.bodyExtra] Text to append to a constructed body.
    *   Only used if `options.body` is not passed.
-   * @param {?object} [headers] Extra response headers to send, if any.
+   * @param {?object} [options.headers] Extra response headers to send, if any.
    * @returns {boolean} `true` when the response is completed.
    */
   #sendNonContentResponse(status, options = null) {

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -540,8 +540,16 @@ export class Request {
       finalBody        = body;
       finalContentType = MimeTypes.typeFromExtensionOrType(contentType);
     } else {
-      const bodyHeader = `${status} ${statuses(status)}:\n`;
-      finalBody        = `${bodyHeader}${bodyExtra ?? ''}`;
+      const statusStr  = statuses(status);
+      const bodyHeader = `${status} ${statusStr}`;
+
+      if (((bodyExtra ?? '') === '') || (bodyExtra === statusStr)) {
+        finalBody = `${bodyHeader}\n`;
+      } else {
+        const finalNl = (bodyExtra.endsWith('\n')) ? '' : '\n';
+        finalBody = `${bodyHeader}:\n${bodyExtra}${finalNl}`;
+      }
+
       finalContentType = 'text/plain';
     }
 

--- a/src/network-protocol/index.js
+++ b/src/network-protocol/index.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '#x/DispatchInfo';
+export * from '#x/ExpressLegacy';
 export * from '#x/IntfHostManager';
 export * from '#x/IntfRateLimiter';
 export * from '#x/IntfRequestHandler';


### PR DESCRIPTION
The main thing this PR achieves is getting our `Request` to be able to respond with file content in a way that matches the rest of our system (as opposed to getting whatever the underlying Express implementations happened to do). Much of this has to do with how we issue non-content responses (e.g. 404s, redirects, etc.). With the `Request` stuff in place, it became possible for `StaticFiles` to start using that instead of using `express.static()` and having to use the "legacy" middleware adapter.

That said, our `Response.sendFile()` still uses Express's `response.sendFile()` under the covers. Ultimately, the goal is to replace that too, with something that is structured more like the rest of this system, mostly for ease of understanding (i.e. mixing callbacks and promises can be confusing) but also arguably for efficiency (not that efficiency is a major goal at the moment).