### PR TITLE
Prep for support of `Set-Cookie` 

### DIFF
--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -70,9 +70,9 @@ export class Cookies {
    * Gets cookie attributes, for a cookie which is expected to be set.
    *
    * @param {string} name Cookie name.
-   * @returns {object} Cookie attributes. In addition to the attributes from
-   *   the original call to {@link #set}, this also includes `name` and `value`
-   *   properties.
+   * @returns {object} Cookie attributes, as a frozen object. In addition to the
+   *   attributes from the original call to {@link #set}, this also includes
+   *   `name` and `value` properties.
    * @throws {Error} Thrown if `name` is not bound.
    */
   getAttributes(name) {
@@ -89,7 +89,9 @@ export class Cookies {
    * Gets a cookie value, if available.
    *
    * @param {string} name Cookie name.
-   * @returns {?object} Cookie attributes, or `null` if not found.
+   * @returns {?object} Cookie attributes, as a frozen object, or `null` if
+   *   there is no such cookie. In addition to the attributes from the original
+   *   call to {@link #set}, this also includes `name` and `value` properties.
    */
   getAttributesOrNull(name) {
     return this.#attributes.get(name) ?? null;

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -42,18 +42,6 @@ export class Cookies {
   }
 
   /**
-   * Gets a map-like iterator of cookie values. Each yielded entry is a
-   * two-element array of a name and corresponding value.
-   *
-   * @returns {object} The iterator.
-   */
-  *entries() {
-    for (const [name, attribs] of this.#attributes) {
-      yield [name, attribs.value];
-    }
-  }
-
-  /**
    * Gets an array-like iterator for the sets of attributes for each cookie, for
    * use in generating `Set-Cookie` headers (or similar). Each yielded value is
    * a frozen plain object with attribute mappings (as per the `attributes`
@@ -64,6 +52,18 @@ export class Cookies {
    */
   cookieSets() {
     return this.#attributes.entries();
+  }
+
+  /**
+   * Gets a map-like iterator of cookie values. Each yielded entry is a
+   * two-element array of a name and corresponding value.
+   *
+   * @returns {object} The iterator.
+   */
+  *entries() {
+    for (const [name, attribs] of this.#attributes) {
+      yield [name, attribs.value];
+    }
   }
 
   /**

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -50,7 +50,7 @@ export class Cookies {
    *
    * @returns {object} The iterator.
    */
-  cookieSets() {
+  attributeSets() {
     return this.#attributes.values();
   }
 

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -42,8 +42,8 @@ export class Cookies {
   }
 
   /**
-   * Gets a map-like iterator of cookie values. Each entry is a two-element
-   * array of a name and corresponding value.
+   * Gets a map-like iterator of cookie values. Each yielded entry is a
+   * two-element array of a name and corresponding value.
    *
    * @returns {object} The iterator.
    */
@@ -51,6 +51,19 @@ export class Cookies {
     for (const [name, attribs] of this.#attributes) {
       yield [name, attribs.value];
     }
+  }
+
+  /**
+   * Gets an array-like iterator for the sets of attributes for each cookie, for
+   * use in generating `Set-Cookie` headers (or similar). Each yielded value is
+   * a frozen plain object with attribute mappings (as per the `attributes`
+   * argument to {@link #set}), plus extra property bindings for `name` and
+   * `value`.
+   *
+   * @returns {object} The iterator.
+   */
+  cookieSets() {
+    return this.#attributes.entries();
   }
 
   /**
@@ -99,7 +112,7 @@ export class Cookies {
   set(name, value, attributes = null) {
     MustBe.string(name, Cookies.#NAME_REGEX);
     MustBe.string(value, Cookies.#VALUE_REGEX);
-    if (attributes) {
+    if (attributes !== null) {
       Cookies.#checkAttributes(attributes);
     }
 

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -44,8 +44,8 @@ export class Cookies {
   }
 
   /**
-   * Gets the iterator of the cookies in this instance. Each entry is a
-   * two-element array of a name and corresponding value.
+   * Gets a map-like iterator of cookie values. Each entry is a two-element
+   * array of a name and corresponding value.
    *
    * @returns {object} The iterator.
    */
@@ -60,8 +60,8 @@ export class Cookies {
    * @returns {string} Cookie value.
    * @throws {Error} Thrown if `name` is not bound.
    */
-  get(name) {
-    const result = this.getOrNull(name);
+  getValue(name) {
+    const result = this.getValueOrNull(name);
 
     if (result !== null) {
       return result;
@@ -76,7 +76,7 @@ export class Cookies {
    * @param {string} name Cookie name.
    * @returns {?string} Cookie value, or `null` if not found.
    */
-  getOrNull(name) {
+  getValueOrNull(name) {
     return this.#cookies.get(name) ?? null;
   }
 

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -51,7 +51,7 @@ export class Cookies {
    * @returns {object} The iterator.
    */
   cookieSets() {
-    return this.#attributes.entries();
+    return this.#attributes.values();
   }
 
   /**

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -67,14 +67,16 @@ export class Cookies {
   }
 
   /**
-   * Gets a cookie value, which is expected to be set.
+   * Gets cookie attributes, for a cookie which is expected to be set.
    *
    * @param {string} name Cookie name.
-   * @returns {string} Cookie value.
+   * @returns {object} Cookie attributes. In addition to the attributes from
+   *   the original call to {@link #set}, this also includes `name` and `value`
+   *   properties.
    * @throws {Error} Thrown if `name` is not bound.
    */
-  getValue(name) {
-    const result = this.getValueOrNull(name);
+  getAttributes(name) {
+    const result = this.getAttributesOrNull(name);
 
     if (result !== null) {
       return result;
@@ -87,12 +89,31 @@ export class Cookies {
    * Gets a cookie value, if available.
    *
    * @param {string} name Cookie name.
+   * @returns {?object} Cookie attributes, or `null` if not found.
+   */
+  getAttributesOrNull(name) {
+    return this.#attributes.get(name) ?? null;
+  }
+
+  /**
+   * Gets cookie attributes, if there is a so-named cookie.
+   *
+   * @param {string} name Cookie name.
+   * @returns {string} Cookie value.
+   * @throws {Error} Thrown if `name` is not bound.
+   */
+  getValue(name) {
+    return this.getAttributes(name).value;
+  }
+
+  /**
+   * Gets a cookie value, if there is a so-named cookie.
+   *
+   * @param {string} name Cookie name.
    * @returns {?string} Cookie value, or `null` if not found.
    */
   getValueOrNull(name) {
-    const attribs = this.#attributes.get(name);
-
-    return attribs?.value ?? null;
+    return this.getAttributesOrNull(name)?.value ?? null;
   }
 
   /**

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -58,7 +58,7 @@ export class Cookies {
    * Gets a map-like iterator of cookie values. Each yielded entry is a
    * two-element array of a name and corresponding value.
    *
-   * @returns {object} The iterator.
+   * @yields {string[]} Name-value pair.
    */
   *entries() {
     for (const [name, attribs] of this.#attributes) {

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -12,6 +12,7 @@
   },
 
   "dependencies": {
+    "@this/data-values": "*",
     "@this/collections": "*",
     "@this/typey": "*",
     "mime": "^4.0.1"

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -76,11 +76,11 @@ ${'iterator'}  | ${Symbol.iterator}
   });
 });
 
-describe('get()', () => {
+describe('getValue()', () => {
   test('throws if a cookie is not found', () => {
     const cookies = new Cookies();
 
-    expect(() => cookies.get('florp')).toThrow();
+    expect(() => cookies.getValue('florp')).toThrow();
   });
 
   test('finds a cookie that was set', () => {
@@ -90,15 +90,15 @@ describe('get()', () => {
 
     cookies.set(name, value);
 
-    expect(cookies.get(name)).toBe(value);
+    expect(cookies.getValue(name)).toBe(value);
   });
 });
 
-describe('getOrNull()', () => {
+describe('getValueOrNull()', () => {
   test('returns `null` if a cookie is not found', () => {
     const cookies = new Cookies();
 
-    expect(cookies.getOrNull('florp')).toBeNull();
+    expect(cookies.getValueOrNull('florp')).toBeNull();
   });
 
   test('finds a cookie that was set', () => {
@@ -108,25 +108,7 @@ describe('getOrNull()', () => {
 
     cookies.set(name, value);
 
-    expect(cookies.getOrNull(name)).toBe(value);
-  });
-});
-
-describe('get()', () => {
-  test('throws if a cookie is not found', () => {
-    const cookies = new Cookies();
-
-    expect(() => cookies.get('florp')).toThrow();
-  });
-
-  test('finds a cookie that was set', () => {
-    const cookies = new Cookies();
-    const name    = 'florp';
-    const value   = 'bloop';
-
-    cookies.set(name, value);
-
-    expect(cookies.get(name)).toBe(value);
+    expect(cookies.getValueOrNull(name)).toBe(value);
   });
 });
 
@@ -214,7 +196,7 @@ describe('set()', () => {
     cookies.set(name, value1);
     cookies.set(name, value2);
     expect(cookies.size).toBe(1);
-    expect(cookies.get(name)).toBe(value2);
+    expect(cookies.getValue(name)).toBe(value2);
   });
 
   test('does not allow modification if the instance is frozen', () => {

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -100,9 +100,20 @@ describe('getAttributes()', () => {
       ...att
     });
   });
+
+  test('when non-null, returns a frozen instance', () => {
+    const cookies = new Cookies();
+    const name    = 'florp';
+    const value   = 'bloop';
+    const att     = { domain: 'florp.fleep', path: '/' };
+
+    cookies.set(name, value, att);
+
+    expect(cookies.getAttributes(name)).toBeFrozen();
+  });
 });
 
-describe('getValueOrNull()', () => {
+describe('getAttributesOrNull()', () => {
   test('returns `null` if a cookie is not found', () => {
     const cookies = new Cookies();
 
@@ -122,6 +133,17 @@ describe('getValueOrNull()', () => {
       value,
       ...att
     });
+  });
+
+  test('when non-null, returns a frozen instance', () => {
+    const cookies = new Cookies();
+    const name    = 'florp';
+    const value   = 'bloop';
+    const att     = { domain: 'florp.fleep', path: '/' };
+
+    cookies.set(name, value, att);
+
+    expect(cookies.getAttributesOrNull(name)).toBeFrozen();
   });
 });
 

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -26,10 +26,10 @@ describe('.size', () => {
   });
 });
 
-describe('cookieSets()', () => {
+describe('attributeSets()', () => {
   test('works on an empty instance', () => {
     const cookies = new Cookies();
-    const iter    = cookies.cookieSets();
+    const iter    = cookies.attributeSets();
 
     expect(iter.next().done).toBeTrue();
   });
@@ -42,7 +42,7 @@ describe('cookieSets()', () => {
 
     cookies.set(name, value, att);
 
-    const iter   = cookies.cookieSets();
+    const iter   = cookies.attributeSets();
     const result = iter.next();
 
     expect(iter.next().done).toBeTrue();
@@ -61,7 +61,7 @@ describe('cookieSets()', () => {
     cookies.set(name1, value1);
     cookies.set(name2, value2, att2);
 
-    const iter   = cookies.cookieSets();
+    const iter   = cookies.attributeSets();
     const result1 = iter.next();
     const result2 = iter.next();
 

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -216,11 +216,12 @@ describe('set()', () => {
 
   test('can set a not-yet-set cookie', () => {
     const cookies = new Cookies();
-    const name    = 'florp';
-    const value   = 'bloop';
 
-    cookies.set(name, value);
+    cookies.set('x', 'y');
     expect(cookies.size).toBe(1);
+
+    cookies.set('a', 'b', { path: '/' });
+    expect(cookies.size).toBe(2);
   });
 
   test('can overwrite a cookie', () => {
@@ -228,11 +229,18 @@ describe('set()', () => {
     const name    = 'florp';
     const value1  = 'bloop';
     const value2  = 'bleep';
+    const att1    = { path: '/' };
+    const att2    = { httpOnly: true };
 
-    cookies.set(name, value1);
-    cookies.set(name, value2);
+    cookies.set(name, value1, att1);
+    cookies.set(name, value2, att2);
     expect(cookies.size).toBe(1);
     expect(cookies.getValue(name)).toBe(value2);
+    expect(cookies.getAttributes(name)).toEqual({
+      name,
+      value: value2,
+      ...att2
+    });
   });
 
   test('does not allow modification if the instance is frozen', () => {

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -26,7 +26,53 @@ describe('.size', () => {
   });
 });
 
-// TODO: cookieSets()
+describe('cookieSets()', () => {
+  test('works on an empty instance', () => {
+    const cookies = new Cookies();
+    const iter    = cookies.cookieSets();
+
+    expect(iter.next().done).toBeTrue();
+  });
+
+  test('works on a single-element instance', () => {
+    const cookies = new Cookies();
+    const name    = 'beep';
+    const value   = 'boop';
+    const att     = { partitioned: true };
+
+    cookies.set(name, value, att);
+
+    const iter   = cookies.cookieSets();
+    const result = iter.next();
+
+    expect(iter.next().done).toBeTrue();
+    expect(result.done).toBeFalsy();
+    expect(result.value).toEqual({ name, value, ...att });
+  });
+
+  test('works on a two-element instance', () => {
+    const cookies = new Cookies();
+    const name1   = 'beep';
+    const value1  = 'boop';
+    const name2   = 'bink';
+    const value2  = 'bonk';
+    const att2    = { httpOnly: true };
+
+    cookies.set(name1, value1);
+    cookies.set(name2, value2, att2);
+
+    const iter   = cookies.cookieSets();
+    const result1 = iter.next();
+    const result2 = iter.next();
+
+    expect(iter.next().done).toBeTrue();
+    expect(result1.done).toBeFalsy();
+    expect(result2.done).toBeFalsy();
+    expect([result1.value, result2.value]).toIncludeSameMembers([
+      { name: name1, value: value1 },
+      { name: name2, value: value2, ...att2 }]);
+  });
+});
 
 describe.each`
 label          | method

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -178,6 +178,42 @@ describe('set()', () => {
     });
   });
 
+  describe('invalid attributes', () => {
+    test.each`
+      arg
+      ${false}
+      ${'boop'}
+      ${123}
+      ${[{ secure: true }]}
+      ${{ name: 'x' }}
+      ${{ value: 'x' }}
+      ${{ bloop: 'x' }}
+      ${{ domain: true }}
+      ${{ domain: 123 }}
+      ${{ expires: true }}
+      ${{ expires: 123 }}
+      ${{ expires: 'boop' }}
+      ${{ expires: new Date() }}
+      ${{ httpOnly: 123 }}
+      ${{ httpOnly: 'boop' }}
+      ${{ maxAge: true }}
+      ${{ maxAge: 123 }}
+      ${{ maxAge: 'boop' }}
+      ${{ partitioned: 123 }}
+      ${{ partitioned: 'boop' }}
+      ${{ path: true }}
+      ${{ path: 123 }}
+      ${{ sameSite: true }}
+      ${{ sameSite: 123 }}
+      ${{ sameSite: 'boop' }}
+      ${{ secure: 123 }}
+      ${{ secure: 'boop' }}
+    `('throws given $arg', ({ arg }) => {
+      const cookies = new Cookies();
+      expect(() => cookies.set('x', 'y', arg)).toThrow();
+    });
+  });
+
   test('can set a not-yet-set cookie', () => {
     const cookies = new Cookies();
     const name    = 'florp';

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -26,6 +26,8 @@ describe('.size', () => {
   });
 });
 
+// TODO: cookieSets()
+
 describe.each`
 label          | method
 ${'entries()'} | ${'entries'}
@@ -60,9 +62,10 @@ ${'iterator'}  | ${Symbol.iterator}
     const value1  = 'boop';
     const name2   = 'bink';
     const value2  = 'bonk';
+    const att2    = { httpOnly: true };
 
     cookies.set(name1, value1);
-    cookies.set(name2, value2);
+    cookies.set(name2, value2, att2);
 
     const iter   = cookies[method]();
     const result1 = iter.next();
@@ -98,7 +101,6 @@ describe('getAttributes()', () => {
     });
   });
 });
-
 
 describe('getValueOrNull()', () => {
   test('returns `null` if a cookie is not found', () => {

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -76,6 +76,53 @@ ${'iterator'}  | ${Symbol.iterator}
   });
 });
 
+describe('getAttributes()', () => {
+  test('throws if a cookie is not found', () => {
+    const cookies = new Cookies();
+
+    expect(() => cookies.getAttributes('florp')).toThrow();
+  });
+
+  test('finds a cookie that was set', () => {
+    const cookies = new Cookies();
+    const name    = 'florp';
+    const value   = 'bloop';
+    const att     = { domain: 'florp.fleep', path: '/' };
+
+    cookies.set(name, value, att);
+
+    expect(cookies.getAttributes(name)).toEqual({
+      name,
+      value,
+      ...att
+    });
+  });
+});
+
+
+describe('getValueOrNull()', () => {
+  test('returns `null` if a cookie is not found', () => {
+    const cookies = new Cookies();
+
+    expect(cookies.getAttributesOrNull('florp')).toBeNull();
+  });
+
+  test('finds a cookie that was set', () => {
+    const cookies = new Cookies();
+    const name    = 'florp';
+    const value   = 'bloop';
+    const att     = { domain: 'florp.fleep', path: '/' };
+
+    cookies.set(name, value, att);
+
+    expect(cookies.getAttributesOrNull(name)).toEqual({
+      name,
+      value,
+      ...att
+    });
+  });
+});
+
 describe('getValue()', () => {
   test('throws if a cookie is not found', () => {
     const cookies = new Cookies();


### PR DESCRIPTION
This PR adds most of the right stuff to `Cookies` such that it can be used to hold cookies to send as `Set-Cookie` responses.