### PR TITLE
Miscellaneous networking stuff, mostly in `Request`.

### DIFF
--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -388,7 +388,7 @@ export class ProtocolWrangler {
 
     this.#logHelper?.logRequest(request, context);
 
-    res.set('Server', this.#serverHeader);
+    res.setHeader('Server', this.#serverHeader);
 
     if (!request.pathnameString) {
       // It's not an `origin` request. We don't handle any other type of

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -79,6 +79,9 @@ export class Request {
   /** @type {ServerResponse|express.Response} HTTP(ish) response object. */
   #expressResponse;
 
+  /** @type {string} The request method, downcased. */
+  #requestMethod;
+
   /**
    * @type {HostInfo} The host header(ish) info, or `null` if not yet figured
    * out.
@@ -118,6 +121,7 @@ export class Request {
     // probably not worth it anyway).
     this.#expressRequest  = MustBe.object(request);
     this.#expressResponse = MustBe.object(response);
+    this.#requestMethod   = request.method.toLowerCase();
 
     if (logger) {
       this.#id     = logger.$meta.makeId();
@@ -221,7 +225,7 @@ export class Request {
    * one of `'get'`, `'head'`, or `'post'`.
    */
   get method() {
-    return this.#expressRequest.method.toLowerCase();
+    return this.#requestMethod;
   }
 
   /**
@@ -432,7 +436,7 @@ export class Request {
    * @returns {boolean} `true` iff the request is to be considered "fresh."
    */
   isFreshWithRespectTo(responseHeaders) {
-    const method = this.method;
+    const method = this.#requestMethod;
 
     if ((method !== 'head') && (method !== 'get')) {
       return false;
@@ -1055,7 +1059,7 @@ export class Request {
     if (body) {
       if ((status === 204) || (status === 205) || (status === 304)) {
         throw new Error(`Non-null body incompatible with status code: ${status}`);
-      } else if ((this.method === 'head') && (status === 200)) {
+      } else if ((this.#requestMethod === 'head') && (status === 200)) {
         throw new Error(`Non-null body incompatible with successful HEAD response.`);
       }
     }

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -521,8 +521,6 @@ export class Request {
       }
     });
 
-    const res = this.#expressResponse;
-
     if (this.isFreshWithRespectTo(headers)) {
       // For basic range-support headers.
       headers.appendAll(this.#rangeInfo().headers);
@@ -680,7 +678,6 @@ export class Request {
       }
     });
 
-    const res = this.#expressResponse;
     return this.#writeCompleteResponse(204, headers);
   }
 

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -1002,10 +1002,8 @@ export class Request {
       'content-type':  () => finalContentType
     });
 
-    this.#writeHead(status, headers);
-    this.#expressResponse.send(finalBody);
-
-    return this.whenResponseDone();
+    const bodyToSend = (this.method === 'head') ? null : finalBody;
+    return this.#writeCompleteResponse(status, headers, bodyToSend);
   }
 
   /**

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -1019,10 +1019,9 @@ export class Request {
     // * Calling it on a `Headers` object will cause it to fail to handle
     //   multiple `Set-Cookies` headers correctly. This is filed as Node issue
     //   #51599 <https://github.com/nodejs/node/issues/51599>.
-    // * When used on a HTTP1 server (that is not the HTTP2 protocol), it forces
-    //   header names to lower case. Though not against the spec, it is atypical
-    //   to send lowercased headers in HTTP1. TODO: We don't fix that issue here
-    //   yet.
+    // * When used on an HTTP1 server (that is not the HTTP2 protocol), it
+    //   forces header names to lower case. Though not against the spec, it is
+    //   atypical to send lowercased headers in HTTP1.
 
     const entries = headers.entriesForVersion(this.#expressRequest.httpVersion);
     for (const [name, value] of entries) {

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -683,8 +683,7 @@ export class Request {
     });
 
     const res = this.#expressResponse;
-    this.#writeHead(204, headers);
-    res.end();
+    this.#writeCompleteResponse(204, headers);
 
     return this.whenResponseDone();
   }

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -258,6 +258,10 @@ export class Request {
 
   /** @returns {string} The name of the protocol which spawned this instance. */
   get protocol() {
+    // Note: `.protocol` is an Express-specific property, and it's got a pretty
+    // ad-hoc definition, that we'd be better off improving upon. TODO: Do that!
+    // Specifically, every instance of this class effectively has an associated
+    // `ProtocolWrangler` instance, and that could expose a `protocolName`.
     return this.#expressRequest.protocol;
   }
 

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -1030,6 +1030,26 @@ export class Request {
     }
   }
 
+  /**
+   * Writes and finishes a response. This does not do anything to adjust the
+   * status code, headers, or body.
+   *
+   * @param {number} statusCode The HTTP(ish) status code.
+   * @param {HttpHeaders} headers Response headers.
+   * @param {?Buffer} [body] Body, or `null` not to include one in the response.
+   */
+  #writeCompleteResponse(statusCode, headers, body = null) {
+    const res = this.#expressResponse;
+
+    this.#writeHead(statusCode, headers);
+
+    if (body) {
+      res.end(body);
+    } else {
+      res.end();
+    }
+  }
+
 
   //
   // Static members

--- a/src/network-protocol/private/Http2Wrangler.js
+++ b/src/network-protocol/private/Http2Wrangler.js
@@ -173,28 +173,6 @@ export class Http2Wrangler extends TcpWrangler {
       set: () => { /* Ignore it. */ }
     });
 
-    // As of Node 21, `http2.Http2ServerResponse` doesn't define `setHeaders()`,
-    // so provide one for it, here. TODO: Remove this once all versions we
-    // support have this method.
-    if (!res.setHeaders) {
-      res.setHeaders = (headers) => {
-        let gotSetCookie = false;
-        for (const [name, value] of headers) {
-          if (name === 'set-cookie') {
-            // When iterating, a `Headers` object will emit multiple entries
-            // with `set-cookie`. We use the first to trigger use of the
-            // special `set-cookie` accessor and ignore subsequent ones.
-            if (!gotSetCookie) {
-              gotSetCookie = true;
-              res.setHeader(name, headers.getSetCookie());
-            }
-          } else {
-            res.setHeader(name, value);
-          }
-        }
-      };
-    }
-
     next();
   }
 

