### PR TITLE
More `Request` stuff, and some knock-on bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ Other notable changes:
   that are subject to alteration during dispatch. In Express, this is
   represented by mutating the request object, but we're an immutable-forward
   shop here.
-* _Mostly_ got rid of direct uses of Express's `Request` and `Response` classes,
-  other than within _our_ `Request`.
+* Got rid of direct uses of Express's `Request` and `Response` classes, other
+  than within _our_ `Request`. Most notably, the request logging code got a
+  major rewrite.
 * Reworked `StaticFiles` to use our `Request` instead of wrapping
   `express.static()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ Other notable changes:
   both the underlying request and response (and other related goodies). For now,
   the underlying Express bits are exposed to clients, but the intention is for
   them to get hidden and for this project's API to be sufficient.
-* Relatedly, introduced new class `DispatchInfo`, to hold the bits of a request
-  that are subject to alteration during dispatch. In Express, this is
-  represented by mutating the request object, but we're an immutable-forward
-  shop here.
+* Relatedly, introduced new class `DispatchInfo`, to hold information about a
+  request dispatch-in-progress (i.e., routing information, more or less). In
+  Express, the equivalent state is represented by mutating the request object,
+  but we're an immutable-forward shop here.
 * Got rid of direct uses of Express's `Request` and `Response` classes, other
   than within _our_ `Request`. Most notably, the request logging code got a
   major rewrite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Other notable changes:
 * Got rid of direct uses of Express's `Request` and `Response` classes, other
   than within _our_ `Request`. Most notably, the request logging code got a
   major rewrite.
+* Reworked _most_ of the code in our `Request` class that does
+  actually-Express-specific stuff, to instead do approximately what Express
+  does, or just not do it at all. Notably, we no longer try to deal with reverse
+  proxies; support will probably be added for them eventually (assuming demand).
 * Reworked `StaticFiles` to use our `Request` instead of wrapping
   `express.static()`.
 

--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -3,7 +3,7 @@
 
 import * as timers from 'node:timers/promises';
 
-import { IntfTimeSource } from '@this/metacomp';
+import { IntfTimeSource, StdTimeSource } from '@this/metacomp';
 import { Methods, MustBe } from '@this/typey';
 
 import { ManualPromise } from '#x/ManualPromise';
@@ -602,49 +602,6 @@ export class TokenBucket {
   // Static members
   //
 
-  /** @type {TokenBucket.StdTimeSource} Default time source. */
-  static #DEFAULT_TIME_SOURCE;
-
-  /**
-   * Standard implementation of {@link IntfTimeSource}, which uses "wall time"
-   * as provided by the JavaScript / Node implementation, and for which the ATU
-   * is actually a second (_not_ a msec).
-   */
-  static StdTimeSource = class StdTimeSource extends IntfTimeSource {
-    // Note: The default constructor is fine.
-
-    /** @override */
-    get unitName() {
-      return 'seconds';
-    }
-
-    /** @override */
-    now() {
-      return Date.now() * StdTimeSource.#SECS_PER_MSEC;
-    }
-
-    /** @override */
-    async waitUntil(time) {
-      for (;;) {
-        const delay = time - this.now();
-        if ((delay <= 0) || !Number.isFinite(delay)) {
-          break;
-        }
-
-        const delayMsec = delay * StdTimeSource.#MSEC_PER_SEC;
-        await timers.setTimeout(delayMsec);
-      }
-    }
-
-    /** @type {number} The number of milliseconds in a second. */
-    static #MSEC_PER_SEC = 1000;
-
-    /** @type {number} The number of seconds in a millisecond. */
-    static #SECS_PER_MSEC = 1 / 1000;
-  };
-
-  static {
-    this.#DEFAULT_TIME_SOURCE = new TokenBucket.StdTimeSource();
-    Object.freeze(this);
-  }
+  /** @type {StdTimeSource} Default time source. */
+  static #DEFAULT_TIME_SOURCE = StdTimeSource.INSTANCE;
 }

--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -1,10 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
-
 import { IntfTimeSource, StdTimeSource } from '@this/metacomp';
-import { Methods, MustBe } from '@this/typey';
+import { MustBe } from '@this/typey';
 
 import { ManualPromise } from '#x/ManualPromise';
 import { Threadlet } from '#x/Threadlet';

--- a/src/async/package.json
+++ b/src/async/package.json
@@ -12,6 +12,7 @@
   },
 
   "dependencies": {
+    "@this/metacomp": "*",
     "@this/typey": "*"
   }
 }

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -4,7 +4,7 @@
 import * as timers from 'node:timers/promises';
 
 import { ManualPromise, PromiseState, TokenBucket } from '@this/async';
-import { IntfTimeSource } from '@this/metacomp';
+import { IntfTimeSource, StdTimeSource } from '@this/metacomp';
 
 
 /**
@@ -95,7 +95,7 @@ describe('constructor()', () => {
     ${{ flowRate: 1,      maxBurstSize: 1,     partialTokens: false }}
     ${{ flowRate: 12.3,   maxBurstSize: 123.4, partialTokens: false }}
     ${{ flowRate: 1,      maxBurstSize: 1,     partialTokens: true }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     timeSource: new TokenBucket.StdTimeSource() }}
+    ${{ flowRate: 1,      maxBurstSize: 1,     timeSource: new StdTimeSource() }}
     ${{ flowRate: 1,      maxBurstSize: 1,     timeSource: new MockTimeSource() }}
     ${{ flowRate: 1, maxBurstSize: 1, initialBurstSize: 0.5, maxQueueGrantSize: 0.5,
         maxQueueSize: 10, partialTokens: true, timeSource: new MockTimeSource() }}

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -4,12 +4,13 @@
 import * as timers from 'node:timers/promises';
 
 import { ManualPromise, PromiseState, TokenBucket } from '@this/async';
+import { IntfTimeSource } from '@this/metacomp';
 
 
 /**
- * Mock implementation of `BaseTimeSource`.
+ * Mock implementation of `IntfTimeSource`.
  */
-class MockTimeSource extends TokenBucket.BaseTimeSource {
+class MockTimeSource extends IntfTimeSource {
   #now      = 0;
   #timeouts = [];
   #ended    = false;
@@ -323,7 +324,7 @@ describe('constructor(<invalid>)', () => {
     ${null}
     ${[1, 2, 3]}
     ${new Map()}
-    ${TokenBucket.BaseTimeSource /* supposed to be an instance, not a class */}
+    ${IntfTimeSource /* supposed to be an instance, not a class */}
     ${MockTimeSource /* ditto */}
   `('rejects invalid `timeSource`: $timeSource', ({ timeSource }) => {
     expect(() => new TokenBucket({ flowRate: 1, maxBurstSize: 1, timeSource })).toThrow();

--- a/src/builtin-applications/package.json
+++ b/src/builtin-applications/package.json
@@ -14,10 +14,10 @@
   "dependencies": {
     "@this/app-config": "*",
     "@this/app-framework": "*",
-    "@this/collections": "*",
     "@this/fs-util": "*",
     "@this/loggy": "*",
     "@this/net-util": "*",
+    "@this/network-protocol": "*",
     "@this/typey": "*",
     "express": "^4.18.2"
   }

--- a/src/builtin-services/export/RequestLogger.js
+++ b/src/builtin-services/export/RequestLogger.js
@@ -44,7 +44,7 @@ export class RequestLogger extends BaseService {
   }
 
   /** @override */
-  async now() {
+  now() {
     return Moment.fromMsec(Date.now());
   }
 

--- a/src/builtin-services/export/RequestLogger.js
+++ b/src/builtin-services/export/RequestLogger.js
@@ -6,6 +6,7 @@ import * as fs from 'node:fs/promises';
 import { FileServiceConfig } from '@this/app-config';
 import { BaseService } from '@this/app-framework';
 import { Rotator } from '@this/app-util';
+import { Moment } from '@this/data-values';
 import { IntfLogger } from '@this/loggy';
 import { IntfRequestLogger } from '@this/network-protocol';
 
@@ -40,6 +41,11 @@ export class RequestLogger extends BaseService {
   /** @override */
   async logCompletedRequest(line) {
     await fs.appendFile(this.config.path, `${line}\n`);
+  }
+
+  /** @override */
+  async now() {
+    return Moment.fromMsec(Date.now());
   }
 
   /** @override */

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -15,6 +15,11 @@ import { Struct } from '#x/Struct';
  * other than a couple modest utilities it doesn't parse / deconstruct values.
  *
  * Instances of this class are always frozen.
+ *
+ * **Note:** This class intentionally does _not_ implement a `static` method to
+ * get the current wall time. There are many possible "sources of truth" for the
+ * time, and it is up to other code to use whatever source is appropriate in
+ * context.
  */
 export class Moment {
   /**

--- a/src/loggy/export/BaseLoggingEnvironment.js
+++ b/src/loggy/export/BaseLoggingEnvironment.js
@@ -116,7 +116,7 @@ export class BaseLoggingEnvironment {
   }
 
   /**
-   * Gets a moment representing "now.""
+   * Gets a moment representing "now."
    *
    * @returns {Moment} The moment "now."
    */

--- a/src/metacomp/export/IntfTimeSource.js
+++ b/src/metacomp/export/IntfTimeSource.js
@@ -1,0 +1,46 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { Methods } from '@this/typey';
+
+
+/**
+ * Interface for accessing a source of time information.
+ *
+ * @interface
+ */
+export class IntfTimeSource {
+  // Note: The default constructor is fine.
+
+  /** @returns {string} The name of the unit which this instance uses. */
+  get unitName() {
+    return Methods.abstract();
+  }
+
+  /**
+   * Gets the current time, in arbitrary time units (ATU) which have elapsed
+   * since an arbitrary base time.
+   *
+   * @abstract
+   * @returns {number} The current time.
+   */
+  now() {
+    return Methods.abstract();
+  }
+
+  /**
+   * Async-returns `null` when {@link #now} would return a value at or beyond
+   * the given time, with the hope that the actual time will be reasonably
+   * close.
+   *
+   * **Note:** Unlike `setTimeout()`, this method takes the actual time value,
+   * not a duration.
+   *
+   * @abstract
+   * @param {number} time The time after which this method is to async-return.
+   * @returns {null} `null`, always.
+   */
+  async waitUntil(time) {
+    return Methods.abstract(time);
+  }
+}

--- a/src/metacomp/export/StdTimeSource.js
+++ b/src/metacomp/export/StdTimeSource.js
@@ -5,6 +5,7 @@ import * as timers from 'node:timers/promises';
 
 import { IntfTimeSource } from '#x/IntfTimeSource';
 
+
 /**
  * Standard implementation of {@link #IntfTimeSource}, which uses "wall time"
  * as provided by the JavaScript / Node implementation, and for which the ATU

--- a/src/metacomp/export/StdTimeSource.js
+++ b/src/metacomp/export/StdTimeSource.js
@@ -1,0 +1,52 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import * as timers from 'node:timers/promises';
+
+import { IntfTimeSource } from '#x/IntfTimeSource';
+
+/**
+ * Standard implementation of {@link #IntfTimeSource}, which uses "wall time"
+ * as provided by the JavaScript / Node implementation, and for which the ATU
+ * is actually a second (_not_ a msec).
+ */
+export class StdTimeSource extends IntfTimeSource {
+  // Note: The default constructor is fine.
+
+  /** @override */
+  get unitName() {
+    return 'seconds';
+  }
+
+  /** @override */
+  now() {
+    return Date.now() * StdTimeSource.#SECS_PER_MSEC;
+  }
+
+  /** @override */
+  async waitUntil(time) {
+    for (;;) {
+      const delay = time - this.now();
+      if ((delay <= 0) || !Number.isFinite(delay)) {
+        break;
+      }
+
+      const delayMsec = delay * StdTimeSource.#MSEC_PER_SEC;
+      await timers.setTimeout(delayMsec);
+    }
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @type {number} The number of milliseconds in a second. */
+  static #MSEC_PER_SEC = 1000;
+
+  /** @type {number} The number of seconds in a millisecond. */
+  static #SECS_PER_MSEC = 1 / 1000;
+
+  /** @type {StdTimeSource} Standard instance of this class */
+  static INSTANCE = new StdTimeSource();
+}

--- a/src/metacomp/index.js
+++ b/src/metacomp/index.js
@@ -2,4 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '#x/BaseProxyHandler';
+export * from '#x/IntfTimeSource';
 export * from '#x/PropertyCacheProxyHandler';
+export * from '#x/StdTimeSource';

--- a/src/network-protocol/export/IntfRequestLogger.js
+++ b/src/network-protocol/export/IntfRequestLogger.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { Moment } from '@this/data-values';
 import { Methods } from '@this/typey';
 
 

--- a/src/network-protocol/export/IntfRequestLogger.js
+++ b/src/network-protocol/export/IntfRequestLogger.js
@@ -11,6 +11,15 @@ import { Methods } from '@this/typey';
  */
 export class IntfRequestLogger {
   /**
+   * Gets this instance's idea of what the current time is.
+   *
+   * @returns {Moment} The current time.
+   */
+  now() {
+    return Methods.abstract();
+  }
+
+  /**
    * Logs a completed request.
    *
    * @abstract

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -379,7 +379,7 @@ export class ProtocolWrangler {
     const reqLogger = request.logger;
     const context   = WranglerContext.getNonNull(req.socket, req.stream?.session);
 
-    const reqCtx = WranglerContext.forRequest(context, reqLogger);
+    const reqCtx = WranglerContext.forRequest(context, request);
     WranglerContext.bind(req, reqCtx);
 
     this.#logHelper?.logRequest(request, context);

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -375,9 +375,9 @@ export class ProtocolWrangler {
    *   to run.
    */
   async #handleExpressRequest(req, res, next) {
-    const request   = new Request(req, res, this.#requestLogger);
-    const reqLogger = request.logger;
     const context   = WranglerContext.getNonNull(req.socket, req.stream?.session);
+    const request   = new Request(context, req, res, this.#requestLogger);
+    const reqLogger = request.logger;
 
     const reqCtx = WranglerContext.forRequest(context, request);
     WranglerContext.bind(req, reqCtx);

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -124,6 +124,22 @@ export class Request {
   }
 
   /**
+   * @returns {object} Map of all incoming headers to their values, as defined
+   * by Node's `IncomingMessage.headers`.
+   */
+  get headers() {
+    return this.#expressRequest.headers;
+  }
+
+  /**
+   * @returns {object} Map of all incoming headers to their values, as defined
+   * by Node's `IncomingMessage.headersDistinct`.
+   */
+  get headersDistinct() {
+    return this.#expressRequest.headersDistinct;
+  }
+
+  /**
    * @returns {HostInfo} Info about the `Host` header (or equivalent). If there
    * is no header (etc.), it is treated as if it were specified as just
    * `localhost`.

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -262,6 +262,18 @@ export class Request {
   }
 
   /**
+   * @returns {string} A reasonably-suggestive but possibly incomplete
+   * representation of the incoming request, in the form of an URL. This is
+   * meant for logging, and specifically _not_ for any routing or other more
+   * meaningful computation (hence the name).
+   */
+  get urlForLogging() {
+    const { protocol, host, urlString } = this;
+
+    return `${protocol}://${host.nameString}${urlString}`;
+  }
+
+  /**
    * @returns {string} The unparsed URL path that was passed in to the original
    * HTTP(ish) request. Colloquially, this is the suffix of the URL-per-se
    * starting at the first slash (`/`) after the host identifier.

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -108,6 +108,17 @@ export class Request {
   }
 
   /**
+   * @returns {?object} _Unsecure_ cookies that have been parsed from the
+   * request, or `null` if there are not any.
+   */
+  get cookies() {
+    // Note: The `cookies` property of the request is provided by Express or
+    // by the `cookie-parser` middleware. As of this writing, there is
+    // nothing actually set up in the system to cause this value to be set.
+    return this.#expressRequest.cookies ?? null;
+  }
+
+  /**
    * @returns {ClientRequest|express.Request} The underlying Express(-like)
    * request object.
    */
@@ -237,6 +248,17 @@ export class Request {
    */
   get searchString() {
     return this.#parsedUrl.search;
+  }
+
+  /**
+   * @returns {?object} _Secure_ cookies that have been parsed from the request,
+   * or `null` if there are not any.
+   */
+  get secureCookies() {
+    // Note: The `secureCookies` property of the request is provided by Express
+    // or by the `cookie-parser` middleware. As of this writing, there is
+    // nothing actually set up in the system to cause this value to be set.
+    return this.#expressRequest.secureCookies ?? null;
   }
 
   /**

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -13,8 +13,7 @@ import statuses from 'statuses';
 import { ManualPromise } from '@this/async';
 import { TreePathKey } from '@this/collections';
 import { IntfLogger } from '@this/loggy';
-import { MimeTypes } from '@this/net-util';
-import { HostInfo } from '@this/net-util';
+import { HostInfo, MimeTypes } from '@this/net-util';
 import { AskIf, MustBe } from '@this/typey';
 
 import { WranglerContext } from '#x/WranglerContext';

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -17,6 +17,8 @@ import { MimeTypes } from '@this/net-util';
 import { HostInfo } from '@this/net-util';
 import { AskIf, MustBe } from '@this/typey';
 
+import { WranglerContext } from '#x/WranglerContext';
+
 
 /**
  * Representation of an in-progress HTTP(ish) request, including both request
@@ -50,6 +52,13 @@ export class Request {
    */
   #id = null;
 
+  /**
+   * @type {WranglerContext} Most-specific outer context responsible for this
+   * instance. (This instance might also get directly associated with a context,
+   * but it doesn't get to find out about it.)
+   */
+  #outerContext;
+
   /** @type {ClientRequest|express.Request} HTTP(ish) request object. */
   #expressRequest;
 
@@ -79,6 +88,8 @@ export class Request {
   /**
    * Constructs an instance.
    *
+   * @param {WranglerContext} context Most-specific context that was responsible
+   *   for constructing this instance.
    * @param {ClientRequest|express.Request} request Request object. This is a
    *   request object as used by Express to a middleware handler (or similar).
    * @param {ServerResponse|express.Response} response Response object. This is
@@ -89,7 +100,9 @@ export class Request {
    *   one that includes an additional subtag representing a new unique(ish) ID
    *   for the request.
    */
-  constructor(request, response, logger) {
+  constructor(context, request, response, logger) {
+    this.#outerContext = MustBe.instanceOf(context, WranglerContext);
+
     // Note: It's impractical to do more thorough type checking here (and
     // probably not worth it anyway).
     this.#expressRequest  = MustBe.object(request);

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -205,6 +205,11 @@ export class Request {
     return this.#parsedUrl.pathname;
   }
 
+  /** @returns {string} The name of the protocol which spawned this instance. */
+  get protocol() {
+    return this.#expressRequest.protocol;
+  }
+
   /**
    * @returns {string} The search a/k/a query portion of {@link #urlString},
    * as an unparsed string, or `''` (the empty string) if there is no search

--- a/src/network-protocol/export/WranglerContext.js
+++ b/src/network-protocol/export/WranglerContext.js
@@ -29,11 +29,8 @@ export class WranglerContext {
   /** @type {?IntfLogger} Logger for a session. */
   #sessionLogger = null;
 
-  /** @type {?string} ID of a request. */
-  #requestId = null;
-
-  /** @type {?IntfLogger} Logger for a request. */
-  #requestLogger = null;
+  /** @type {?Request} Request. */
+  #request = null;
 
   // Note: The default constructor is fine here.
 
@@ -49,16 +46,14 @@ export class WranglerContext {
 
   /** @returns {?string} Most-specific available id, if any. */
   get id() {
-    return this.#requestId
-      ?? this.#sessionId
-      ?? this.#connectionId;
+    return this.requestId ?? this.#sessionId ?? this.#connectionId;
   }
 
   /** @returns {object} Plain object with all IDs in this context. */
   get ids() {
     const result = {};
 
-    if (this.#requestId)    result.requestId    = this.#requestId;
+    if (this.requestId)     result.requestId    = this.requestId;
     if (this.#sessionId)    result.sessionId    = this.#sessionId;
     if (this.#connectionId) result.connectionId = this.#connectionId;
 
@@ -67,19 +62,22 @@ export class WranglerContext {
 
   /** @returns {?IntfLogger} Most-specific available logger, if any. */
   get logger() {
-    return this.#requestLogger
-      ?? this.#sessionLogger
-      ?? this.#connectionLogger;
+    return this.requestLogger ?? this.#sessionLogger ?? this.#connectionLogger;
   }
 
-  /** @returns {?string} ID of a request. */
+  /** @returns {?Request} Request, if any. */
+  get request() {
+    return this.#request;
+  }
+
+  /** @returns {?string} ID of a request, if any. */
   get requestId() {
-    return this.#requestId;
+    return this.#request?.id;
   }
 
-  /** @returns {?IntfLogger} Logger for a request, or `null` if none. */
+  /** @returns {?IntfLogger} Logger for a request, if any. */
   get requestLogger() {
-    return this.#requestLogger;
+    return this.#request?.logger;
   }
 
   /** @returns {?string} ID of a session. */
@@ -157,10 +155,10 @@ export class WranglerContext {
    *
    * @param {?WranglerContext} outerContext Instance of this class which has
    *   outer context (for the connection and/or session), if any.
-   * @param {?IntfLogger} logger The request logger, if any.
+   * @param {Request} request The request.
    * @returns {WranglerContext} An appropriately-constructed instance.
    */
-  static forRequest(outerContext, logger) {
+  static forRequest(outerContext, request) {
     const ctx = new WranglerContext();
 
     if (outerContext) {
@@ -171,10 +169,7 @@ export class WranglerContext {
       ctx.#sessionId        = outerContext.#sessionId;
     }
 
-    if (logger) {
-      ctx.#requestLogger = logger;
-      ctx.#requestId     = Request.idFromLogger(logger);
-    }
+    ctx.#request = request;
 
     return ctx;
   }

--- a/src/network-protocol/private/RequestLogHelper.js
+++ b/src/network-protocol/private/RequestLogHelper.js
@@ -35,12 +35,17 @@ export class RequestLogHelper {
    * @param {WranglerContext} context Connection or session context.
    */
   logRequest(request, context) {
-    const { expressRequest: req, expressResponse: res, logger } = request;
+    const {
+      expressRequest: req,
+      expressResponse: res,
+      logger,
+      method,
+      protocol
+    } = request;
 
     const startTime = logger?.$env.now();
-    const urlish    = `${req.protocol}://${request.host.nameString}${request.urlString}`;
+    const urlish    = `${protocol}://${request.host.nameString}${request.urlString}`;
     const origin    = context.socketAddressPort ?? '<unknown-origin>';
-    const method    = request.method;
 
     context.logger?.newRequest(request.id);
     logger?.opened(context.ids);

--- a/src/network-protocol/private/RequestLogHelper.js
+++ b/src/network-protocol/private/RequestLogHelper.js
@@ -3,7 +3,6 @@
 
 import * as http2 from 'node:http2';
 
-import { Moment } from '@this/data-values';
 import { FormatUtils } from '@this/loggy';
 
 import { IntfRequestLogger } from '#x/IntfRequestLogger';

--- a/src/network-protocol/private/RequestLogHelper.js
+++ b/src/network-protocol/private/RequestLogHelper.js
@@ -38,6 +38,7 @@ export class RequestLogHelper {
     const {
       expressRequest: req,
       expressResponse: res,
+      headers,
       host,
       logger,
       method,
@@ -52,7 +53,7 @@ export class RequestLogHelper {
     context.logger?.newRequest(request.id);
     logger?.opened(context.ids);
     logger?.request(origin, method, urlish);
-    logger?.headers(RequestLogHelper.#sanitizeRequestHeaders(req.headers));
+    logger?.headers(RequestLogHelper.#sanitizeRequestHeaders(headers));
 
     const cookies = req.cookies;
     if (cookies) {
@@ -118,12 +119,18 @@ export class RequestLogHelper {
   static #sanitizeRequestHeaders(headers) {
     const result = { ...headers };
 
-    delete result[http2.sensitiveHeaders];
     delete result[':authority'];
     delete result[':method'];
     delete result[':path'];
     delete result[':scheme'];
     delete result.host;
+
+    // Non-obvious: This deletes the symbol property `http2.sensitiveHeaders`
+    // from the result (whose array is a value of header names that, per Node
+    // docs, aren't supposed to be compressed due to poor interaction with
+    // desirable cryptography properties). This _isn't_ supposed to actually
+    // delete the headers named by this value.
+    delete result[http2.sensitiveHeaders];
 
     return result;
   }

--- a/src/network-protocol/private/RequestLogHelper.js
+++ b/src/network-protocol/private/RequestLogHelper.js
@@ -43,7 +43,7 @@ export class RequestLogHelper {
       urlForLogging
     } = request;
 
-    const startTime = logger?.$env.now();
+    const startTime = this.#requestLogger.now();
     const origin    = context.socketAddressPort ?? '<unknown-origin>';
 
     context.logger?.newRequest(request.id);
@@ -59,7 +59,7 @@ export class RequestLogHelper {
     // thrown during handling.
     const info = await request.getLoggableResponseInfo();
 
-    const endTime  = logger?.$env.now();
+    const endTime  = this.#requestLogger.now();
     const duration = endTime.subtract(startTime);
 
     // Rearrange `info` into preferred loggable form.
@@ -97,7 +97,7 @@ export class RequestLogHelper {
     }
 
     const requestLogLine = [
-      Moment.stringFromSecs(Date.now() / 1000, { decimals: 4 }),
+      endTime.toString({ decimals: 4 }),
       origin,
       method,
       JSON.stringify(urlForLogging),

--- a/src/network-protocol/private/RequestLogHelper.js
+++ b/src/network-protocol/private/RequestLogHelper.js
@@ -38,6 +38,7 @@ export class RequestLogHelper {
     const {
       expressRequest: req,
       expressResponse: res,
+      cookies,
       headers,
       host,
       logger,
@@ -55,7 +56,6 @@ export class RequestLogHelper {
     logger?.request(origin, method, urlish);
     logger?.headers(RequestLogHelper.#sanitizeRequestHeaders(headers));
 
-    const cookies = req.cookies;
     if (cookies) {
       logger?.cookies(cookies);
     }

--- a/src/network-protocol/private/RequestLogHelper.js
+++ b/src/network-protocol/private/RequestLogHelper.js
@@ -38,13 +38,15 @@ export class RequestLogHelper {
     const {
       expressRequest: req,
       expressResponse: res,
+      host,
       logger,
       method,
-      protocol
+      protocol,
+      urlString
     } = request;
 
     const startTime = logger?.$env.now();
-    const urlish    = `${protocol}://${request.host.nameString}${request.urlString}`;
+    const urlish    = `${protocol}://${host.nameString}${urlString}`;
     const origin    = context.socketAddressPort ?? '<unknown-origin>';
 
     context.logger?.newRequest(request.id);

--- a/src/network-protocol/private/RequestLogHelper.js
+++ b/src/network-protocol/private/RequestLogHelper.js
@@ -36,7 +36,6 @@ export class RequestLogHelper {
    */
   logRequest(request, context) {
     const {
-      expressRequest: req,
       expressResponse: res,
       cookies,
       headers,

--- a/src/network-protocol/private/RequestLogHelper.js
+++ b/src/network-protocol/private/RequestLogHelper.js
@@ -39,20 +39,17 @@ export class RequestLogHelper {
       expressResponse: res,
       cookies,
       headers,
-      host,
       logger,
       method,
-      protocol,
-      urlString
+      urlForLogging
     } = request;
 
     const startTime = logger?.$env.now();
-    const urlish    = `${protocol}://${host.nameString}${urlString}`;
     const origin    = context.socketAddressPort ?? '<unknown-origin>';
 
     context.logger?.newRequest(request.id);
     logger?.opened(context.ids);
-    logger?.request(origin, method, urlish);
+    logger?.request(origin, method, urlForLogging);
     logger?.headers(RequestLogHelper.#sanitizeRequestHeaders(headers));
 
     if (cookies) {
@@ -92,7 +89,7 @@ export class RequestLogHelper {
         Moment.stringFromSecs(Date.now() / 1000, { decimals: 4 }),
         origin,
         method,
-        JSON.stringify(urlish),
+        JSON.stringify(urlForLogging),
         res.statusCode,
         FormatUtils.byteCountString(contentLength, { spaces: false }),
         duration.toString({ spaces: false }),


### PR DESCRIPTION
The main point of this PR was to get all remaining code that used `expressRequest` and `expressResponse` to instead use `Request`, mostly by adding needed stuff to `Request`. A couple of tangentially-related bits also got fixed up and/or generally tweaked. Details:

* Added a bunch more accessors to `Request`, including cookie stuff on the incoming-request side, along with an "omnibus" stuff-to-log method on the response side.
* `Request`s now hold onto their _outer_ `WranglerContext`s.
* `WranglerContext` instances representing requests now hold onto the actual `Request` object.
* Added `now()` to `IntfRequestLogger`, so that it is now possible to log time consistently for requests.
* Extracted `*TimeSource` classes out of `TokenBucket`. (Not actually needed yet, but it will help with future improvements.)
