### PR TITLE
Http dates and cookie headers

### DIFF
--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -70,6 +70,16 @@ export class Moment {
   }
 
   /**
+   * Makes a string representing this instance, in the standard HTTP format.
+   * See {@link #httpStringFromSecs} for more details.
+   *
+   * @returns {string} The HTTP standard form.
+   */
+  toHttpString() {
+    return Moment.httpStringFromSecs(this.#atSecs);
+  }
+
+  /**
    * Makes a friendly plain object representing this instance, which represents
    * both seconds since the Unix Epoch as well as a string indicating the
    * date-time in UTC.
@@ -123,6 +133,46 @@ export class Moment {
    */
   static fromMsec(atMsec) {
     return new Moment(atMsec / 1000);
+  }
+
+  /**
+   * Makes a string representing the given number of seconds since the Unix
+   * Epoch (note: _not_ milliseconds), in the standard HTTP format. This format
+   * is used, notably, for request and response header fields that represent
+   * dates.
+   *
+   * **Note:** The HTTP standard, RFC 9110 section 5.6.7 in particular, is very
+   * specific about the format.
+   *
+   * @param {number} atSecs Time in the form of seconds since the Unix Epoch.
+   * @returns {string} The HTTP standard form.
+   */
+  static httpStringFromSecs(atSecs) {
+    // In the Year of Our Muffin 2024, there is still no built-in Javascript
+    // function to do this. SMDH.
+
+    const DAYS   = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const MONTHS = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+    ];
+
+    // Formats a number as *t*wo *d*igits.
+    const td = (num) => {
+      return (num < 10) ? `0${num}` : `${num}`;
+    };
+
+    const when  = new Date(atSecs * 1000);
+    const day   = when.getUTCDay();
+    const date  = when.getUTCDate();
+    const month = when.getUTCMonth();
+    const year  = when.getUTCFullYear();
+    const hours = when.getUTCHours();
+    const mins  = when.getUTCMinutes();
+    const secs  = when.getUTCSeconds();
+
+    return `${DAYS[day]}, ${td(date)} ${MONTHS[month]} ${year} ` +
+     `${td(hours)}:${td(mins)}:${td(secs)} GMT`;
   }
 
   /**

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -189,8 +189,19 @@ export class Moment {
       return (num < 10) ? `0${num}` : `${num}`;
     };
 
+    // Creates the fractional seconds part of the string.
+    const makeFrac = () => {
+      // Non-obvious: If you take `atSecs % 1` and then operate on the remaining
+      // fraction, you can end up with a string representation that's off by 1,
+      // because of floating point (im)precision. That's why we _don't_ do that.
+      const tenPower = 10 ** decimals;
+      const frac     = Math.floor(atSecs * tenPower % tenPower);
+      const result   = frac.toString().padStart(decimals, '0');
+
+      return `.${result}`;
+    };
+
     const when    = new Date(atSecs * 1000);
-    const day     = when.getUTCDay();
     const date    = when.getUTCDate();
     const month   = when.getUTCMonth();
     const year    = when.getUTCFullYear();
@@ -198,22 +209,10 @@ export class Moment {
     const mins    = when.getUTCMinutes();
     const secs    = when.getUTCSeconds();
     const timeSep = colons ? ':' : '';
+    const frac    = (decimals === 0) ? '' : makeFrac();
 
-    const result =
+    return '' +
       `${year}${td(month + 1)}${td(date)}-` +
-      `${td(hours)}${timeSep}${td(mins)}${timeSep}${td(secs)}`;
-
-    if (decimals === 0) {
-      return result;
-    }
-
-    // Non-obvious: If you take `atSecs % 1` and then operate on the remaining
-    // fraction, you can end up with a string representation that's off by 1,
-    // because of floating point (im)precision. That's why we _don't_ do that.
-    const tenPower = 10 ** decimals;
-    const frac     = Math.floor(atSecs * tenPower % tenPower);
-    const fracStr  = frac.toString().padStart(decimals, '0');
-
-    return `${result}.${fracStr}`;
+      `${td(hours)}${timeSep}${td(mins)}${timeSep}${td(secs)}${frac}`;
   }
 }

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -189,30 +189,31 @@ export class Moment {
       return (num < 10) ? `0${num}` : `${num}`;
     };
 
-    const d       = new Date(atSecs * 1000);
+    const when    = new Date(atSecs * 1000);
+    const day     = when.getUTCDay();
+    const date    = when.getUTCDate();
+    const month   = when.getUTCMonth();
+    const year    = when.getUTCFullYear();
+    const hours   = when.getUTCHours();
+    const mins    = when.getUTCMinutes();
+    const secs    = when.getUTCSeconds();
     const timeSep = colons ? ':' : '';
-    const parts   = [
-      d.getUTCFullYear().toString(),
-      (d.getUTCMonth() + 1).toString().padStart(2, '0'),
-      d.getUTCDate().toString().padStart(2, '0'),
-      '-',
-      d.getUTCHours().toString().padStart(2, '0'),
-      timeSep,
-      d.getUTCMinutes().toString().padStart(2, '0'),
-      timeSep,
-      d.getUTCSeconds().toString().padStart(2, '0')
-    ];
 
-    if (decimals !== 0) {
-      // Non-obvious: If you take `atSecs % 1` and then operate on the remaining
-      // fraction, you can end up with a string representation that's off by 1,
-      // because of floating point (im)precision. That's why we _don't_ do that.
-      const tenPower = 10 ** decimals;
-      const frac     = Math.floor(atSecs * tenPower % tenPower);
-      const fracStr  = frac.toString().padStart(decimals, '0');
-      parts.push('.', fracStr);
+    const result =
+      `${year}${td(month + 1)}${td(date)}-` +
+      `${td(hours)}${timeSep}${td(mins)}${timeSep}${td(secs)}`;
+
+    if (decimals === 0) {
+      return result;
     }
 
-    return parts.join('');
+    // Non-obvious: If you take `atSecs % 1` and then operate on the remaining
+    // fraction, you can end up with a string representation that's off by 1,
+    // because of floating point (im)precision. That's why we _don't_ do that.
+    const tenPower = 10 ** decimals;
+    const frac     = Math.floor(atSecs * tenPower % tenPower);
+    const fracStr  = frac.toString().padStart(decimals, '0');
+
+    return `${result}.${fracStr}`;
   }
 }

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -148,31 +148,7 @@ export class Moment {
    * @returns {string} The HTTP standard form.
    */
   static httpStringFromSecs(atSecs) {
-    // In the Year of Our Muffin 2024, there is still no built-in Javascript
-    // function to do this. SMDH.
-
-    const DAYS   = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const MONTHS = [
-      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
-    ];
-
-    // Formats a number as *t*wo *d*igits.
-    const td = (num) => {
-      return (num < 10) ? `0${num}` : `${num}`;
-    };
-
-    const when  = new Date(atSecs * 1000);
-    const day   = when.getUTCDay();
-    const date  = when.getUTCDate();
-    const month = when.getUTCMonth();
-    const year  = when.getUTCFullYear();
-    const hours = when.getUTCHours();
-    const mins  = when.getUTCMinutes();
-    const secs  = when.getUTCSeconds();
-
-    return `${DAYS[day]}, ${td(date)} ${MONTHS[month]} ${year} ` +
-     `${td(hours)}:${td(mins)}:${td(secs)} GMT`;
+    return new Date(atSecs * 1000).toUTCString();
   }
 
   /**
@@ -207,6 +183,11 @@ export class Moment {
    */
   static stringFromSecs(atSecs, options = {}) {
     const { colons = true, decimals = 0 } = options;
+
+    // Formats a number as *t*wo *d*igits.
+    const td = (num) => {
+      return (num < 10) ? `0${num}` : `${num}`;
+    };
 
     const d       = new Date(atSecs * 1000);
     const timeSep = colons ? ':' : '';

--- a/src/data-values/tests/Moment.test.js
+++ b/src/data-values/tests/Moment.test.js
@@ -67,6 +67,26 @@ describe('subtract()', () => {
 });
 
 describe.each`
+method                    | isStatic
+${'httpStringFromSecs'}   | ${true}
+${'toHttpString'}         | ${false}
+`('$method()', ({ method, isStatic }) => {
+  test.each`
+  atSecs              | expected
+  ${0}                | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
+  ${0.00001}          | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
+  ${0.1}              | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
+  ${0.99999}          | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
+  `('with ($atSecs, $options)', ({ atSecs, expected }) => {
+    const result = isStatic
+      ? Moment[method](atSecs)
+      : new Moment(atSecs)[method]();
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe.each`
 method                    | isStatic  | returnsObject
 ${'stringFromSecs'}       | ${true}   | ${false}
 ${'plainObjectFromSecs'}  | ${true}   | ${true}

--- a/src/data-values/tests/Moment.test.js
+++ b/src/data-values/tests/Moment.test.js
@@ -72,12 +72,34 @@ ${'httpStringFromSecs'}   | ${true}
 ${'toHttpString'}         | ${false}
 `('$method()', ({ method, isStatic }) => {
   test.each`
-  atSecs              | expected
-  ${0}                | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
-  ${0.00001}          | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
-  ${0.1}              | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
-  ${0.99999}          | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
-  `('with ($atSecs, $options)', ({ atSecs, expected }) => {
+  atSecs        | expected
+  ${0}          | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
+  ${0.00001}    | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
+  ${0.1}        | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
+  ${0.99999}    | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
+  ${631155661}  | ${'Mon, 01 Jan 1990 01:01:01 GMT'}
+  ${631245722}  | ${'Tue, 02 Jan 1990 02:02:02 GMT'}
+  ${631335783}  | ${'Wed, 03 Jan 1990 03:03:03 GMT'}
+  ${631425844}  | ${'Thu, 04 Jan 1990 04:04:04 GMT'}
+  ${631515905}  | ${'Fri, 05 Jan 1990 05:05:05 GMT'}
+  ${631605966}  | ${'Sat, 06 Jan 1990 06:06:06 GMT'}
+  ${631696027}  | ${'Sun, 07 Jan 1990 07:07:07 GMT'}
+  ${631786088}  | ${'Mon, 08 Jan 1990 08:08:08 GMT'}
+  ${631876149}  | ${'Tue, 09 Jan 1990 09:09:09 GMT'}
+  ${631966210}  | ${'Wed, 10 Jan 1990 10:10:10 GMT'}
+  ${632059994}  | ${'Thu, 11 Jan 1990 12:13:14 GMT'}
+  ${982873840}  | ${'Thu, 22 Feb 2001 20:30:40 GMT'}
+  ${985304085}  | ${'Thu, 22 Mar 2001 23:34:45 GMT'}
+  ${988004327}  | ${'Mon, 23 Apr 2001 05:38:47 GMT'}
+  ${991265551}  | ${'Wed, 30 May 2001 23:32:31 GMT'}
+  ${991952480}  | ${'Thu, 07 Jun 2001 22:21:20 GMT'}
+  ${994622399}  | ${'Sun, 08 Jul 2001 19:59:59 GMT'}
+  ${998113621}  | ${'Sat, 18 Aug 2001 05:47:01 GMT'}
+  ${1001652489} | ${'Fri, 28 Sep 2001 04:48:09 GMT'}
+  ${1004527353} | ${'Wed, 31 Oct 2001 11:22:33 GMT'}
+  ${1004577804} | ${'Thu, 01 Nov 2001 01:23:24 GMT'}
+  ${1007885236} | ${'Sun, 09 Dec 2001 08:07:16 GMT'}
+  `('with ($atSecs)', ({ atSecs, expected }) => {
     const result = isStatic
       ? Moment[method](atSecs)
       : new Moment(atSecs)[method]();

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -119,6 +119,20 @@ export class Cookies {
   }
 
   /**
+   * Gets an array-like iterator of `Set-Cookie` response header strings, one
+   * per entry in this instance. This is equivalent to applying {@link
+   * #responseHeaderFrom} to each set of attributes yielded from {@link
+   * #attributeSets}.
+   *
+   * @yields {string} A `Set-Cookie` header string.
+   */
+  *responseHeaders() {
+    for (const attrib of this.attributeSets()) {
+      yield Cookies.responseHeaderFrom(attrib);
+    }
+  }
+
+  /**
    * Adds or replaces a cookie.
    *
    * **Note:** The `attributes` object, if present, is copied, so that clients

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -279,7 +279,7 @@ export class Cookies {
     }
 
     if (expires !== undefined) {
-      result.push('; Expires=', expires.toHttpDateString());
+      result.push('; Expires=', expires.toHttpString());
     }
 
     if (httpOnly) {
@@ -304,6 +304,10 @@ export class Cookies {
       result.push('; SameSite=',
         sameSite.charAt(0).toUpperCase(),
         sameSite.slice(1));
+    }
+
+    if (secure) {
+      result.push('; Secure');
     }
 
     return result.join('');

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -257,6 +257,59 @@ export class Cookies {
   }
 
   /**
+   * Converts an "attributes" object as returned by this class (which includes
+   * `name` and `value`) into a `Set-Cookie` response header value string.
+   *
+   * @param {object} attributes The attributes.
+   * @returns {string} The corresponding header value string.
+   */
+  static responseHeaderFrom(attributes) {
+    const {
+      domain, expires, httpOnly, maxAge, name,
+      partitioned, path, sameSite, secure, value
+    } = attributes;
+
+    const encode = encodeURIComponent;
+
+    const result = [name, '=', encode(value)
+    ];
+
+    if (domain !== undefined) {
+      result.push('; Domain=', encode(domain));
+    }
+
+    if (expires !== undefined) {
+      result.push('; Expires=', expires.toHttpDateString());
+    }
+
+    if (httpOnly) {
+      result.push('; HttpOnly');
+    }
+
+    if (maxAge) {
+      result.push('; Max-Age=', maxAge.secs);
+    }
+
+    if (partitioned) {
+      result.push('; Partitioned');
+    }
+
+    if (path !== undefined) {
+      result.push('; Path=', encodeURI(path));
+    }
+
+    if (sameSite !== undefined) {
+      // `attributes` represents the values as lower case, but the spec wants
+      // them capitalized.
+      result.push('; SameSite=',
+        sameSite.charAt(0).toUpperCase(),
+        sameSite.slice(1));
+    }
+
+    return result.join('');
+  }
+
+  /**
    * Validates a cookie attributes object.
    *
    * @param {object} attributes The attributes.
@@ -292,7 +345,7 @@ export class Cookies {
         }
 
         case 'sameSite': {
-          MustBe.string(value, /^(strict|lax|none)$/);
+          MustBe.string(value, /^(lax|none|strict)$/);
           break;
         }
 

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -287,7 +287,7 @@ export class Cookies {
     }
 
     if (maxAge) {
-      result.push('; Max-Age=', maxAge.secs);
+      result.push('; Max-Age=', Math.trunc(maxAge.secs));
     }
 
     if (partitioned) {

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -219,9 +219,9 @@ export class Cookies {
 
   /**
    * Parses a `Cookie` header, and constructs an instance based on the contents.
-   * Cookie values are interpreted using the global function
-   * `decodeURIComponent()`; if that function reports an error, then the
-   * corresponding cookie is not included in the result.
+   * Cookie values are interpreted using the global function `decodeURI()`; if
+   * that function reports an error, then the corresponding cookie is not
+   * included in the result.
    *
    * This method takes a strict view of what is valid syntax for a cookie
    * assignment (including allowed characters), but it is lenient with respect
@@ -241,7 +241,7 @@ export class Cookies {
       const value = value1 ?? value2;
 
       try {
-        const decoded = decodeURIComponent(value);
+        const decoded = decodeURI(value);
 
         if (!result) {
           result = new Cookies();
@@ -269,10 +269,9 @@ export class Cookies {
       partitioned, path, sameSite, secure, value
     } = attributes;
 
-    const encode = encodeURIComponent;
+    const encode = encodeURI;
 
-    const result = [name, '=', encode(value)
-    ];
+    const result = [name, '=', encode(value)];
 
     if (domain !== undefined) {
       result.push('; Domain=', encode(domain));
@@ -295,7 +294,7 @@ export class Cookies {
     }
 
     if (path !== undefined) {
-      result.push('; Path=', encodeURI(path));
+      result.push('; Path=', encode(path));
     }
 
     if (sameSite !== undefined) {

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { Duration, Moment } from '@this/data-values';
 import { Cookies } from '@this/net-util';
 
 
@@ -555,6 +556,78 @@ describe('responseHeaderFrom()', () => {
     value: 'florp!'
   }}
   ${'blort=florp!'}
+  --
+  ${{
+    name:   'a',
+    value:  'b',
+    domain: 'beep.boop'
+  }}
+  ${'a=b; Domain=beep.boop'}
+  --
+  ${{
+    name:    'a',
+    value:   'b',
+    expires: Moment.fromMsec(Date.UTC(2020, 0, 1, 2, 3, 4))
+  }}
+  ${'a=b; Expires=Wed, 01 Jan 2020 02:03:04 GMT'}
+  --
+  ${{
+    name:     'a',
+    value:    'b',
+    httpOnly: true
+  }}
+  ${'a=b; HttpOnly'}
+  --
+  ${{
+    name:  'a',
+    value: 'b',
+    maxAge: new Duration(12345)
+  }}
+  ${'a=b; Max-Age=12345'}
+  --
+  ${{
+    name:  'a',
+    value: 'b',
+    maxAge: new Duration(12.987)
+  }}
+  ${'a=b; Max-Age=12'}
+  --
+  ${{
+    name:        'a',
+    value:       'b',
+    partitioned: true
+  }}
+  ${'a=b; Partitioned'}
+  --
+  ${{
+    name:  'a',
+    value: 'b',
+    path:  '/beep/boop'
+  }}
+  ${'a=b; Path=/beep/boop'}
+  --
+  ${{
+    name:     'a',
+    value:    'b',
+    sameSite: 'strict'
+  }}
+  ${'a=b; SameSite=Strict'}
+  --
+  ${{
+    name:   'a',
+    value:  'b',
+    secure: true
+  }}
+  ${'a=b; Secure'}
+  --
+  ${{
+    name:     'a',
+    value:    'b',
+    // This is a standard combo.
+    sameSite: 'none',
+    secure:   true
+  }}
+  ${'a=b; SameSite=None; Secure'}
   `('works for: $attribs', ({ attribs, expected }) => {
     expect(Cookies.responseHeaderFrom(attribs)).toBe(expected);
   });

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -515,7 +515,7 @@ describe('parse()', () => {
   test('decodes a syntactically correct quoted value', () => {
     const name    = 'yah';
     const value   = '!@#$%^&*()\u{27a1}\u{1f723}';
-    const encVal  = encodeURIComponent(value);
+    const encVal  = encodeURI(value);
     const cookies = Cookies.parse(`${name}="${encVal}"`);
 
     expect([...cookies]).toEqual([[name, value]]);

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -539,3 +539,23 @@ describe('parse()', () => {
       [[name1, value1], [name2, value2]]);
   });
 });
+
+describe('responseHeaderFrom()', () => {
+  test.each`
+  attribs | expected
+  --
+  ${{
+    name:  'x',
+    value: 'y'
+  }}
+  ${'x=y'}
+  --
+  ${{
+    name: 'blort',
+    value: 'florp!'
+  }}
+  ${'blort=florp!'}
+  `('works for: $attribs', ({ attribs, expected }) => {
+    expect(Cookies.responseHeaderFrom(attribs)).toBe(expected);
+  });
+});

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -553,9 +553,15 @@ describe('responseHeaderFrom()', () => {
   --
   ${{
     name: 'blort',
-    value: 'florp!'
+    value: 'beep/florp!'
   }}
-  ${'blort=florp!'}
+  ${'blort=beep/florp!'}
+  --
+  ${{
+    name: 'blort',
+    value: 'a b c'
+  }}
+  ${'blort=a%20b%20c'}
   --
   ${{
     name:   'a',
@@ -628,6 +634,24 @@ describe('responseHeaderFrom()', () => {
     secure:   true
   }}
   ${'a=b; SameSite=None; Secure'}
+  --
+  ${{
+    name:        'a',
+    value:       'b',
+    domain:      'zip.zap.zoop',
+    expires:     Moment.fromMsec(Date.UTC(2069, 8, 7, 6, 55, 44)),
+    httpOnly:    true,
+    maxAge:      new Duration(987654321),
+    partitioned: true,
+    path:        '/a/bb/ccc',
+    sameSite:    'lax',
+    secure:      true
+  }}
+  ${
+    'a=b; Domain=zip.zap.zoop; Expires=Sat, 07 Sep 2069 06:55:44 GMT; ' +
+    'HttpOnly; Max-Age=987654321; Partitioned; Path=/a/bb/ccc; SameSite=Lax; ' +
+    'Secure'
+  }
   `('works for: $attribs', ({ attribs, expected }) => {
     expect(Cookies.responseHeaderFrom(attribs)).toBe(expected);
   });


### PR DESCRIPTION
This PR finishes up the implementation in `Cookies` for handling and generating `Set-Cookie` response headers. This included doing a bit of work in `Moment` to get it to generate the right date format.