### PR TITLE
Request logging rework

### DIFF
--- a/src/network-protocol/export/WranglerContext.js
+++ b/src/network-protocol/export/WranglerContext.js
@@ -6,7 +6,7 @@ import * as stream from 'node:stream';
 
 import { FormatUtils, IntfLogger } from '@this/loggy';
 
-import { RequestLogHelper } from '#p/RequestLogHelper';
+import { Request } from '#x/Request';
 
 
 /**
@@ -173,7 +173,7 @@ export class WranglerContext {
 
     if (logger) {
       ctx.#requestLogger = logger;
-      ctx.#requestId     = RequestLogHelper.idFromLogger(logger);
+      ctx.#requestId     = Request.idFromLogger(logger);
     }
 
     return ctx;


### PR DESCRIPTION
This PR reworks `RequestLogHelper` so that it takes our `Request` object instead of the underlying Express(ish) bits. It still uses `request.expressRequest` and `request.expressResponse`, but we're within spitting distance of being able to fix that.