### PR TITLE
Send cookies… after a lot of infrastructure work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Breaking changes:
   part of the `options`.
 
 Other notable changes:
-* Added support for incoming cookies.
+* Added support for sending and receiving cookies.
 * Fixed `Range` request edge cases.
+* Expanded the `net-util` package with a bunch of HTTP-related stuff.
 * Notice promptly when clients drop connections, instead of letting them time
   out (and end up getting a write-after-close error).
 * Cleaned up the request logging code, including details of what lands in the

--- a/src/net-util/export/HeaderNames.js
+++ b/src/net-util/export/HeaderNames.js
@@ -1,0 +1,111 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+
+/**
+ * Utility class for canonicalization of HTTP(ish) header names.
+ */
+export class HeaderNames {
+  /**
+   * @type {Map<string, string>} Mapping from arbitrarily-cased header names to
+   * their modern (downcased) versions. Seeded proactively and then lazily
+   * accumulated.
+   */
+  static #ANY_TO_MODERN = new Map();
+
+  /**
+   * @type {Map<string, string>} Mapping from arbitrarily-cased header names to
+   * their classic version (mostly capitalized though with some exceptions).
+   * Seeded proactively and then lazily accumulated.
+   */
+  static #ANY_TO_CLASSIC = new Map();
+
+  static {
+    const add = (classic) => {
+      const modern = classic.toLowerCase();
+      this.#ANY_TO_MODERN.set(classic, modern);
+      this.#ANY_TO_MODERN.set(modern, modern);
+      this.#ANY_TO_CLASSIC.set(modern, classic);
+      this.#ANY_TO_CLASSIC.set(classic, classic);
+    };
+
+    add('Accept-Ranges');
+    add('Cache-Control');
+    add('Connection');
+    add('Content-Length');
+    add('Content-Type');
+    add('Cookie');
+    add('Date');
+    add('ETag');
+    add('Keep-Alive');
+    add('Last-Modified');
+    add('Location');
+    add('Server');
+    add('Set-Cookie');
+  }
+
+  /**
+   * Given a header name in any casing, return the classic casing. Classic
+   * casing is _mostly_ capitalized at dashes, but `ETag` is a notable
+   * exception.
+   *
+   * **Note:** This implementation does not know about all the exceptions. If
+   * there is an exception which, in practice, is common enough to worry about,
+   * this class can (and should) be updated. That said, because headers are
+   * case-ignored, missing cases are not expected to cause actual problems
+   * (beyond mild developer annoyance).
+   *
+   * @param {string} orig The original header name.
+   * @returns {string} The modern casing for same.
+   */
+  static classicFrom(orig) {
+    const already = this.#ANY_TO_CLASSIC.get(orig);
+
+    if (already) {
+      return already;
+    }
+
+    // If it's an exception, it will be in the `ANY_TO_CLASSIC` table, mapped
+    // from the modern version. So we check that first before manually
+    // transforming the string.
+    const modern   = this.modernFrom(orig);
+    const already2 = this.#ANY_TO_CLASSIC.get(modern);
+
+    if (already2) {
+      return already2;
+    }
+
+    const chars = [...modern];
+
+    for (let i = 0; i < chars.length; i++) {
+      if ((i === 0) || (chars[i - 1] === '-')) {
+        chars[i] = chars[i].toUpperCase();
+      }
+    }
+
+    const result = chars.join('');
+
+    this.#ANY_TO_CLASSIC.set(orig, result);
+
+    return result;
+  }
+
+  /**
+   * Given a header name in any casing, return the canonical modern casing,
+   * which is to say fully downcased.
+   *
+   * @param {string} orig The original header name.
+   * @returns {string} The modern casing for same.
+   */
+  static modernFrom(orig) {
+    const already = this.#ANY_TO_MODERN.get(orig);
+
+    if (already) {
+      return already;
+    } else {
+      const result = orig.toLowerCase();
+      this.#ANY_TO_MODERN.set(orig, result);
+      return result;
+    }
+  }
+}

