### PR TITLE
No-body responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
-* None.
+* Split off `Request.sendNoBodyResponse()` from `sendContent()`, and made the
+  latter take separate `body` and `contentType` arguments instead of those being
+  part of the `options`.
 
 Other notable changes:
 * Added support for incoming cookies.
+* Fixed `Range` request edge cases.
 * Notice promptly when clients drop connections, instead of letting them time
   out (and end up getting a write-after-close error).
 * Cleaned up the request logging code, including details of what lands in the

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -136,12 +136,12 @@ const applications = [
     siteDirectory: filePath('../site'),
   },
   {
-    name:     'responseEmpty',
+    name:     'responseEmptyBody',
     class:    'SimpleResponse',
     filePath: filePath('../site-extra/empty-file.txt')
   },
   {
-    name:        'responseNoContent',
+    name:        'responseNoBody',
     class:       'SimpleResponse'
   },
   {
@@ -189,12 +189,12 @@ const endpoints = [
         at:          ['//*/florp/']
       },
       {
-        application: 'responseEmpty',
-        at:          ['//*/resp/empty/']
+        application: 'responseEmptyBody',
+        at:          ['//*/resp/empty-body/']
       },
       {
-        application: 'responseNoContent',
-        at:          ['//*/resp/no-content/']
+        application: 'responseNoBody',
+        at:          ['//*/resp/no-body/']
       },
       {
         application: 'responseOne',

--- a/src/builtin-applications/export/SimpleResponse.js
+++ b/src/builtin-applications/export/SimpleResponse.js
@@ -47,11 +47,11 @@ export class SimpleResponse extends BaseApplication {
 
     if (finalBody) {
       this.#respondFunc = (request) => {
-        request.sendContent(finalBody, contentType, sendOptions);
+        return request.sendContent(finalBody, contentType, sendOptions);
       };
     } else {
       this.#respondFunc = (request) => {
-        request.sendEmptyResponse(sendOptions);
+        return request.sendEmptyResponse(sendOptions);
       };
     }
   }