--- a/src/network-protocol/private/Http2Wrangler.js
+++ b/src/network-protocol/private/Http2Wrangler.js
@@ -48,7 +48,6 @@ export class Http2Wrangler extends TcpWrangler {
 
     // Express needs to be wrapped in order for it to use HTTP2.
     this.#application = http2ExpressBridge(express);
-    this.#application.use('/', (req, res, next) => this.#tweakResponse(req, res, next));
   }
 
   /** @override */
@@ -155,28 +154,6 @@ export class Http2Wrangler extends TcpWrangler {
   }
 
   /**
-   * Tweaks the response object of an incoming request. (Note: Actual high-level
-   * application dispatch happens in the base class.)
-   *
-   * @param {http2.Http2ServerRequest} req_unused The incoming request.
-   * @param {http2.Http2ServerResponse} res Response creator.
-   * @param {function(?*)} next Next-middleware function.
-   */
-  #tweakResponse(req_unused, res, next) {
-    // Express likes to set status messages, but HTTP2 doesn't actually have
-    // those. Node helpfully warns about that, but in practice this is just an
-    // artifact of Express wanting to not-rely on Node to get default status
-    // messages right. So, it's reasonable to squelch the problem with this
-    // somewhat grotty patch to the response object.
-    Object.defineProperty(res, 'statusMessage', {
-      get: () => '',
-      set: () => { /* Ignore it. */ }
-    });
-
-    next();
-  }
-
-  /**
    * Runs the high-level stack.
    */
   async #run() {
@@ -269,4 +246,18 @@ export class Http2Wrangler extends TcpWrangler {
    * before considering it "timed out" and telling it to close.
    */
   static #SESSION_TIMEOUT_MSEC = 1 * 60 * 1000; // One minute.
+
+  static {
+    // Various networking code (that we don't control) occasionally uses the
+    // `.statusMessage` setter, but HTTP2 doesn't actually have status messages,
+    // and Node "helpfully" warns about that. But in practice, the warnings are
+    // just an annoying reminder of dependencies that we can't in practice
+    // usefully tweak. So, it's reasonable to squelch the problem with this
+    // somewhat grotty patch.
+    const proto = http2.Http2ServerResponse.prototype;
+    Object.defineProperty(proto, 'statusMessage', {
+      get: () => '',
+      set: () => { /* Ignore it. */ }
+    });
+  }
 }


### PR DESCRIPTION
This PR is a grab-bag of networking code improvements and tweakage, including:

* Adding `#writeCompleteResponse()`, and using it in all the places that just used `#writeHead()` followed by `end()`.
* a bunch of work to avoid Express-isms.