--- a/src/net-util/export/HttpHeaders.js
+++ b/src/net-util/export/HttpHeaders.js
@@ -58,6 +58,17 @@ export class HttpHeaders extends Headers {
   }
 
   /**
+   * Appends all of the given cookies as `Set-Cookie` headers.
+   *
+   * @param {Cookies} cookies Cookies to append.
+   */
+  appendSetCookie(cookies) {
+    for (const cookie of cookies.responseHeaders()) {
+      this.append('set-cookie', cookie);
+    }
+  }
+
+  /**
    * Like the default `entries()` method, except alters names to be cased
    * appropriately for the indicated HTTP version. In addition, most values
    * returned are strings, but `Set-Cookie` values are always arrays of strings.

--- a/src/net-util/export/HttpHeaders.js
+++ b/src/net-util/export/HttpHeaders.js
@@ -79,7 +79,7 @@ export class HttpHeaders extends Headers {
         }
       } else {
         const got = this.get(modName);
-        if (got !== undefined) {
+        if (got !== null) {
           result[n] = got;
         }
       }

--- a/src/net-util/export/HttpHeaders.js
+++ b/src/net-util/export/HttpHeaders.js
@@ -1,0 +1,90 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { HeaderNames } from '#x/HeaderNames';
+
+
+/**
+ * Subclass of the standard global class `Headers`, with extra functionality
+ * found to be useful in practice.
+ */
+export class HttpHeaders extends Headers {
+  /**
+   * Constructs an instance.
+   *
+   * @param {?Headers|Map|object} [other] Initial source of entries. This is
+   *   allowed to be anything that implements a map-like iterator, or a plain
+   *   object.
+   */
+  constructor(other = null) {
+    super();
+
+    // Note: We don't use the default constructor's ability to initialize from
+    // an argument because it does the wrong thing with non-`Headers` objects
+    // with array-valued names. (Specifically, it joins them with `,` and not
+    // `, `; that is, it doesn't include a space.)
+
+    if (other) {
+      this.appendAll(other);
+    }
+  }
+
+  /**
+   * Appends all of the entries in the given other value to this one. In the
+   * case of a plain object, this appends its enumerable property values.
+   *
+   * @param {Headers|Map|object} other Source of entries to append. This is
+   *   allowed to be anything that implements a map-like iterator, or a plain
+   *   object.
+   */
+  appendAll(other) {
+    const iterator = other[Symbol.iterator]
+      ? other[Symbol.iterator]() // Use the defined iterator.
+      : Object.entries(other);   // Treat it as a plain object.
+
+    for (const [name, value] of iterator) {
+      if (((typeof value) === 'object') && (value !== null)) {
+        if (Array.isArray(value)) {
+          for (const v of value) {
+            this.append(name, v);
+          }
+        } else {
+          throw new Error(`Strange header value: ${value}`);
+        }
+      } else {
+        this.append(name, `${value}`);
+      }
+    }
+  }
+
+  /**
+   * Extracts a subset of the headers. Names which aren't found are not listed
+   * in the result, and don't cause an error. Extracted values are always
+   * simple (pre-combined) strings, except for `Set-Cookies`, which is always
+   * an array.
+   *
+   * @param {...string} names Names of headers to extract.
+   * @returns {object} The extracted subset, as a mapping from the given `names`
+   *   to their values.
+   */
+  extract(...names) {
+    const result = {};
+
+    for (const n of names) {
+      const modName = HeaderNames.modernFrom(n);
+      if (modName === 'set-cookie') {
+        const cookies = this.getSetCookie();
+        if (cookies.length !== 0) {
+          result[n] = cookies;
+        }
+      } else {
+        const got = this.get(modName);
+        if (got !== undefined) {
+          result[n] = got;
+        }
+      }
+    }
+
+    return result;
+  }
+}

--- a/src/net-util/export/HttpHeaders.js
+++ b/src/net-util/export/HttpHeaders.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { Cookies } from '#x/Cookies';
 import { HeaderNames } from '#x/HeaderNames';
 
 

--- a/src/net-util/index.js
+++ b/src/net-util/index.js
@@ -4,5 +4,6 @@
 export * from '#x/Cookies';
 export * from '#x/HeaderNames';
 export * from '#x/HostInfo';
+export * from '#x/HttpHeaders';
 export * from '#x/MimeTypes';
 export * from '#x/Uris';

--- a/src/net-util/index.js
+++ b/src/net-util/index.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '#x/Cookies';
+export * from '#x/HeaderNames';
 export * from '#x/HostInfo';
 export * from '#x/MimeTypes';
 export * from '#x/Uris';

--- a/src/net-util/tests/HeaderNames.test.js
+++ b/src/net-util/tests/HeaderNames.test.js
@@ -1,0 +1,39 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { HeaderNames } from '@this/net-util';
+
+
+describe('modernFrom()', () => {
+  test.each`
+  arg                | expected
+  ${'Cache-Control'} | ${'cache-control'}
+  ${'cache-control'} | ${'cache-control'}
+  ${'cacHE-COntroL'} | ${'cache-control'}
+  ${'ETag'}          | ${'etag'}
+  ${'etag'}          | ${'etag'}
+  ${'ETAG'}          | ${'etag'}
+  ${'Beep-Boop-Bop'} | ${'beep-boop-bop'} // This one should get "synthesized."
+  ${'beep-boop-bop'} | ${'beep-boop-bop'}
+  ${'beep-BOOP-bop'} | ${'beep-boop-bop'}
+  `('returns $expected for $arg', ({ arg, expected }) => {
+    expect(HeaderNames.modernFrom(arg)).toBe(expected);
+  });
+});
+
+describe('classicFrom()', () => {
+  test.each`
+  arg                | expected
+  ${'Cache-Control'} | ${'Cache-Control'}
+  ${'cache-control'} | ${'Cache-Control'}
+  ${'cacHE-COntroL'} | ${'Cache-Control'}
+  ${'ETag'}          | ${'ETag'}
+  ${'etag'}          | ${'ETag'}
+  ${'ETAG'}          | ${'ETag'}
+  ${'Beep-Boop-Bop'} | ${'Beep-Boop-Bop'} // This one should get "synthesized."
+  ${'beep-boop-bop'} | ${'Beep-Boop-Bop'}
+  ${'beep-BOOP-bop'} | ${'Beep-Boop-Bop'}
+  `('returns $expected for $arg', ({ arg, expected }) => {
+    expect(HeaderNames.classicFrom(arg)).toBe(expected);
+  });
+});

