### PR TITLE
"Target" not "URL"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ Breaking changes:
 * None.
 
 Other notable changes:
-* None.
+* Fixed handling of non-`origin` request targets. Before v0.6.1, these were
+  treated as if they were `origin` requests (that is, the usual kind that
+  specify a resource path), and in v0.6.1 they started causing crashes. Now,
+  they're properly classified.
 
 ### v0.6.1 -- 2024-01-19
 

--- a/src/builtin-applications/export/Redirector.js
+++ b/src/builtin-applications/export/Redirector.js
@@ -37,7 +37,7 @@ export class Redirector extends BaseApplication {
 
   /** @override */
   async _impl_handleRequest(request, dispatch) {
-    return request.redirect(
+    return request.sendRedirect(
       `${this.#target}${dispatch.extraString}`,
       this.#statusCode);
   }

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -60,7 +60,7 @@ export class StaticFiles extends BaseApplication {
 
     if (resolved.redirect) {
       const redirectTo = resolved.redirect;
-      return request.redirect(redirectTo, 301);
+      return request.sendRedirect(redirectTo, 301);
     } else if (resolved.path) {
       return await request.sendFile(resolved.path, StaticFiles.#SEND_OPTIONS);
     } else {

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -52,7 +52,7 @@ export class StaticFiles extends BaseApplication {
 
     if (!resolved) {
       if (this.#notFoundType) {
-        return request.notFound(this.#notFoundType, this.#notFoundContents);
+        return request.sendNotFound(this.#notFoundType, this.#notFoundContents);
       } else {
         return false;
       }

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -393,7 +393,7 @@ export class ProtocolWrangler {
     } else if (this.#rateLimiter) {
       const granted = await this.#rateLimiter.newRequest(reqLogger);
       if (!granted) {
-        res.sendStatus(503); // "Service Unavailable."
+        await request.sendError(503); // "Service Unavailable."
 
         // Wait for the response to have been at least nominally sent before
         // closing the socket, in the hope that there is a good chance that it

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -389,7 +389,8 @@ export class ProtocolWrangler {
     if (!request.pathnameString) {
       // It's not an `origin` request. We don't handle any other type of
       // target... yet.
-      return request.sendError(400); // "Bad Request."
+      await request.sendError(400); // "Bad Request."
+      return;
     } else if (this.#rateLimiter) {
       const granted = await this.#rateLimiter.newRequest(reqLogger);
       if (!granted) {

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -399,10 +399,14 @@ export class ProtocolWrangler {
 
     res.set('Server', this.#serverHeader);
 
-    if (this.#rateLimiter) {
+    if (!request.pathnameString) {
+      // It's not an `origin` request. We don't handle any other type of
+      // target... yet.
+      return request.sendError(400); // "Bad Request."
+    } else if (this.#rateLimiter) {
       const granted = await this.#rateLimiter.newRequest(reqLogger);
       if (!granted) {
-        res.sendStatus(503);
+        res.sendStatus(503); // "Service Unavailable."
 
         // Wait for the response to have been at least nominally sent before
         // closing the socket, in the hope that there is a good chance that it

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -375,21 +375,8 @@ export class ProtocolWrangler {
    *   to run.
    */
   async #handleExpressRequest(req, res, next) {
-    const context = WranglerContext.getNonNull(req.socket, req.stream?.session);
-
-    // TODO: `request.url` is not sanitized by Node, and furthermore it could
-    // legitimately be the form used when talking to a proxy (see RFC7230,
-    // section 5.3). `Request` does its own sanity check and will reject those,
-    // but we should catch it here, in a less ad-hoc way, before trying to
-    // construct the `Request`. And we should log it!
-    let request;
-    try {
-      request = new Request(context, req, res, this.#requestLogger);
-    } catch (e) {
-      res.sendStatus(400); // "Bad Request."
-      return;
-    }
-
+    const context   = WranglerContext.getNonNull(req.socket, req.stream?.session);
+    const request   = new Request(context, req, res, this.#requestLogger);
     const reqLogger = request.logger;
 
     const reqCtx = WranglerContext.forRequest(context, request);

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -381,7 +381,7 @@ export class ProtocolWrangler {
     // legitimately be the form used when talking to a proxy (see RFC7230,
     // section 5.3). `Request` does its own sanity check and will reject those,
     // but we should catch it here, in a less ad-hoc way, before trying to
-    // construct the `Request`.
+    // construct the `Request`. And we should log it!
     let request;
     try {
       request = new Request(context, req, res, this.#requestLogger);

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -421,50 +421,6 @@ export class Request {
   }
 
   /**
-   * Issues a redirect response, with a standard response message and plain text
-   * body. The response message depends on the status code.
-   *
-   * Calling this method results in this request being considered complete, and
-   * as such no additional response-related methods will work.
-   *
-   * **Note:** This method does _not_ do any URL-encoding on the given `target`.
-   * It is assumed to be valid and already encoded if necessary. (This is unlike
-   * Express which tries to be "smart" about encoding, which can ultimately be
-   * more like "confusing.")
-   *
-   * @param {string} target Possibly-relative target URL.
-   * @param {number} [status] Status code.
-   * @returns {boolean} `true` when the response is completed.
-   */
-  async sendRedirect(target, status = 302) {
-    // Note: This method avoids using `express.Response.redirect()` (a) to avoid
-    // ambiguity with the argument `"back"`, and (b) generally with an eye
-    // towards dropping Express entirely as a dependency.
-
-    MustBe.string(target);
-
-    return this.#sendNonContentResponse(status, {
-      bodyExtra: `  ${target}\n`,
-      headers:   { 'Location': target }
-    });
-  }
-
-  /**
-   * Issues a redirect response targeted at the original request's referrer. If
-   * there was no referrer, this redirects to `/`.
-   *
-   * Calling this method results in this request being considered complete, and
-   * as such no additional response-related methods will work.
-   *
-   * @param {number} [status] Status code.
-   * @returns {boolean} `true` when the response is completed.
-   */
-  async sendRedirectBack(status = 302) {
-    const target = this.#expressRequest.header('referrer') ?? '/';
-    return this.sendRedirect(target, status);
-  }
-
-  /**
    * Issues a successful response, with the given body contents or with an empty
    * body as appropriate. The actual reported status will be one of:
    *
@@ -669,6 +625,50 @@ export class Request {
     // completed (which could be slightly later), and also plumb through any
     // errors that were encountered during final response processing.
     return this.whenResponseDone();
+  }
+
+  /**
+   * Issues a redirect response, with a standard response message and plain text
+   * body. The response message depends on the status code.
+   *
+   * Calling this method results in this request being considered complete, and
+   * as such no additional response-related methods will work.
+   *
+   * **Note:** This method does _not_ do any URL-encoding on the given `target`.
+   * It is assumed to be valid and already encoded if necessary. (This is unlike
+   * Express which tries to be "smart" about encoding, which can ultimately be
+   * more like "confusing.")
+   *
+   * @param {string} target Possibly-relative target URL.
+   * @param {number} [status] Status code.
+   * @returns {boolean} `true` when the response is completed.
+   */
+  async sendRedirect(target, status = 302) {
+    // Note: This method avoids using `express.Response.redirect()` (a) to avoid
+    // ambiguity with the argument `"back"`, and (b) generally with an eye
+    // towards dropping Express entirely as a dependency.
+
+    MustBe.string(target);
+
+    return this.#sendNonContentResponse(status, {
+      bodyExtra: `  ${target}\n`,
+      headers:   { 'Location': target }
+    });
+  }
+
+  /**
+   * Issues a redirect response targeted at the original request's referrer. If
+   * there was no referrer, this redirects to `/`.
+   *
+   * Calling this method results in this request being considered complete, and
+   * as such no additional response-related methods will work.
+   *
+   * @param {number} [status] Status code.
+   * @returns {boolean} `true` when the response is completed.
+   */
+  async sendRedirectBack(status = 302) {
+    const target = this.#expressRequest.header('referrer') ?? '/';
+    return this.sendRedirect(target, status);
   }
 
   /**

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -401,26 +401,6 @@ export class Request {
   }
 
   /**
-   * Issues a "not found" (status `404`) response, with optional body. If no
-   * body is provided, a simple default plain-text body is used. The response
-   * includes the single content/cache-related header `Cache-Control: no-store,
-   * must-revalidate`. If the request method is `HEAD`, this will _not_ send the
-   * body as part of the response.
-   *
-   * @param {string} [contentType] Content type for the body. Must be valid if
-   *  `body` is passed as non-`null`.
-   * @param {string|Buffer} [body] Body content.
-   * @returns {boolean} `true` when the response is completed.
-   */
-  async sendNotFound(contentType = null, body = null) {
-    const sendOpts = body
-      ? { contentType, body }
-      : { bodyExtra: `  ${this.targetString}\n` };
-
-    return this.#sendNonContentResponse(404, sendOpts);
-  }
-
-  /**
    * Issues a successful response, with the given body contents or with an empty
    * body as appropriate. The actual reported status will be one of:
    *
@@ -625,6 +605,26 @@ export class Request {
     // completed (which could be slightly later), and also plumb through any
     // errors that were encountered during final response processing.
     return this.whenResponseDone();
+  }
+
+  /**
+   * Issues a "not found" (status `404`) response, with optional body. If no
+   * body is provided, a simple default plain-text body is used. The response
+   * includes the single content/cache-related header `Cache-Control: no-store,
+   * must-revalidate`. If the request method is `HEAD`, this will _not_ send the
+   * body as part of the response.
+   *
+   * @param {string} [contentType] Content type for the body. Must be valid if
+   *  `body` is passed as non-`null`.
+   * @param {string|Buffer} [body] Body content.
+   * @returns {boolean} `true` when the response is completed.
+   */
+  async sendNotFound(contentType = null, body = null) {
+    const sendOpts = body
+      ? { contentType, body }
+      : { bodyExtra: `  ${this.targetString}\n` };
+
+    return this.#sendNonContentResponse(404, sendOpts);
   }
 
   /**

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -71,12 +71,12 @@ export class Request {
   #host = null;
 
   /**
-   * @type {?URL} The parsed version of `.#expressRequest.url`, or `null` if not
-   * yet calculated. **Note:** Despite its name, `.url` doesn't contain any of
-   * the usual URL bits before the start of the path, so those fields are
-   * meaningless here.
+   * @type {?URL} The parsed version of {@link #targetString}, or `null` if not
+   * yet calculated. **Note:** Despite it being an instance of `URL`, the
+   * `target` doesn't ever contain the parts of a URL before the path, so those
+   * fields are meaningless here.
    */
-  #parsedUrlObject = null;
+  #parsedTargetObject = null;
 
   /**
    * @type {?TreePathKey} The parsed version of {@link #pathnameString}, or
@@ -249,7 +249,7 @@ export class Request {
    * standard `URL` class.
    */
   get pathnameString() {
-    return this.#parsedUrl.pathname;
+    return this.#parsedTarget.pathname;
   }
 
   /** @returns {string} The name of the protocol which spawned this instance. */
@@ -267,7 +267,7 @@ export class Request {
    * standard `URL` class.
    */
   get searchString() {
-    return this.#parsedUrl.search;
+    return this.#parsedTarget.search;
   }
 
   /**
@@ -729,8 +729,8 @@ export class Request {
    * private getter because the return value is mutable, and we don't want to
    * allow clients to actually mutate it.
    */
-  get #parsedUrl() {
-    if (!this.#parsedUrlObject) {
+  get #parsedTarget() {
+    if (!this.#parsedTargetObject) {
       // Note: An earlier version of this code said `new URL(this.targetString,
       // 'x://x')`, so as to make it possible for `targetString` to omit the
       // scheme and host. However, that was totally incorrect, because the
@@ -747,10 +747,10 @@ export class Request {
         urlObj.pathname = '/';
       }
 
-      this.#parsedUrlObject = urlObj;
+      this.#parsedTargetObject = urlObj;
     }
 
-    return this.#parsedUrlObject;
+    return this.#parsedTargetObject;
   }
 
   /**

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -291,14 +291,18 @@ export class Request {
 
   /**
    * @returns {string} A reasonably-suggestive but possibly incomplete
-   * representation of the incoming request, in the form of an URL. This is
-   * meant for logging, and specifically _not_ for any routing or other more
+   * representation of the incoming request, in the form of a URL. This is meant
+   * for logging, and specifically _not_ for any routing or other more
    * meaningful computation (hence the name).
    */
   get urlForLogging() {
-    const { protocol, host, targetString } = this;
+    const { protocol, host }     = this;
+    const { targetString, type } = this.#parsedTarget;
+    const protoHost              = `${protocol}://${host.nameString}`;
 
-    return `${protocol}://${host.nameString}${targetString}`;
+    return (type === 'origin')
+      ? `${protoHost}${targetString}`
+      : `${protoHost}:${type}=${targetString}`;
   }
 
   /**

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -732,12 +732,12 @@ export class Request {
   get #parsedTarget() {
     if (!this.#parsedTargetObject) {
       // Note: An earlier version of this code said `new URL(this.targetString,
-      // 'x://x')`, so as to make it possible for `targetString` to omit the
-      // scheme and host. However, that was totally incorrect, because the
-      // _real_ requirement is for `targetString` to _always_ be the path. The
-      // most notable case where the old code failed was in parsing a path that
-      // began with two slashes, which would get incorrectly parsed as having a
-      // host.
+      // 'x://x')`, so as to make the constructor work given that `targetString`
+      // should omit the scheme and host. However, that was totally incorrect,
+      // because the _real_ requirement is for `targetString` to _always_ be
+      // _just_ the path. The most notable case where the old code failed was in
+      // parsing a path that began with two slashes, which would get incorrectly
+      // parsed as having a host.
       const urlObj = new URL(`x://x${this.targetString}`);
 
       if (urlObj.pathname === '') {

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -412,7 +412,7 @@ export class Request {
    * @param {string|Buffer} [body] Body content.
    * @returns {boolean} `true` when the response is completed.
    */
-  async notFound(contentType = null, body = null) {
+  async sendNotFound(contentType = null, body = null) {
     const sendOpts = body
       ? { contentType, body }
       : { bodyExtra: `  ${this.targetString}\n` };

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -282,9 +282,13 @@ export class Request {
   }
 
   /**
-   * @returns {string} The unparsed URL path that was passed in to the original
-   * HTTP(ish) request. Colloquially, this is the suffix of the URL-per-se
-   * starting at the first slash (`/`) after the host identifier.
+   * @returns {string} The unparsed target that was passed in to the original
+   * HTTP(ish) request. In the common case of the target being a path to a
+   * resource, colloquially speaking, this is the suffix of the URL-per-se
+   * starting at the first slash (`/`) after the host identifier. That said,
+   * there are other non-path forms for a target. See
+   * <https://www.rfc-editor.org/rfc/rfc7230#section-5.3> for the excruciating
+   * details.
    *
    * For example, for the requested URL
    * `https://example.com:123/foo/bar?baz=10`, this would be `/foo/bar?baz=10`.
@@ -293,6 +297,9 @@ export class Request {
    * to diverge from Node for the sake of clarity.
    */
   get targetString() {
+    // Note: Node calls the target the `.url`, but it's totes _not_ actually a
+    // URL, bless their innocent hearts.
+
     // Note: Though this framework uses Express under the covers (as of this
     // writing), and Express _does_ rewrite the underlying request's `.url` in
     // some circumstances, the way we use Express should never cause it to do

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -436,7 +436,7 @@ export class Request {
    * @param {number} [status] Status code.
    * @returns {boolean} `true` when the response is completed.
    */
-  async redirect(target, status = 302) {
+  async sendRedirect(target, status = 302) {
     // Note: This method avoids using `express.Response.redirect()` (a) to avoid
     // ambiguity with the argument `"back"`, and (b) generally with an eye
     // towards dropping Express entirely as a dependency.
@@ -459,9 +459,9 @@ export class Request {
    * @param {number} [status] Status code.
    * @returns {boolean} `true` when the response is completed.
    */
-  async redirectBack(status = 302) {
+  async sendRedirectBack(status = 302) {
     const target = this.#expressRequest.header('referrer') ?? '/';
-    return this.redirect(target, status);
+    return this.sendRedirect(target, status);
   }
 
   /**

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -282,18 +282,6 @@ export class Request {
   }
 
   /**
-   * @returns {string} A reasonably-suggestive but possibly incomplete
-   * representation of the incoming request, in the form of an URL. This is
-   * meant for logging, and specifically _not_ for any routing or other more
-   * meaningful computation (hence the name).
-   */
-  get urlForLogging() {
-    const { protocol, host, targetString } = this;
-
-    return `${protocol}://${host.nameString}${targetString}`;
-  }
-
-  /**
    * @returns {string} The unparsed URL path that was passed in to the original
    * HTTP(ish) request. Colloquially, this is the suffix of the URL-per-se
    * starting at the first slash (`/`) after the host identifier.
@@ -312,6 +300,18 @@ export class Request {
     // not the Express-specific `.originalUrl`. (Ultimately, the hope is to drop
     // use of Express, as it provides little value to this project.)
     return this.#expressRequest.url;
+  }
+
+  /**
+   * @returns {string} A reasonably-suggestive but possibly incomplete
+   * representation of the incoming request, in the form of an URL. This is
+   * meant for logging, and specifically _not_ for any routing or other more
+   * meaningful computation (hence the name).
+   */
+  get urlForLogging() {
+    const { protocol, host, targetString } = this;
+
+    return `${protocol}://${host.nameString}${targetString}`;
   }
 
   /**

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -105,20 +105,6 @@ export class Request {
       this.#id     = logger.$meta.makeId();
       this.#logger = logger[this.#id];
     }
-
-    if (!/^[/]/.test(request.url)) {
-      // Sanity check. If we end up here, it's a bug and not (in particular) a
-      // malformed request (which never should have made it this far).
-      // TODO: In practice this is happening, and it's not clear why. Log it,
-      // so we can figure out what's going on.
-      this.#logger.strangeOriginalUrl({
-        hostname: request.hostname,
-        method:   request.method,
-        protocol: request.protocol,
-        url:      request.url
-      });
-      throw new Error(`Shouldn't happen: ${request.url}`);
-    }
   }
 
   /**


### PR DESCRIPTION
This PR gets `Request` — and the system in general — to be a-okay with the forms of the "target" on an incoming request to be any of the possible forms, not just `/`-separated paths.

I also went ahead and renamed some bits from `url` to `target`. In Node, these things are called `url`s, but they aren't actually ever real URLs per se, which is of course super confusing. I originally named our stuff `url*` to match, but I decided I'd rather reduce the semantic confusion.