### PR TITLE
More cookie fun

### DIFF
--- a/src/main-lactoserv/package-lock.json
+++ b/src/main-lactoserv/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.6.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "cookie": "^0.6.0",
         "etag": "^1.8.1",
         "express": "^4.18.2",
         "fresh": "^0.5.2",
@@ -156,14 +155,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -1,8 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import cookie from 'cookie';
-
 import { MustBe } from '@this/typey';
 
 

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -137,9 +137,10 @@ export class Cookies {
     // even though the "longest match" rule should have let the `<value2>`
     // alternative "win" when a quoted form is present.
     this.#ASSIGN_REGEX = Object.freeze(
-      new RegExp(
-        `(?<name>${nameRx})=(?:(?<value1>(?!")${valueRx})|"(?<value2>${valueRx})")(?: *;| *$)`,
-        'gv'));
+      new RegExp(''
+        + `(?<name>${nameRx})=`
+        + `(?:(?<value1>(?!")${valueRx})|"(?<value2>${valueRx})")`
+        + `(?: *;| *$)`, 'gv'));
   }
 
   /** @type {Cookies} Standard frozen empty instance of this class. */

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -138,7 +138,7 @@ export class Cookies {
     // alternative "win" when a quoted form is present.
     this.#ASSIGN_REGEX = Object.freeze(
       new RegExp(
-        `(?<name>${nameRx})=(?:(?<value1>(?!")${valueRx})|"(?<value2>${valueRx})");?`,
+        `(?<name>${nameRx})=(?:(?<value1>(?!")${valueRx})|"(?<value2>${valueRx})")(?:;| *$)`,
         'gv'));
   }
 

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -138,7 +138,7 @@ export class Cookies {
     // alternative "win" when a quoted form is present.
     this.#ASSIGN_REGEX = Object.freeze(
       new RegExp(
-        `(?<name>${nameRx})=(?:(?<value1>(?!")${valueRx})|"(?<value2>${valueRx})")(?:;| *$)`,
+        `(?<name>${nameRx})=(?:(?<value1>(?!")${valueRx})|"(?<value2>${valueRx})")(?: *;| *$)`,
         'gv'));
   }
 

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@this/collections": "*",
     "@this/typey": "*",