--- a/src/net-util/tests/HttpHeaders.test.js
+++ b/src/net-util/tests/HttpHeaders.test.js
@@ -1,0 +1,154 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { HttpHeaders } from '@this/net-util';
+
+describe('constructor', () => {
+  describe('given no arguments', () => {
+    test('doesn\'t throw', () => {
+      expect(() => new HttpHeaders()).not.toThrow();
+    });
+
+    test('constructs a subclass of `Headers`', () => {
+      expect(new HttpHeaders()).toBeInstanceOf(Headers);
+    });
+
+    test('has no entries', () => {
+      const hh = new HttpHeaders();
+      expect([...hh]).toEqual([]);
+    });
+  });
+});
+
+describe.each`
+label            | constructor
+${'constructor'} | ${true}
+${'appendAll()'} | ${false}
+`('$label', ({ constructor }) => {
+  function prep(arg) {
+    if (constructor) {
+      return new HttpHeaders(arg);
+    } else {
+      const hh = new HttpHeaders();
+      hh.appendAll(arg);
+      return hh;
+    }
+  }
+
+  const aPlainObj1 = { foo: 'bar', 'florp': ['um', 'yeah'] };
+  const aMap1      = new Map([['foo', 'bar'], ['florp', 'um, yeah']]);
+  const aHeaders1  = new Headers();
+  const anotherHH1 = new HttpHeaders();
+
+  aHeaders1.append('foo', 'bar');
+  aHeaders1.append('florp', 'um');
+  aHeaders1.append('florp', 'yeah');
+
+  anotherHH1.append('foo', 'bar');
+  anotherHH1.append('florp', 'um');
+  anotherHH1.append('florp', 'yeah');
+
+  const aPlainObj2 = { 'set-cookie': ['x=1', 'y=2'] };
+  const aMap2      = new Map([['set-cookie', ['x=1', 'y=2']]]);
+  const aHeaders2  = new Headers();
+  const anotherHH2 = new HttpHeaders();
+
+  aHeaders2.append('set-cookie', 'x=1');
+  aHeaders2.append('set-cookie', 'y=2');
+
+  anotherHH2.append('set-cookie', 'x=1');
+  anotherHH2.append('set-cookie', 'y=2');
+
+  describe.each`
+  label                      | arg1          | arg2
+  ${'a plain object'}        | ${aPlainObj1} | ${aPlainObj2}
+  ${'a Map'}                 | ${aMap1}      | ${aMap2}
+  ${'a `Headers` per se'}    | ${aHeaders1}  | ${aHeaders2}
+  ${'another `HttpHeaders`'} | ${anotherHH1} | ${anotherHH2}
+  `('given $label', ({ arg1, arg2 }) => {
+    test('includes its elements', () => {
+      const hh = prep(arg1);
+      expect([...hh]).toIncludeSameMembers([['foo', 'bar'], ['florp', 'um, yeah']]);
+    });
+
+    test('works given multiple `set-cookie`s', () => {
+      const hh = prep(arg2);
+      expect([...hh]).toEqual([['set-cookie', 'x=1'], ['set-cookie', 'y=2']]);
+      expect(hh.getSetCookie()).toIncludeSameMembers(['x=1', 'y=2']);
+    });
+  });
+});
+
+describe('appendAll()', () => {
+  test('sets a non-existent name to a single given value', () => {
+    const hh = new HttpHeaders();
+
+    hh.set('a', 'b');
+    hh.appendAll({ 'x': 'y' });
+
+    expect([...hh]).toIncludeSameMembers([['a', 'b'], ['x', 'y']]);
+  });
+
+  test('sets a non-existent name to multiple given values', () => {
+    const hh = new HttpHeaders();
+
+    hh.set('a', 'b');
+    hh.appendAll({ 'x': ['y', 'z'] });
+
+    expect([...hh]).toIncludeSameMembers([['a', 'b'], ['x', 'y, z']]);
+  });
+
+  test('appends a single value to a pre-existing name', () => {
+    const hh = new HttpHeaders();
+
+    hh.set('a', 'b');
+    hh.set('x', 'y');
+    hh.appendAll({ 'x': 'z' });
+
+    expect([...hh]).toIncludeSameMembers([['a', 'b'], ['x', 'y, z']]);
+  });
+
+  test('appends multiple values to a pre-existing name', () => {
+    const hh = new HttpHeaders();
+
+    hh.set('a', 'b');
+    hh.set('x', 'y');
+    hh.append('x', 'z');
+    hh.appendAll({ 'x': ['z1', 'z2'] });
+
+    expect([...hh]).toIncludeSameMembers([
+      ['a', 'b'], ['x', 'y, z, z1, z2']
+    ]);
+  });
+
+  test('appends multiple `set-cookies` from a plain object', () => {
+    const hh = new HttpHeaders();
+
+    hh.set('set-cookie', 'a=1');
+    hh.appendAll({ 'set-cookie': ['b=2', 'c=3'] });
+
+    expect([...hh]).toIncludeSameMembers([
+      ['set-cookie', 'a=1'],
+      ['set-cookie', 'b=2'],
+      ['set-cookie', 'c=3']
+    ]);
+  });
+
+  test('appends multiple `set-cookies` from a `Headers`', () => {
+    const hh = new HttpHeaders();
+    const orig = new Headers();
+
+    hh.set('set-cookie', 'a=1');
+    orig.append('set-cookie', 'b=2');
+    orig.append('set-cookie', 'c=3');
+    hh.appendAll(orig);
+
+    expect([...hh]).toIncludeSameMembers([
+      ['set-cookie', 'a=1'],
+      ['set-cookie', 'b=2'],
+      ['set-cookie', 'c=3']
+    ]);
+  });
+});
+
+// TODO: `extract()`

