### PR TITLE
`HostInfo`

### DIFF
--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -122,7 +122,7 @@ const applications = [
     name:       'myWackyRedirector',
     class:      'Redirector',
     statusCode: 308,
-    target:     'https://milk.com/boop/'
+    target:     'https://localhost:8443/resp/'
   },
   {
     name:          'myStaticFun',

--- a/src/app-framework/export/NetworkEndpoint.js
+++ b/src/app-framework/export/NetworkEndpoint.js
@@ -99,10 +99,10 @@ export class NetworkEndpoint extends BaseComponent {
    */
   async handleRequest(request, dispatch_unused) {
     // Find the mount map for the most-specific matching host.
-    const hostMatch = this.#mountMap.find(request.hostname);
+    const hostMatch = this.#mountMap.find(request.host.nameKey);
     if (!hostMatch) {
       // No matching host.
-      request.logger?.hostNotFound(request.hostname);
+      request.logger?.hostNotFound(request.host.nameString);
       return false;
     }
 

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -39,7 +39,7 @@ export class HostInfo {
    *   se or a string.
    */
   constructor(nameString, portNumber) {
-    this.#nameString = MustBe.string(nameString);
+    this.#nameString = MustBe.string(nameString, /./);
     this.#portNumber = AskIf.string(portNumber)
       ? Number(MustBe.string(portNumber, /^[0-9]+$/))
       : MustBe.number(portNumber);

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -1,0 +1,186 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { TreePathKey } from '@this/collections';
+import { AskIf, MustBe } from '@this/typey';
+
+
+/**
+ * Information about a network host, including port number, along with parsing
+ * facilities for same.
+ */
+export class HostInfo {
+  /** @type {string} The (fully qualified) name string. */
+  #nameString;
+
+  /** @type {number} The port number. */
+  #portNumber;
+
+  /** @type {?string} The string form of {@link #portNumber}, if calculated. */
+  #portString = null;
+
+  /**
+   * @type {?boolean} Is the hostname actually an IP address? `null` if not yet
+   * calculated.
+   */
+  #nameIsIp = null;
+
+  /** @type {?TreePathKey} A path key representing {@link #nameString}. */
+  #nameKey = null;
+
+  /**
+   * Constructs an instance.
+   *
+   * **Note:** You are probably better off constructing an instance using one
+   * of the static methods on this class.
+   *
+   * @param {string} nameString The name string.
+   * @param {string|number} portNumber The port number, as either a number per
+   *   se or a string.
+   */
+  constructor(nameString, portNumber) {
+    this.#nameString = MustBe.string(nameString);
+    this.#portNumber = AskIf.string(portNumber)
+      ? Number(MustBe.string(portNumber, /^[0-9]+$/))
+      : MustBe.number(portNumber);
+
+    MustBe.number(this.#portNumber, {
+      safeInteger:  true,
+      minInclusive: 0,
+      maxInclusive: 65535
+    })
+  }
+
+  /**
+   * @returns {TreePathKey} A path key representing the {@link #nameString},
+   * parsed into components. The order of components is back-to-front (reverse
+   * order from how it's written). If the hostname is actually a numeric IP
+   * address, then the key just has that address as a single-component.
+   */
+  get nameKey() {
+    if (!this.#nameKey) {
+      const parts = this.nameIsIpAddress()
+        ? [this.#nameString]
+        : this.#nameString.split('.').reverse();
+
+      // Freezing `parts` lets `new TreePathKey()` avoid making a copy.
+      this.#nameKey = new TreePathKey(Object.freeze(parts), false);
+    }
+
+    return this.#nameKey;
+  }
+
+  /** @returns {string} The (fully qualified) name string. */
+  get nameString() {
+    return this.#nameString;
+  }
+
+  /** @returns {number} The port number. */
+  get portNumber() {
+    return this.#portNumber;
+  }
+
+  /** @returns {string} The port number, as a string. */
+  get portString() {
+    if (this.#portString === null) {
+      this.#portString = this.#portNumber.toString();
+    }
+
+    return this.#portString;
+  }
+
+  /**
+   * Indicates whether the hostname is actually a numeric IP address.
+   *
+   * @returns {boolean} `true` iff the hostname is an IP address.
+   */
+  nameIsIpAddress() {
+    if (this.#nameIsIp === null) {
+      this.#nameIsIp = /^(\[[:0-9a-fA-F]+\]|[.0-9]+)$/.test(this.#nameString);
+    }
+
+    return this.#nameIsIp;
+  }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * Gets an instance of this class representing `localhost` with the given
+   * protocol.
+   *
+   * @param {string} protocol The network protocol used.
+   * @returns {HostInfo} The constructed instance.
+   */
+  static localhostInstance(protocol) {
+    return this.parseHostHeader('localhost', protocol);
+  }
+
+  /**
+   * Constructs an instance of this class by parsing a string in the format
+   * used by the `Host` header of an HTTP(ish) request. The incoming protocol
+   * is also required, so as to be able to figure out the port number if not
+   * included in the string.
+   *
+   * @param {string} hostString The `Host` header string to parse.
+   * @param {string} protocol The network protocol used.
+   * @returns {HostInfo} The parsed info.
+   * @throws {Error} Thrown if there was parsing trouble.
+   */
+  static parseHostHeader(hostString, protocol) {
+    MustBe.string(hostString);
+    MustBe.string(protocol);
+
+    // After ensuring it contains no ats or slashes (which are definitely not
+    // allowed by the URI syntax as part of the hostname per se, and would
+    // confuse / mess up our parsing attempt), just let `new URL()` parse the
+    // header; it's _probably_ not going to turn out to be an efficiency
+    // problem, and it handles a bunch of edge cases too.
+
+    if (/[/@]/.test(hostString)) {
+      throw this.#parsingError(hostString);
+    }
+
+    const { hostname, port } = new URL(`x://${hostString}`);
+    if (port === '') {
+      return new HostInfo(hostname, (protocol === 'http') ? 80 : 443);
+    } else {
+      return new HostInfo(hostname, parseInt(port));
+    }
+  }
+
+  /**
+   * Like {@link #parseHostHeader}, except treats erroneous input as if
+   * `localhost` were specified. This method is meant to help implementations
+   * provide reasonable responses in the face of bad input (instead of, e.g.,
+   * just crashing).
+   *
+   * @param {string} hostString The `Host` header string to parse.
+   * @param {string} protocol The network protocol used.
+   * @returns {HostInfo} The parsed info.
+   */
+  static safeParseHostHeader(hostString, protocol) {
+    try {
+      return this.parseHostHeader(hostString, protocol);
+    } catch (e) {
+      return this.localhostInstance(protocol);
+    }
+  }
+
+  /**
+   * Constructs a standard-form parsing error.
+   *
+   * @param {string} input The input.
+   * @returns {Error} The error.
+   */
+  static #parsingError(input) {
+    const error = new TypeError('Invalid URL');
+
+    error.code  = 'ERR_INVALID_URL';
+    error.input = input;
+
+    return error;
+  }
+}

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -162,6 +162,9 @@ export class HostInfo {
    * @returns {HostInfo} The parsed info.
    */
   static safeParseHostHeader(hostString, protocol) {
+    MustBe.string(hostString);
+    MustBe.string(protocol);
+
     try {
       return this.parseHostHeader(hostString, protocol);
     } catch (e) {

--- a/src/net-util/export/Uris.js
+++ b/src/net-util/export/Uris.js
@@ -184,6 +184,35 @@ export class Uris {
   }
 
   /**
+   * Like {@link #checkHostname}, except it returns `null` to indicate a parsing
+   * error.
+   *
+   * @param {string} name Hostname to parse.
+   * @param {boolean} [allowWildcard] Is a wildcard form allowed for
+   *   `name`?
+   * @returns {?string} `value` if it is a string which matches the stated
+   *   pattern, canonicalized if it is an IP address. Returns `null` to indicate
+   *   a parsing error.
+   */
+  static checkHostnameOrNull(name, allowWildcard = false) {
+    // Handle IP address cases.
+    const canonicalIp = this.checkIpAddressOrNull(name, false);
+    if (canonicalIp) {
+      return canonicalIp;
+    }
+
+    if (!AskIf.string(name, this.#HOSTNAME_PATTERN)) {
+      return null;
+    }
+
+    if ((!allowWildcard) && /[*]/.test(name)) {
+      return null;
+    }
+
+    return name;
+  }
+
+  /**
    * Checks that a given value is a string which can be used as a network
    * interface address, and returns a somewhat-canonicalized form. This allows:
    *

--- a/src/net-util/index.js
+++ b/src/net-util/index.js
@@ -1,5 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+export * from '#x/HostInfo';
 export * from '#x/MimeTypes';
 export * from '#x/Uris';

--- a/src/net-util/tests/HostInfo.test.js
+++ b/src/net-util/tests/HostInfo.test.js
@@ -1,0 +1,51 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { TreePathKey } from '@this/collections';
+import { HostInfo } from '@this/net-util';
+
+
+describe('constructor', () => {
+  // Failure cases for name argument.
+  test.each`
+  arg
+  ${undefined}
+  ${null}
+  ${false}
+  ${1}
+  ${['x']}
+  `('fails when passing name as $arg', ({ arg }) => {
+    expect(() => new HostInfo(arg, 123)).toThrow();
+  });
+
+  // Failure cases for port argument.
+  test.each`
+  arg
+  ${undefined}
+  ${null}
+  ${false}
+  ${''}
+  ${'x'}
+  ${'!'}
+  ${['x']}
+  ${-1}
+  ${0.5}
+  ${65535.9}
+  ${65536}
+  `('fails when passing port as $arg', ({ arg }) => {
+    expect(() => new HostInfo('host', arg)).toThrow();
+  });
+
+  test('accepts a valid port number string', () => {
+    expect(() => new HostInfo('host', '123')).not.toThrow();
+  });
+});
+
+// TODO: nameKey
+// TODO: nameString
+// TODO: portNumber
+// TODO: portString
+// TODO: nameIsIpAddress
+// TODO: localhostInstance
+// TODO: parseHostHeader
+// TODO: safeParseHostHeader

--- a/src/net-util/tests/HostInfo.test.js
+++ b/src/net-util/tests/HostInfo.test.js
@@ -14,6 +14,7 @@ describe('constructor', () => {
   ${false}
   ${1}
   ${['x']}
+  ${''}
   `('fails when passing name as $arg', ({ arg }) => {
     expect(() => new HostInfo(arg, 123)).toThrow();
   });
@@ -42,9 +43,48 @@ describe('constructor', () => {
 });
 
 // TODO: nameKey
-// TODO: nameString
-// TODO: portNumber
-// TODO: portString
+
+describe('nameString', () => {
+  test('gets the name that was passed in the constructor', () => {
+    const name = 'floop.florp';
+    const hi   = new HostInfo(name, 123);
+
+    expect(hi.nameString).toBe(name);
+  });
+});
+
+describe('portNumber', () => {
+  test('gets the port number-per-se that was passed in the constructor', () => {
+    const port = 5432;
+    const hi   = new HostInfo('host', port);
+
+    expect(hi.portNumber).toBe(port);
+  });
+
+  test('gets the parsed port number-as-string that was passed in the constructor', () => {
+    const port = 7771;
+    const hi   = new HostInfo('host', port.toString());
+
+    expect(hi.portNumber).toBe(port);
+  });
+});
+
+describe('portString', () => {
+  test('gets the string form of the port number-per-se that was passed in the constructor', () => {
+    const port = 99;
+    const hi   = new HostInfo('host', port);
+
+    expect(hi.portString).toBe(port.toString());
+  });
+
+  test('gets the port number-as-string that was passed in the constructor', () => {
+    const port = '8001';
+    const hi   = new HostInfo('host', port);
+
+    expect(hi.portString).toBe(port);
+  });
+});
+
 // TODO: nameIsIpAddress
 // TODO: localhostInstance
 // TODO: parseHostHeader

--- a/src/net-util/tests/HostInfo.test.js
+++ b/src/net-util/tests/HostInfo.test.js
@@ -44,7 +44,7 @@ describe('constructor', () => {
 
 // TODO: nameKey
 
-describe('nameString', () => {
+describe('.nameString', () => {
   test('gets the name that was passed in the constructor', () => {
     const name = 'floop.florp';
     const hi   = new HostInfo(name, 123);
@@ -53,7 +53,7 @@ describe('nameString', () => {
   });
 });
 
-describe('portNumber', () => {
+describe('.portNumber', () => {
   test('gets the port number-per-se that was passed in the constructor', () => {
     const port = 5432;
     const hi   = new HostInfo('host', port);
@@ -69,7 +69,7 @@ describe('portNumber', () => {
   });
 });
 
-describe('portString', () => {
+describe('.portString', () => {
   test('gets the string form of the port number-per-se that was passed in the constructor', () => {
     const port = 99;
     const hi   = new HostInfo('host', port);
@@ -85,7 +85,51 @@ describe('portString', () => {
   });
 });
 
-// TODO: nameIsIpAddress
-// TODO: localhostInstance
+describe('nameIsIpAddress()', () => {
+  test('returns `true` given an IPv4 address for the name', () => {
+    const hi = new HostInfo('1.2.3.4', 123);
+    expect(hi.nameIsIpAddress()).toBeTrue();
+  });
+
+  test('returns `true` given an IPv6 address for the name', () => {
+    const hi = new HostInfo('[1234:abcd::ef]', 123);
+    expect(hi.nameIsIpAddress()).toBeTrue();
+  });
+
+  // Various `false` cases.
+  test.each`
+  arg
+  ${'a'}
+  ${'floop'}
+  ${'x.y'}
+  ${'12.x'}
+  ${'x.12'}
+  ${'x.12.y'}
+  `('returns `false` given the name $arg', ({ arg }) => {
+    const hi = new HostInfo(arg, 123);
+    expect(hi.nameIsIpAddress()).toBeFalse();
+  });
+});
+
+describe('localhostInstance()', () => {
+  describe.each`
+  protocol   | port
+  ${'http'}  | ${80}
+  ${'https'} | ${443}
+  ${'http2'} | ${443}
+  `('for protocol $protocol (port $port)', ({ protocol, port }) => {
+    test('constructs an instance with name `localhost`', () => {
+      const hi = HostInfo.localhostInstance(protocol);
+      expect(hi.nameString).toBe('localhost');
+    });
+
+    test('constructs an instance with the expected port', () => {
+      const hi = HostInfo.localhostInstance(protocol);
+      expect(hi.portNumber).toBe(port);
+      expect(hi.portString).toBe(port.toString());
+    });
+  });
+});
+
 // TODO: parseHostHeader
 // TODO: safeParseHostHeader

--- a/src/net-util/tests/Uris.test.js
+++ b/src/net-util/tests/Uris.test.js
@@ -406,6 +406,7 @@ describe('checkProtocol()', () => {
 describe.each`
 method                   | throws   | returns
 ${'checkHostname'}       | ${true}  | ${'string'}
+${'checkHostnameOrNull'} | ${false} | ${'string'}
 ${'parseHostname'}       | ${true}  | ${'path'}
 ${'parseHostnameOrNull'} | ${false} | ${'path'}
 `('$method()', ({ method, throws, returns }) => {
@@ -447,12 +448,9 @@ ${'parseHostnameOrNull'} | ${false} | ${'path'}
     if (throws) {
       expect(() => Uris[method](hostname, false)).toThrow();
       expect(() => Uris[method](hostname, true)).toThrow();
-    } else if (returns === 'path') {
+    } else {
       expect(Uris[method](hostname, false)).toBeNull();
       expect(Uris[method](hostname, true)).toBeNull();
-    } else {
-      // No such methods are defined.
-      throw new Error('Shouldn\'t happen');
     }
   });
 

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -142,19 +142,6 @@ export class Request {
   }
 
   /**
-   * @returns {TreePathKey} Parsed path key representing the hostname, in most-
-   * to least-specific order (that is, back to front). If the original hostname
-   * looks like an IP address, this just returns a single-element key with the
-   * canonicalized IP address string as the sole element.
-   *
-   * **Note:** This corresponds to the `subdomains` value defined by
-   * `express.Request`.
-   */
-  get hostname() {
-    return this.host.nameKey;
-  }
-
-  /**
    * @returns {?string} The unique-ish request ID, or `null` if there is none
    * (which will happen if there is no associated logger).
    */

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -14,7 +14,7 @@ import { ManualPromise } from '@this/async';
 import { TreePathKey } from '@this/collections';
 import { IntfLogger } from '@this/loggy';
 import { MimeTypes } from '@this/net-util';
-import { Uris } from '@this/net-util';
+import { HostInfo, Uris } from '@this/net-util';
 import { AskIf, MustBe } from '@this/typey';
 
 import { RequestLogHelper } from '#p/RequestLogHelper';
@@ -31,6 +31,14 @@ import { RequestLogHelper } from '#p/RequestLogHelper';
  * time, this will be less and less necessary, and eventually the wrapped
  * objects will be able to be fully hidden from the interface presented by this
  * class.
+ *
+ * **Note:** This class does not implement any understanding of reverse proxy
+ * headers. It is up to constructors of this class to pass appropriate
+ * constructor parameters to get this class to do the right thing when running
+ * behind a reverse proxy. That said, as of this writing there isn't anything
+ * that actually does that. See
+ * <https://github.com/danfuzz/lactoserv/issues/213>.
+ *
  */
 export class Request {
   /**
@@ -49,19 +57,10 @@ export class Request {
   #expressResponse;
 
   /**
-   * @type {?boolean} Is the hostname an IP address? Or `null` if not yet
-   * determined.
+   * @type {HostInfo} The host header(ish) info, or `null` if not yet figured
+   * out.
    */
-  #hostnameIsIp = null;
-
-  /**
-   * @type {?string} Canonicalized hostname string, or `null` if not yet
-   * calculated.
-   */
-  #hostnameStringCanonical = null;
-
-  /** @type {?TreePathKey} Parsed hostname, or `null` if not yet calculated. */
-  #parsedHostname = null;
+  #host = null;
 
   /**
    * @type {?URL} The parsed version of `.#expressRequest.url`, or `null` if not
@@ -118,6 +117,31 @@ export class Request {
   }
 
   /**
+   * @returns {HostInfo} Info about the `Host` header (or equivalent). If there
+   * is no header (etc.), it is treated as if it were specified as just
+   * `localhost`.
+   */
+  get host() {
+    if (!this.#host) {
+      const req = this.#expressRequest;
+
+      // Note: `authority` is used by HTTP2.
+      const { authority, protocol } = req;
+
+      if (authority) {
+        this.#host = HostInfo.safeParseHostHeader(authority, protocol);
+      } else {
+        const host = req.get('host');
+        this.#host = host
+          ? HostInfo.safeParseHostHeader(host, protocol)
+          : HostInfo.localhostInstance(protocol);
+      }
+    }
+
+    return this.#host;
+  }
+
+  /**
    * @returns {TreePathKey} Parsed path key representing the hostname, in most-
    * to least-specific order (that is, back to front). If the original hostname
    * looks like an IP address, this just returns a single-element key with the
@@ -127,54 +151,7 @@ export class Request {
    * `express.Request`.
    */
   get hostname() {
-    // Note: This doesn't actually use `subdomains` from `express.Request`, so
-    // as to make it easier to ultimately drop Express entirely as a dependency.
-    // Also, unlike Express, this canonicalizes IP addresses.
-    if (!this.#parsedHostname) {
-      const hostname = this.hostnameString;
-      let parts;
-
-      if (!hostname) {
-        parts = [];
-      } else if (this.#hostnameIsIp) {
-        parts = [hostname];
-      } else {
-        parts = hostname.split('.').reverse();
-      }
-
-      // Freezing `parts` lets `new TreePathKey()` avoid making a copy.
-      this.#parsedHostname = new TreePathKey(Object.freeze(parts), false);
-    }
-
-    return this.#parsedHostname;
-  }
-
-  /**
-   * @returns {?string} The hostname that was passed with the original request,
-   * canonicalized if it happened to be an IP address in non-canonical form,
-   * or `null` if there was no `Host` header (or similar).
-   */
-  get hostnameString() {
-    if (this.#hostnameIsIp === null) {
-      // Note: `expressRequest.hostname` is an Express-specific field. TODO:
-      // Replace this usage with our own implementation here, as part of the
-      // effort to drop the dependency on Express.
-
-      const hostname    = this.#expressRequest.hostname ?? null;
-      const canonicalIp = hostname
-        ? Uris.checkIpAddressOrNull(hostname)
-        : null;
-
-      if (canonicalIp) {
-        this.#hostnameIsIp            = true;
-        this.#hostnameStringCanonical = canonicalIp;
-      } else {
-        this.#hostnameIsIp            = false;
-        this.#hostnameStringCanonical = hostname;
-      }
-    }
-
-    return this.#hostnameStringCanonical;
+    return this.host.nameKey;
   }
 
   /**

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -14,7 +14,7 @@ import { ManualPromise } from '@this/async';
 import { TreePathKey } from '@this/collections';
 import { IntfLogger } from '@this/loggy';
 import { MimeTypes } from '@this/net-util';
-import { HostInfo, Uris } from '@this/net-util';
+import { HostInfo } from '@this/net-util';
 import { AskIf, MustBe } from '@this/typey';
 
 import { RequestLogHelper } from '#p/RequestLogHelper';


### PR DESCRIPTION
This PR has to do with the `Host` header and similar stuff. A new class `HostInfo` encapsulates a lot of the necessary logic, and corresponding bits got removed from `Request`. Though perhaps not a permanent state of affairs, this PR effectively removes from the system any notion of how to run behind a reverse proxy; specifically, we no longer deal with `X-Forwarded-Host` or similar (which we used to get for "free" from Express).
