### PR TITLE
`BaseApplication` tweakage

### DIFF
--- a/src/app-framework/export/BaseApplication.js
+++ b/src/app-framework/export/BaseApplication.js
@@ -37,38 +37,11 @@ export class BaseApplication extends BaseComponent {
 
   /** @override */
   async handleRequest(request, dispatch) {
-    let startTime;
-    let id;
-
-    if (this.logger) {
-      startTime = this.#loggingEnv.now();
-      id        = request.id;
-      this.logger.handling(id, dispatch.extraString);
-    }
-
     const result = this.#callHandler(request, dispatch);
 
-    if (this.logger) {
-      // Arrange to log about the result of the `_impl_` call once it settles.
-      (async () => {
-        let eventType;
-        let error = [];
-
-        try {
-          const settled = await result;
-          eventType = settled ? 'handled' : 'notHandled';
-        } catch (e) {
-          error = [e];
-          eventType = 'threw';
-        }
-
-        const endTime  = this.#loggingEnv.now();
-        const duration = endTime.subtract(startTime);
-        this.logger[eventType](id, duration, ...error);
-      })();
-    }
-
-    return result;
+    return this.logger
+      ? this.#logHandlerCall(request, dispatch, result)
+      : result;
   }
 
   /**
@@ -89,8 +62,7 @@ export class BaseApplication extends BaseComponent {
    *
    * @param {Request} request Request object.
    * @param {DispatchInfo} dispatch Dispatch information.
-   * @returns {boolean} Was the request handled? Flag as defined by the method
-   *   {@link IntfRequestHandler#handleRequest}.
+   * @returns {boolean} Was the request handled?
    */
   async #callHandler(request, dispatch) {
     const result = this._impl_handleRequest(request, dispatch);
@@ -117,6 +89,38 @@ export class BaseApplication extends BaseComponent {
       throw error('async-returned undefined; probably needs an explicit `return`');
     } else {
       throw error('async-returned something other than a boolean');
+    }
+  }
+
+  /**
+   * Logs a call to the handler, ultimately returning or throwing whatever the
+   * given result settles to.
+   *
+   * @param {Request} request Request object.
+   * @param {DispatchInfo} dispatch Dispatch information.
+   * @param {Promise<boolean>} result Promise for the handler result.
+   * @returns {boolean} Was the request handled?
+   */
+  async #logHandlerCall(request, dispatch, result) {
+    const startTime = this.#loggingEnv.now();
+    const logger    = this.logger;
+    const id        = request.id;
+
+    logger.handling(id, dispatch.extraString);
+
+    const done = (fate, ...error) => {
+      const endTime  = this.#loggingEnv.now();
+      const duration = endTime.subtract(startTime);
+      logger[fate](id, duration, ...error);
+    };
+
+    try {
+      const finalResult = await result;
+      done(finalResult ? 'handled' : 'notHandled');
+      return finalResult;
+    } catch (e) {
+      done('threw', e);
+      throw e;
     }
   }
 


### PR DESCRIPTION
Two tweaks to `BaseApplication` here:

* Notice bad behavior from concrete subclasses, and complain explicitly rather than just let the next layer up get confused and throw an error.
* Cleaned up the logging code, so it's not intermingled with the code doing dispatch-per-se.