--- a/src/net-util/tests/HttpHeaders.test.js
+++ b/src/net-util/tests/HttpHeaders.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { HttpHeaders } from '@this/net-util';
+import { Cookies, HttpHeaders } from '@this/net-util';
 
 describe('constructor', () => {
   describe('given no arguments', () => {
@@ -147,6 +147,32 @@ describe('appendAll()', () => {
       ['set-cookie', 'a=1'],
       ['set-cookie', 'b=2'],
       ['set-cookie', 'c=3']
+    ]);
+  });
+});
+
+describe('appendSetCookie()', () => {
+  test('appends a single cookie', () => {
+    const cookies = new Cookies();
+    const hh      = new HttpHeaders();
+
+    cookies.set('beep', 'boop', { httpOnly: true });
+    hh.appendSetCookie(cookies);
+
+    expect([...hh]).toEqual([['set-cookie', 'beep=boop; HttpOnly']]);
+  });
+
+  test('appends two cookies', () => {
+    const cookies = new Cookies();
+    const hh      = new HttpHeaders();
+
+    cookies.set('beep', 'boop', { httpOnly: true });
+    cookies.set('fleep', 'floop', { secure: true });
+    hh.appendSetCookie(cookies);
+
+    expect([...hh]).toIncludeSameMembers([
+      ['set-cookie', 'beep=boop; HttpOnly'],
+      ['set-cookie', 'fleep=floop; Secure']
     ]);
   });
 });

--- a/src/net-util/tests/HttpHeaders.test.js
+++ b/src/net-util/tests/HttpHeaders.test.js
@@ -151,6 +151,36 @@ describe('appendAll()', () => {
   });
 });
 