--- a/src/builtin-applications/export/SimpleResponse.js
+++ b/src/builtin-applications/export/SimpleResponse.js
@@ -35,7 +35,7 @@ export class SimpleResponse extends BaseApplication {
     const { body, contentType, filePath } = this.config;
     let finalBody = body;
 
-    const sendOptions = { ...SimpleResponse.#SEND_OPTIONS };
+    const sendOptions = SimpleResponse.#SEND_OPTIONS;
 
     if (filePath) {
       if (!await FsUtil.fileExists(filePath)) {
@@ -46,10 +46,8 @@ export class SimpleResponse extends BaseApplication {
     }
 
     if (finalBody) {
-      sendOptions.body        = finalBody;
-      sendOptions.contentType = contentType;
       this.#respondFunc = (request) => {
-        request.sendContent(sendOptions);
+        request.sendContent(finalBody, contentType, sendOptions);
       };
     } else {
       this.#respondFunc = (request) => {

--- a/src/builtin-applications/export/SimpleResponse.js
+++ b/src/builtin-applications/export/SimpleResponse.js
@@ -6,7 +6,6 @@ import fs from 'node:fs/promises';
 import { ApplicationConfig, Files } from '@this/app-config';
 import { BaseApplication } from '@this/app-framework';
 import { FsUtil } from '@this/fs-util';
-import { IntfLogger } from '@this/loggy';
 import { MimeTypes } from '@this/net-util';
 import { MustBe } from '@this/typey';
 
@@ -15,46 +14,48 @@ import { MustBe } from '@this/typey';
  * Simple response server. See docs for configuration object details.
  */
 export class SimpleResponse extends BaseApplication {
-  /** @type {?object} Send options to use, if known. */
-  #sendOptions = null;
-
   /**
-   * Constructs an instance.
-   *
-   * @param {ApplicationConfig} config Configuration for this application.
-   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
+   * @type {?function(Request): Promise} Function to call to issue a response.
    */
-  constructor(config, logger) {
-    super(config, logger);
-  }
+  #respondFunc = null;
+
+  // Note: The default contructor is fine for this class.
 
   /** @override */
   async _impl_handleRequest(request, dispatch_unused) {
-    return await request.sendContent(this.#sendOptions);
+    return await this.#respondFunc(request);
   }
 
   /** @override */
   async _impl_start(isReload_unused) {
-    if (this.#sendOptions) {
+    if (this.#respondFunc) {
       return;
     }
 
     const { body, contentType, filePath } = this.config;
-    const sendOptions = {
-      ...SimpleResponse.#SEND_OPTIONS,
-      body,
-      contentType
-    };
+    let finalBody = body;
+
+    const sendOptions = { ...SimpleResponse.#SEND_OPTIONS };
 
     if (filePath) {
       if (!await FsUtil.fileExists(filePath)) {
         throw new Error(`Not found or not a non-directory file: ${filePath}`);
       }
 
-      sendOptions.body = await fs.readFile(filePath);
+      finalBody = await fs.readFile(filePath);
     }
 
-    this.#sendOptions = sendOptions;
+    if (finalBody) {
+      sendOptions.body        = finalBody;
+      sendOptions.contentType = contentType;
+      this.#respondFunc = (request) => {
+        request.sendContent(sendOptions);
+      };
+    } else {
+      this.#respondFunc = (request) => {
+        request.sendEmptyResponse(sendOptions);
+      };
+    }
   }
 
   /** @override */

--- a/src/builtin-applications/export/SimpleResponse.js
+++ b/src/builtin-applications/export/SimpleResponse.js
@@ -51,7 +51,7 @@ export class SimpleResponse extends BaseApplication {
       };
     } else {
       this.#respondFunc = (request) => {
-        return request.sendEmptyResponse(sendOptions);
+        return request.sendNoBodyResponse(sendOptions);
       };
     }
   }

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -872,7 +872,8 @@ export class Request {
    *
    * @param {?number} [length] Length of the underlying response. If `null`,
    *   this method just returns a basic no-range-request success response.
-   * @param {?object} [responseHeaders] Response headers to-be.
+   * @param {?object} [responseHeaders] Response headers to-be. Not used when
+   *   passing `null` for `length`.
    * @returns {object} Disposition info.
    */
   #rangeInfo(length = null, responseHeaders = null) {
@@ -884,7 +885,7 @@ export class Request {
       };
     }
 
-    if (!length) {
+    if (length === null) {
       return status200();
     }
 

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -521,6 +521,9 @@ export class Request {
    *
    * This method ignores range requests entirely.
    *
+   * **Note:** What this method does is different than calling {@link
+   * #sendContent} with a zero-length body.
+   *
    * @param {object} options Options to control response behavior.
    * @param {?object} [options.headers] Extra headers to include in the
    *   response, if any. These are only included if the response is successful.
@@ -530,7 +533,7 @@ export class Request {
    * @returns {boolean} `true` when the response is completed.
    * @throws {Error} Thrown if there is any trouble sending the response.
    */
-  async sendEmptyResponse(options = {}) {
+  async sendNoBodyResponse(options = {}) {
     const { headers = null, maxAgeMsec = 0 } = options ?? {};
     const res          = this.#expressResponse;
     const finalHeaders = { ...(headers ?? {}) };

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -498,7 +498,7 @@ export class Request {
     } else {
       const rangeInfo = this.#rangeInfo(bodyBuffer.length, finalHeaders);
       if (rangeInfo.error) {
-        return this.#sendNonContentResponse(rangeInfo.status, rangeInfo.headers);
+        return this.#sendNonContentResponse(rangeInfo.status, { headers: rangeInfo.headers });
       } else {
         res.set(rangeInfo.headers);
         bodyBuffer = bodyBuffer.subarray(rangeInfo.start, rangeInfo.end);
@@ -898,6 +898,7 @@ export class Request {
     if ((ranges === -1) || (ranges === -2) || (ranges.type !== RANGE_UNIT)) {
       // Couldn't parse at all, not satisfiable, or wrong unit.
       return {
+        error:   true,
         status:  416,
         headers: { 'Content-Range': `${RANGE_UNIT} */${length}` }
       };
@@ -954,7 +955,7 @@ export class Request {
    * @param {?string} [options.contentType] Content type for the body. Required
    *   if `options.body` is passed.
    * @param {?object} [options.headers] Extra response headers to send, if any.
-   * @returns {boolean} `true` when the response is completed.
+   * @returns {Promise<boolean>} `true` when the response is completed.
    */
   #sendNonContentResponse(status, options = null) {
     MustBe.number(status, { safeInteger: true, minInclusive: 0, maxInclusive: 599 });

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -538,8 +538,7 @@ export class Request {
     const res          = this.#expressResponse;
     const finalHeaders = { ...(headers ?? {}) };
 
-    finalHeaders['Cache-Control'] =
-      `public, max-age=${Math.floor(maxAgeMsec / 1000)}`;
+    finalHeaders['Cache-Control'] = Request.#cacheControlHeader(maxAgeMsec);
 
     res.status(204);
     res.set(finalHeaders);

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -443,14 +443,15 @@ export class Request {
    * This method honors range requests, and will reject ones that cannot be
    * satisfied.
    *
+   * @param {string|Buffer|null} body Complete body to send, with `null`
+   *   indicating a zero-length response (which, to be clear is different than
+   *   not sending a body at all). If passed as a `string`, it is encoded as
+   *   UTF-8, and the content type of the response will list that as the
+   *   charset.
+   * @param {string} contentType Content type for the body. If this value starts
+   *   with `text/` and/or the `body` is passed as a string, then the actual
+   *   `Content-Type` header will indicate a charset of `utf-8`.
    * @param {object} options Options to control response behavior.
-   * @param {string|Buffer|null} [options.body] Complete body to send, if any.
-   *   If passed as a `string`, it is encoded as UTF-8, and the content type of
-   *   the response will list that as the charset.
-   * @param {?string} [options.contentType] Content type for the body. Required
-   *   if `options.body` is passed. If this value starts with `text/` and/or
-   *   the `body` is passed as a string, then the actual `Content-Type` header
-   *   will indicate a charset of `utf-8`.
    * @param {?object} [options.headers] Extra headers to include in the
    *   response, if any. These are only included if the response is successful.
    * @param {?number} [options.maxAgeMsec] Value to send back in the
@@ -459,65 +460,55 @@ export class Request {
    * @returns {boolean} `true` when the response is completed.
    * @throws {Error} Thrown if there is any trouble sending the response.
    */
-  async sendContent(options = {}) {
-    const { body, contentType, headers = null, maxAgeMsec = 0 } = options ?? {};
-    const stringBody = AskIf.string(body);
-    const res        = this.#expressResponse;
+  async sendContent(body, contentType, options = {}) {
+    let bodyBuffer;
+    let stringBody = false;
 
-    const finalHeaders = { ...(headers ?? {}) };
-
-    if (body) {
-      if (!contentType) {
-        throw new Error('Missing `contentType`.');
-      } else if (!(body instanceof Buffer)) {
-        MustBe.string(body);
-      }
-
-      finalHeaders['Content-Type'] =
-        MimeTypes.typeFromExtensionOrType(contentType);
+    if (body === null) {
+      // This is an unusual case, and it's not worth doing anything particularly
+      // special for it (e.g. pre-allocating a zero-length buffer).
+      bodyBuffer = Buffer.alloc(0);
+    } else if (AskIf.string(body)) {
+      bodyBuffer = Buffer.from(body, 'utf8');
+      stringBody = true;
+    } else if (body instanceof Buffer) {
+      bodyBuffer = body;
     } else {
-      // Reject range requests when there is no content.
-      return this.#sendNonContentResponse(416, {
-        headers: { 'Content-Range': 'bytes */0' }
-      });
+      throw new Error('`body` must be a string, a `Buffer`, or `null`.');
     }
 
-    finalHeaders['Cache-Control'] =
-      `public, max-age=${Math.floor(maxAgeMsec / 1000)}`;
+    MustBe.string(contentType);
+    contentType = MimeTypes.typeFromExtensionOrType(contentType);
 
-    if (body) {
-      let bodyBuffer = stringBody ? Buffer.from(body, 'utf8') : body;
+    const { headers = null, maxAgeMsec = 0 } = options ?? {};
+    const res          = this.#expressResponse;
+    const finalHeaders = { ...(headers ?? {}) };
 
-      if (stringBody || /^text[/]/.test(finalHeaders['Content-Type'])) {
-        finalHeaders['Content-Type'] += '; charset=utf-8';
-      }
+    finalHeaders['ETag']          = etag(bodyBuffer);
+    finalHeaders['Cache-Control'] = `public, max-age=${Math.floor(maxAgeMsec / 1000)}`;
+    finalHeaders['Content-Type']  = (stringBody || /^text[/]/.test(contentType))
+      ? `${contentType}; charset=utf-8`
+      : contentType;
 
-      finalHeaders['ETag'] = etag(bodyBuffer);
-
-      if (this.isFreshWithRespectTo(finalHeaders)) {
-        res.status(304);
-        res.set(finalHeaders);
-        res.set(this.#rangeInfo().headers); // For basic range-support headers.
-        res.end();
-      } else {
-        const rangeInfo = this.#rangeInfo(bodyBuffer.length, finalHeaders);
-        if (rangeInfo.error) {
-          return this.#sendNonContentResponse(rangeInfo.status, rangeInfo.headers);
-        } else {
-          res.set(rangeInfo.headers);
-          bodyBuffer = bodyBuffer.subarray(rangeInfo.start, rangeInfo.end);
-        }
-
-        finalHeaders['Content-Length'] = bodyBuffer.length;
-        res.set(finalHeaders);
-
-        res.status(rangeInfo.status);
-        res.end(bodyBuffer);
-      }
-    } else {
-      res.status(204);
+    if (this.isFreshWithRespectTo(finalHeaders)) {
+      res.status(304);
       res.set(finalHeaders);
+      res.set(this.#rangeInfo().headers); // For basic range-support headers.
       res.end();
+    } else {
+      const rangeInfo = this.#rangeInfo(bodyBuffer.length, finalHeaders);
+      if (rangeInfo.error) {
+        return this.#sendNonContentResponse(rangeInfo.status, rangeInfo.headers);
+      } else {
+        res.set(rangeInfo.headers);
+        bodyBuffer = bodyBuffer.subarray(rangeInfo.start, rangeInfo.end);
+      }
+
+      finalHeaders['Content-Length'] = bodyBuffer.length;
+      res.set(finalHeaders);
+
+      res.status(rangeInfo.status);
+      res.end(bodyBuffer);
     }
 
     return this.whenResponseDone();

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -481,14 +481,16 @@ export class Request {
     contentType = MimeTypes.typeFromExtensionOrType(contentType);
 
     const { headers = null, maxAgeMsec = 0 } = options ?? {};
-    const res          = this.#expressResponse;
-    const finalHeaders = { ...(headers ?? {}) };
+    const res = this.#expressResponse;
 
-    finalHeaders['ETag']          = etag(bodyBuffer);
-    finalHeaders['Cache-Control'] = `public, max-age=${Math.floor(maxAgeMsec / 1000)}`;
-    finalHeaders['Content-Type']  = (stringBody || /^text[/]/.test(contentType))
-      ? `${contentType}; charset=utf-8`
-      : contentType;
+    const finalHeaders = {
+      ...(headers ?? {}),
+      'Cache-Control': Request.#cacheControlHeader(maxAgeMsec),
+      'Content-Type': (stringBody || /^text[/]/.test(contentType))
+        ? `${contentType}; charset=utf-8`
+        : contentType,
+      'ETag': etag(bodyBuffer)
+    };
 
     if (this.isFreshWithRespectTo(finalHeaders)) {
       res.status(304);
@@ -535,10 +537,12 @@ export class Request {
    */
   async sendNoBodyResponse(options = {}) {
     const { headers = null, maxAgeMsec = 0 } = options ?? {};
-    const res          = this.#expressResponse;
-    const finalHeaders = { ...(headers ?? {}) };
+    const res = this.#expressResponse;
 
-    finalHeaders['Cache-Control'] = Request.#cacheControlHeader(maxAgeMsec);
+    const finalHeaders = {
+      ...(headers ?? {}),
+      'Cache-Control': Request.#cacheControlHeader(maxAgeMsec)
+    };
 
     res.status(204);
     res.set(finalHeaders);

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -1020,6 +1020,16 @@ export class Request {
   }
 
   /**
+   * Gets a `Cache-Control` header for the given max-age.
+   *
+   * @param {number} maxAgeMsec The max age, for cache control.
+   * @returns {string} The corresponding header.
+   */
+  static #cacheControlHeader(maxAgeMsec) {
+    return `public, max-age=${Math.floor(maxAgeMsec / 1000)}`;
+  }
+
+  /**
    * Extracts a string error code from the given `Error`, or returns a generic
    * "unknown error" if there's nothing else reasonable.
    *

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -524,6 +524,37 @@ export class Request {
   }
 
   /**
+   * Issues a successful response, with no body. The reported status will always
+   * be `204` ("No content"), and the response always includes a `Cache-Control`
+   * header.
+   *
+   * This method ignores range requests entirely.
+   *
+   * @param {object} options Options to control response behavior.
+   * @param {?object} [options.headers] Extra headers to include in the
+   *   response, if any. These are only included if the response is successful.
+   * @param {?number} [options.maxAgeMsec] Value to send back in the
+   *   `max-age` property of the `Cache-Control` response header. Defaults to
+   *   `0`.
+   * @returns {boolean} `true` when the response is completed.
+   * @throws {Error} Thrown if there is any trouble sending the response.
+   */
+  async sendEmptyResponse(options = {}) {
+    const { headers = null, maxAgeMsec = 0 } = options ?? {};
+    const res          = this.#expressResponse;
+    const finalHeaders = { ...(headers ?? {}) };
+
+    finalHeaders['Cache-Control'] =
+      `public, max-age=${Math.floor(maxAgeMsec / 1000)}`;
+
+    res.status(204);
+    res.set(finalHeaders);
+    res.end();
+
+    return this.whenResponseDone();
+  }
+
+  /**
    * Issues an error (status `4xx` or `5xx`) response, with optional body. If no
    * body is provided, a simple default plain-text body is used. The response
    * includes the single content/cache-related header `Cache-Control: no-store,


### PR DESCRIPTION
This PR separates out `sendNoBodyResponse()` from `sendContent()`, making the latter both simpler and less-confusingly named. I also ended up spotting and fixing problems with range responses.