-    "cookie": "^0.6.0",
     "mime": "^4.0.1"
   }
 }

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -131,6 +131,71 @@ describe('get()', () => {
 });
 
 describe('set()', () => {
+  describe('invalid names (not strings)', () => {
+    test.each`
+      arg
+      ${undefined}
+      ${null}
+      ${false}
+      ${1}
+      ${[]}
+      ${['x']}
+    `('throws given $arg', ({ arg }) => {
+      const cookies = new Cookies();
+      expect(() => cookies.set(arg, 'beep')).toThrow();
+    });
+  });
+
+  describe('invalid values (not strings)', () => {
+    test.each`
+      arg
+      ${undefined}
+      ${null}
+      ${false}
+      ${1}
+      ${[]}
+      ${['x']}
+    `('throws given $arg', ({ arg }) => {
+      const cookies = new Cookies();
+      expect(() => cookies.set('x', arg)).toThrow();
+    });
+  });
+
+  describe('syntactically incorrect names', () => {
+    test.each`
+      arg
+      ${''}
+      ${' '}
+      ${','}
+      ${';'}
+      ${':'}
+      ${'@'}
+      ${'='}
+      ${'<uh>'}
+      ${'{wha}'}
+      ${'(yeah)'}
+      ${'[whee]'}
+    `('throws given $arg', ({ arg }) => {
+      const cookies = new Cookies();
+      expect(() => cookies.set(arg, 'beep')).toThrow();
+    });
+  });
+
+  describe('syntactically incorrect values', () => {
+    test.each`
+      arg
+      ${' '}
+      ${';'}
+      ${'\\'}
+      ${','}
+      ${'"'}
+      ${'"boop"'} // If passed with double quotes, the end result is de-quoted.
+    `('throws given $arg', ({ arg }) => {
+      const cookies = new Cookies();
+      expect(() => cookies.set('x', arg)).toThrow();
+    });
+  });
+
   test('can set a not-yet-set cookie', () => {
     const cookies = new Cookies();
     const name    = 'florp';
@@ -199,6 +264,17 @@ describe('parse()', () => {
     ${'12312'}
     `('returns `null` given: $input', ({ input }) => {
       expect(Cookies.parse(input)).toBeNull();
+    });
+  });
+
+  describe('syntax errors in the name', () => {
+    test.each`
+    name
+    ${''}
+    ${' '}
+    ${'('}
+    `('returns `null` given name: $name', ({ name }) => {
+      expect(Cookies.parse(`${name}=boop`)).toBeNull();
     });
   });
 
@@ -315,7 +391,7 @@ describe('parse()', () => {
 
   test('returns `null` given a syntactically incorrect quoted value', () => {
     const name    = 'yah';
-    const value   = 'foo%bar';
+    const value   = 'foo\\bar';
     const cookies = Cookies.parse(`${name}="${value}"`);
 
     expect(cookies).toBeNull();

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -242,6 +242,16 @@ describe('.EMPTY', () => {
 });
 
 describe('parse()', () => {
+  function prefixSuffixTest(prefix, suffix) {
+    const name      = 'blort';
+    const value     = 'fleep';
+    const cUnquoted = Cookies.parse(`${prefix}${name}=${value}${suffix}`);
+    const cQuoted   = Cookies.parse(`${prefix}${name}="${value}"${suffix}`);
+
+    expect([...cUnquoted]).toEqual([[name, value]]);
+    expect([...cQuoted]).toEqual([[name, value]]);
+  }
+
   test('returns `null` given an empty string', () => {
     expect(Cookies.parse('')).toBeNull();
   });
@@ -295,67 +305,45 @@ describe('parse()', () => {
   });
 
   test('tolerates a leading space', () => {
-    const name    = 'blort';
-    const value   = 'fleep';
-    const cookies = Cookies.parse(` ${name}=${value}`);
-
-    expect([...cookies]).toEqual([[name, value]]);
+    prefixSuffixTest(' ', '');
   });
 
   test('tolerates a trailing space', () => {
-    const name    = 'blort';
-    const value   = 'fleep';
-    const cookies = Cookies.parse(`${name}=${value} `);
-
-    expect([...cookies]).toEqual([[name, value]]);
+    prefixSuffixTest('', ' ');
   });
 
   test('tolerates a leading semicolon', () => {
-    const name    = 'blort';
-    const value   = 'fleep';
-    const cookies = Cookies.parse(`;${name}=${value}`);
-
-    expect([...cookies]).toEqual([[name, value]]);
+    prefixSuffixTest(';', '');
   });
 
   test('tolerates a trailing semicolon', () => {
-    const name    = 'blort';
-    const value   = 'fleep';
-    const cookies = Cookies.parse(`${name}=${value};`);
-
-    expect([...cookies]).toEqual([[name, value]]);
+    prefixSuffixTest('', ';');
   });
 
   test('tolerates a leading semicolon-space', () => {
-    const name    = 'blort';
-    const value   = 'fleep';
-    const cookies = Cookies.parse(`; ${name}=${value}`);
-
-    expect([...cookies]).toEqual([[name, value]]);
+    prefixSuffixTest('; ', '');
   });
 
   test('tolerates a trailing semicolon-space', () => {
-    const name    = 'blort';
-    const value   = 'fleep';
-    const cookies = Cookies.parse(`${name}=${value}; `);
+    prefixSuffixTest('', '; ');
+  });
 
-    expect([...cookies]).toEqual([[name, value]]);
+  test('tolerates a leading space-semicolon', () => {
+    prefixSuffixTest(' ;', '');
+  });
+
+  test('tolerates a trailing space-semicolon', () => {
+    prefixSuffixTest('', ' ;');
   });
 
   test('tolerates a leading recoverable syntax error', () => {
-    const name    = 'blort';
-    const value   = 'fleep';
-    const cookies = Cookies.parse(`zonk; ${name}=${value}`);
-
-    expect([...cookies]).toEqual([[name, value]]);
+    prefixSuffixTest('zonk; ', '');
+    prefixSuffixTest('@# ', '');
   });
 
   test('tolerates a trailing recoverable syntax error', () => {
-    const name    = 'blort';
-    const value   = 'fleep';
-    const cookies = Cookies.parse(`${name}=${value}; 123!`);
-
-    expect([...cookies]).toEqual([[name, value]]);
+    prefixSuffixTest('', '; 123!');
+    prefixSuffixTest('', '; ()*  ');
   });
 
   test('works for a two-unquoted-assignment instance', () => {


### PR DESCRIPTION
This PR tightens up cookie parsing. I ended up rolling my own parser instead of using the NPM package `cookie`. `cookie` was quite a bit too lenient for my tastes, and it seemed better to just drop it rather than try to spackle over it with another layer of checks.