+describe('entriesForVersion()', () => {
+  test('works for version 1 (smoke test)', () => {
+    const hh = new HttpHeaders({
+      'beep-BOOP':  ['10', '20'],
+      'EtAg':       '"zonk"',
+      'SET-cookie': ['a=123', 'b=456']
+    });
+
+    expect([...(hh.entriesForVersion('1.1'))]).toIncludeSameMembers([
+      ['Beep-Boop',  '10, 20'],
+      ['ETag',       '"zonk"'],
+      ['Set-Cookie', ['a=123', 'b=456']]
+    ]);
+  });
+
+  test('works for version 2 (smoke test)', () => {
+    const hh = new HttpHeaders({
+      'beep-BOOP':  ['10', '20'],
+      'EtAg':       '"zonk"',
+      'SET-cookie': ['a=123', 'b=456']
+    });
+
+    expect([...(hh.entriesForVersion('2.0'))]).toIncludeSameMembers([
+      ['beep-boop',  '10, 20'],
+      ['etag',       '"zonk"'],
+      ['set-cookie', ['a=123', 'b=456']]
+    ]);
+  });
+});
+
 describe('extract()', () => {
   test('tolerates all not-found names', () => {
     const hh = new HttpHeaders();

--- a/src/net-util/tests/HttpHeaders.test.js
+++ b/src/net-util/tests/HttpHeaders.test.js
@@ -247,9 +247,11 @@ describe('extract()', () => {
     hh.set('FOO', 'bar');
     hh.set('SET-COOKIE', 'a=b');
 
-    expect(hh.extract('Set-Cookie', 'Foo')).toEqual({
+    expect(hh.extract('Set-Cookie', 'Foo', 'foo', 'FOO')).toEqual({
       'Set-Cookie': ['a=b'],
-      'Foo': 'bar'
+      'Foo': 'bar',
+      'foo': 'bar',
+      'FOO': 'bar'
     });
   });
 });

--- a/src/net-util/tests/HttpHeaders.test.js
+++ b/src/net-util/tests/HttpHeaders.test.js
@@ -151,4 +151,49 @@ describe('appendAll()', () => {
   });
 });
 
-// TODO: `extract()`
+describe('extract()', () => {
+  test('tolerates all not-found names', () => {
+    const hh = new HttpHeaders();
+
+    hh.set('foo', 'bar');
+
+    expect(hh.extract('a', 'b', 'zzz')).toEqual({});
+  });
+
+  test('tolerates some but not all not-found names', () => {
+    const hh = new HttpHeaders();
+
+    hh.set('foo', 'bar');
+
+    expect(hh.extract('a', 'foo', 'b')).toEqual({ foo: 'bar' });
+  });
+
+  test('extracts a single `set-cookies` as an array', () => {
+    const hh = new HttpHeaders();
+
+    hh.set('set-cookie', 'a=b');
+
+    expect(hh.extract('set-cookie')).toEqual({ 'set-cookie': ['a=b'] });
+  });
+
+  test('extracts multiple `set-cookies` as an array', () => {
+    const hh = new HttpHeaders();
+
+    hh.set('set-cookie', 'a=b');
+    hh.append('set-cookie', 'c=d');
+
+    expect(hh.extract('set-cookie')).toEqual({ 'set-cookie': ['a=b', 'c=d'] });
+  });
+
+  test('preserves case of extracted result', () => {
+    const hh = new HttpHeaders();
+
+    hh.set('FOO', 'bar');
+    hh.set('SET-COOKIE', 'a=b');
+
+    expect(hh.extract('Set-Cookie', 'Foo')).toEqual({
+      'Set-Cookie': ['a=b'],
+      'Foo': 'bar'
+    });
+  });
+});

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -1025,10 +1025,12 @@ export class Request {
   /**
    * Gets a `Cache-Control` header for the given max-age.
    *
-   * @param {number} maxAgeMsec The max age, for cache control.
+   * @param {?number} [maxAgeMsec] The max age, for cache control, or `null` for
+   *   the default value of `0`.
    * @returns {string} The corresponding header.
    */
-  static #cacheControlHeader(maxAgeMsec) {
+  static #cacheControlHeader(maxAgeMsec = null) {
+    maxAgeMsec ??= 0;
     return `public, max-age=${Math.floor(maxAgeMsec / 1000)}`;
   }
 

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -14,7 +14,7 @@ import statuses from 'statuses';
 import { ManualPromise } from '@this/async';
 import { TreePathKey } from '@this/collections';
 import { IntfLogger } from '@this/loggy';
-import { Cookies, HostInfo, MimeTypes } from '@this/net-util';
+import { Cookies, HeaderNames, HostInfo, MimeTypes } from '@this/net-util';
 import { AskIf, MustBe } from '@this/typey';
 
 import { WranglerContext } from '#x/WranglerContext';
@@ -1023,22 +1023,23 @@ export class Request {
     //   to send lowercased headers in HTTP1. TODO: We don't fix that issue here
     //   yet.
 
+    const classicNaming = (this.#expressRequest.httpVersion[0] === '1');
+
     let gotSetCookie = false;
     for (const [name, value] of headers) {
+      const finalName = classicNaming ? HeaderNames.classicFrom(name) : name;
       if (name === 'set-cookie') {
         // When iterating, a `Headers` object will emit multiple entries
         // with `set-cookie`. We use the first to trigger use of the
         // special `set-cookie` accessor and ignore subsequent ones.
         if (!gotSetCookie) {
           gotSetCookie = true;
-          res.setHeader(name, headers.getSetCookie());
+          res.setHeader(finalName, headers.getSetCookie());
         }
       } else {
-        res.setHeader(name, value);
+        res.setHeader(finalName, value);
       }
     }
-
-    this.#logger.SET_HEADERS(headers); // ####### TEMP
   }
 
 

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -501,9 +501,10 @@ export class Request {
     };
 
     if (this.isFreshWithRespectTo(finalHeaders)) {
-      res.status(304);
-      res.set(finalHeaders);
-      res.set(this.#rangeInfo().headers); // For basic range-support headers.
+      // For basic range-support headers.
+      Object.assign(finalHeaders, this.#rangeInfo().headers);
+
+      this.#writeHead(304, finalHeaders);
       res.end();
     } else {
       const rangeInfo = this.#rangeInfo(bodyBuffer.length, finalHeaders);
@@ -515,9 +516,7 @@ export class Request {
       }
 
       finalHeaders['Content-Length'] = bodyBuffer.length;
-      res.set(finalHeaders);
-
-      res.status(rangeInfo.status);
+      this.#writeHead(rangeInfo.status, finalHeaders);
       res.end(bodyBuffer);
     }
 

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -488,12 +488,12 @@ export class Request {
     MustBe.string(contentType);
     contentType = MimeTypes.typeFromExtensionOrType(contentType);
 
-    const { headers = null, maxAgeMsec = 0 } = options ?? {};
+    const { headers = null } = options ?? {};
     const res = this.#expressResponse;
 
     const finalHeaders = {
       ...(headers ?? {}),
-      'Cache-Control': Request.#cacheControlHeader(maxAgeMsec),
+      'Cache-Control': Request.#cacheControlHeader(options.maxAgeMsec),
       'Content-Type': (stringBody || /^text[/]/.test(contentType))
         ? `${contentType}; charset=utf-8`
         : contentType,
@@ -540,12 +540,12 @@ export class Request {
    * @throws {Error} Thrown if there is any trouble sending the response.
    */
   async sendNoBodyResponse(options = {}) {
-    const { headers = null, maxAgeMsec = 0 } = options ?? {};
+    const { headers = null } = options ?? {};
     const res = this.#expressResponse;
 
     const finalHeaders = {
       ...(headers ?? {}),
-      'Cache-Control': Request.#cacheControlHeader(maxAgeMsec)
+      'Cache-Control': Request.#cacheControlHeader(options.maxAgeMsec)
     };
 
     res.status(204);

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -922,7 +922,7 @@ export class Request {
           Request.#extractHeaders(responseHeaders, 'last-modified');
         const lmDate = Request.#parseDate(lastModified);
         const ifDate = Request.#parseDate(ifRange);
-        if (lmDate > ifDate) {
+        if ((lmDate === null) || (ifDate === null) || (lmDate > ifDate)) {
           return status200(); // _Not_ matched.
         }
       }

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -1104,9 +1104,7 @@ export class Request {
     const result = headers ? new HttpHeaders(headers) : new HttpHeaders();
 
     if (cookies) {
-      for (const cookie of cookies.responseHeaders()) {
-        result.append('set-cookie', cookie);
-      }
+      result.appendSetCookie(cookies);
     }
 
     for (const [name, func] of Object.entries(extras)) {

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -623,15 +623,17 @@ export class Request {
     // the code here (hopefully with a bit of DRYing out in the process).
 
     const doneMp = new ManualPromise();
-    const res    = this.#expressResponse;
 
     // In re `dotfiles`: If the caller wants to send a dotfile, that's their
     // business. (`sendFile()` by default tries to be something like a
     // "friendly" static file server, but we're lower level here.)
     const sendOpts = { dotfiles: 'allow' };
 
-    res.setHeaders(headers);
-    res.sendFile(path, sendOpts, (err) => {
+    // Note: `sendFile()` below will change the status code when appropriate,
+    // to respond to range and conditional requests.
+    this.#writeHead(200, headers);
+
+    this.#expressResponse.sendFile(path, sendOpts, (err) => {
       if (err instanceof Error) {
         doneMp.reject(err);
       } else if (err) {

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -452,6 +452,9 @@ export class Request {
    *   with `text/` and/or the `body` is passed as a string, then the actual
    *   `Content-Type` header will indicate a charset of `utf-8`.
    * @param {object} options Options to control response behavior.
+   * @param {?Cookies} [options.cookies] Cookies to include (via `Set-Cookie`
+   *   headers) in the response, if any. These are only included if the response
+   *   is successful.
    * @param {?object} [options.headers] Extra headers to include in the
    *   response, if any. These are only included if the response is successful.
    * @param {?number} [options.maxAgeMsec] Value to send back in the
@@ -527,6 +530,9 @@ export class Request {
    * #sendContent} with a zero-length body.
    *
    * @param {object} options Options to control response behavior.
+   * @param {?Cookies} [options.cookies] Cookies to include (via `Set-Cookie`
+   *   headers) in the response, if any. These are only included if the response
+   *   is successful.
    * @param {?object} [options.headers] Extra headers to include in the
    *   response, if any. These are only included if the response is successful.
    * @param {?number} [options.maxAgeMsec] Value to send back in the

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -38,6 +38,18 @@ import { WranglerContext } from '#x/WranglerContext';
  * behind a reverse proxy. That said, as of this writing there isn't anything
  * that actually does that. See
  * <https://github.com/danfuzz/lactoserv/issues/213>.
+ *
+ * #### `options` on `send*()` methods
+ *
+ * The `send*()` methods accept an `options` object argument, which accepts the
+ * following properties, which all affect only _successful_ responses (not ones
+ * reporting an error status).
+ *
+ * * `{?Cookies} cookies` -- Cookies to include (via `Set-Cookie` headers) in
+ *   the response, if any.
+ * * `{?object} headers` -- Extra headers to include in the response, if any.
+ * * `{?number} maxAgeMsec` -- Value to send back in the `max-age` property of
+ *   the `Cache-Control` response header. Defaults to `0`.
  */
 export class Request {
   /**
@@ -451,15 +463,8 @@ export class Request {
    * @param {string} contentType Content type for the body. If this value starts
    *   with `text/` and/or the `body` is passed as a string, then the actual
    *   `Content-Type` header will indicate a charset of `utf-8`.
-   * @param {object} options Options to control response behavior.
-   * @param {?Cookies} [options.cookies] Cookies to include (via `Set-Cookie`
-   *   headers) in the response, if any. These are only included if the response
-   *   is successful.
-   * @param {?object} [options.headers] Extra headers to include in the
-   *   response, if any. These are only included if the response is successful.
-   * @param {?number} [options.maxAgeMsec] Value to send back in the
-   *   `max-age` property of the `Cache-Control` response header. Defaults to
-   *   `0`.
+   * @param {object} options Options to control response behavior. See class
+   *   header comment for more details.
    * @returns {boolean} `true` when the response is completed.
    * @throws {Error} Thrown if there is any trouble sending the response.
    */
@@ -529,15 +534,8 @@ export class Request {
    * **Note:** What this method does is different than calling {@link
    * #sendContent} with a zero-length body.
    *
-   * @param {object} options Options to control response behavior.
-   * @param {?Cookies} [options.cookies] Cookies to include (via `Set-Cookie`
-   *   headers) in the response, if any. These are only included if the response
-   *   is successful.
-   * @param {?object} [options.headers] Extra headers to include in the
-   *   response, if any. These are only included if the response is successful.
-   * @param {?number} [options.maxAgeMsec] Value to send back in the
-   *   `max-age` property of the `Cache-Control` response header. Defaults to
-   *   `0`.
+   * @param {object} options Options to control response behavior. See class
+   *   header comment for more details.
    * @returns {boolean} `true` when the response is completed.
    * @throws {Error} Thrown if there is any trouble sending the response.
    */
@@ -590,12 +588,8 @@ export class Request {
    * sort of stuff should be handled _before_ calling this method.
    *
    * @param {string} path Absolute path to the file to send.
-   * @param {object} options Options to control response behavior.
-   * @param {?object} [options.headers] Extra headers to include in the
-   *   response, if any.
-   * @param {?number} [options.maxAgeMsec] Value to send back in the
-   *   `max-age` property of the `Cache-Control` response header. Defaults to
-   *   `0`.
+   * @param {object} options Options to control response behavior. See class
+   *   header comment for more details.
    * @returns {boolean} `true` when the response is completed.
    * @throws {Error} Thrown if there is any trouble sending the response.
    */

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -1023,7 +1023,7 @@ export class Request {
       const obj = headers;
       headers = new Headers();
       for (const [name, value] of Object.entries(obj)) {
-        if (typeof value === 'string') {
+        if (typeof value !== 'object') {
           headers.append(name, value);
         } else {
           for (const v of value) {

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -14,7 +14,8 @@ import statuses from 'statuses';
 import { ManualPromise } from '@this/async';
 import { TreePathKey } from '@this/collections';
 import { IntfLogger } from '@this/loggy';
-import { Cookies, HeaderNames, HostInfo, MimeTypes } from '@this/net-util';
+import { Cookies, HeaderNames, HostInfo, HttpHeaders, MimeTypes }
+  from '@this/net-util';
 import { AskIf, MustBe } from '@this/typey';
 
 import { WranglerContext } from '#x/WranglerContext';
@@ -49,7 +50,8 @@ import { WranglerContext } from '#x/WranglerContext';
  *   the response, if any.
  * * `{?object} headers` -- Extra headers to include in the response, if any.
  *   If specified, this can be any of the types accepted by the standard
- *   `Headers` constructor.
+ *   `Headers` constructor. Note that this system defines a useful `Headers`
+ *   subclass, {@link HttpHeaders}.
  * * `{?number} maxAgeMsec` -- Value to send back in the `max-age` property of
  *   the `Cache-Control` response header. Defaults to `0`.
  */

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -540,16 +540,14 @@ export class Request {
    */
   async sendNoBodyResponse(options = {}) {
     const { headers = null } = options ?? {};
-    const res = this.#expressResponse;
 
     const finalHeaders = {
       ...(headers ?? {}),
       'Cache-Control': Request.#cacheControlHeader(options.maxAgeMsec)
     };
 
-    res.status(204);
-    res.set(finalHeaders);
-    res.end();
+    this.#writeHead(204, finalHeaders);
+    this.#expressResponse.end();
 
     return this.whenResponseDone();
   }

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -1003,28 +1003,10 @@ export class Request {
    * shouldn't-be-differences between the concrete protocol implementations.
    *
    * @param {number} statusCode The HTTP(ish) status code.
-   * @param {?Headers|object} headers Response headers.
+   * @param {Headers} headers Response headers.
    */
-  #writeHead(statusCode, headers = null) {
+  #writeHead(statusCode, headers) {
     const res = this.#expressResponse;
-
-    if (headers === null) {
-      headers = new Headers();
-    } else if (!(headers instanceof Headers)) {
-      // We got a plain object. Make it into a `Headers` object. TODO: Remove
-      // this once we consistently use `Headers` objects in this class.
-      const obj = headers;
-      headers = new Headers();
-      for (const [name, value] of Object.entries(obj)) {
-        if (typeof value !== 'object') {
-          headers.append(name, value);
-        } else {
-          for (const v of value) {
-            headers.append(name, v);
-          }
-        }
-      }
-    }
 
     res.status(statusCode);
 

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -489,15 +489,15 @@ export class Request {
     contentType = MimeTypes.typeFromExtensionOrType(contentType);
 
     const headers = Request.#makeResponseHeaders(options, {
-      'Cache-Control': () => {
+      'cache-control': () => {
         return Request.#cacheControlHeader(options.maxAgeMsec);
       },
-      'Content-Type': () => {
+      'content-type': () => {
         return (stringBody || /^text[/]/.test(contentType))
           ? `${contentType}; charset=utf-8`
           : contentType;
       },
-      'ETag': () => {
+      'etag': () => {
         return etag(bodyBuffer);
       }
     });
@@ -518,7 +518,7 @@ export class Request {
         bodyBuffer = bodyBuffer.subarray(rangeInfo.start, rangeInfo.end);
       }
 
-      headers.set('Content-Length', bodyBuffer.length);
+      headers.set('content-length', bodyBuffer.length);
       this.#writeHead(rangeInfo.status, headers);
       res.end(bodyBuffer);
     }
@@ -543,7 +543,7 @@ export class Request {
    */
   async sendNoBodyResponse(options = {}) {
     const headers = Request.#makeResponseHeaders(options, {
-      'Cache-Control': () => {
+      'cache-control': () => {
         return Request.#cacheControlHeader(options.maxAgeMsec);
       }
     });
@@ -603,10 +603,10 @@ export class Request {
     }
 
     const headers = Request.#makeResponseHeaders(options, {
-      'Cache-Control': () => {
+      'cache-control': () => {
         return Request.#cacheControlHeader(options.maxAgeMsec);
       },
-      'Content-Type': () => {
+      'content-type': () => {
         return MimeTypes.typeFromExtension(path);
       }
     });
@@ -987,8 +987,8 @@ export class Request {
     }
 
     const headers = Request.#makeResponseHeaders(options, {
-      'Cache-Control': () => 'no-store, must-revalidate',
-      'Content-Type':  () => finalContentType
+      'cache-control': () => 'no-store, must-revalidate',
+      'content-type':  () => finalContentType
     });
 
     this.#writeHead(status, headers);
@@ -1105,7 +1105,7 @@ export class Request {
 
     if (cookies) {
       for (const cookie of cookies.responseHeaders()) {
-        result.append('Set-Cookie', cookie);
+        result.append('set-cookie', cookie);
       }
     }
 

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -991,17 +991,14 @@ export class Request {
       finalContentType = 'text/plain';
     }
 
-    const res = this.#expressResponse;
+    const finalHeaders = {
+      ...(headers ?? {}),
+      'Cache-Control': 'no-store, must-revalidate',
+      'Content-Type':  finalContentType
+    };
 
-    res.status(status);
-    res.contentType(finalContentType);
-
-    if (headers) {
-      res.set(headers);
-    }
-
-    res.set('Cache-Control', 'no-store, must-revalidate');
-    res.send(finalBody);
+    this.#writeHead(status, finalHeaders);
+    this.#expressResponse.send(finalBody);
 
     return this.whenResponseDone();
   }

--- a/src/network-protocol/private/Http2Wrangler.js
+++ b/src/network-protocol/private/Http2Wrangler.js
@@ -180,12 +180,14 @@ export class Http2Wrangler extends TcpWrangler {
       res.setHeaders = (headers) => {
         let gotSetCookie = false;
         for (const [name, value] of headers) {
-          if ((name === 'set-cookie') && !gotSetCookie) {
+          if (name === 'set-cookie') {
             // When iterating, a `Headers` object will emit multiple entries
             // with `set-cookie`. We use the first to trigger use of the
             // special `set-cookie` accessor and ignore subsequent ones.
-            gotSetCookie = true;
-            res.setHeader(name, headers.getSetCookie());
+            if (!gotSetCookie) {
+              gotSetCookie = true;
+              res.setHeader(name, headers.getSetCookie());
+            }
           } else {
             res.setHeader(name, value);
           }

--- a/src/network-protocol/private/Http2Wrangler.js
+++ b/src/network-protocol/private/Http2Wrangler.js
@@ -173,6 +173,26 @@ export class Http2Wrangler extends TcpWrangler {
       set: () => { /* Ignore it. */ }
     });
 
+    // As of Node 21, `http2.Http2ServerResponse` doesn't define `setHeaders()`,
+    // so provide one for it, here. TODO: Remove this once all versions we
+    // support have this method.
+    if (!res.setHeaders) {
+      res.setHeaders = (headers) => {
+        let gotSetCookie = false;
+        for (const [name, value] of headers) {
+          if ((name === 'set-cookie') && !gotSetCookie) {
+            // When iterating, a `Headers` object will emit multiple entries
+            // with `set-cookie`. We use the first to trigger use of the
+            // special `set-cookie` accessor and ignore subsequent ones.
+            gotSetCookie = true;
+            res.setHeader(name, headers.getSetCookie());
+          } else {
+            res.setHeader(name, value);
+          }
+        }
+      };
+    }
+
     next();
   }
 


### PR DESCRIPTION
The original point of this PR was to make it possible to send `Set-Cookies` headers. But to get there, I had to do a lot of work on the inner workings of `Request`, and I also ended up adding a bunch of new utilities to the `net-util` package.