### PR TITLE
Allow FD interfaces to define what port they listen on.

### DIFF
--- a/src/net-util/tests/Uris.test.js
+++ b/src/net-util/tests/Uris.test.js
@@ -578,9 +578,14 @@ describe('parseInterface()', () => {
     expect(got).toStrictEqual({ address: '*', port: 17777 });
   });
 
-  test('parses an FD interface as expected', () => {
+  test('parses an FD interface with no port as expected', () => {
     const got = Uris.parseInterface('/dev/fd/109');
     expect(got).toStrictEqual({ fd: 109 });
+  });
+
+  test('parses an FD interface with port as expected', () => {
+    const got = Uris.parseInterface('/dev/fd/109:914');
+    expect(got).toStrictEqual({ fd: 109, port: 914 });
   });
 
   test('accepts the minimum and maximum allowed FD numbers', () => {

--- a/src/network-protocol/export/ProtocolWrangler.js
+++ b/src/network-protocol/export/ProtocolWrangler.js
@@ -142,9 +142,11 @@ export class ProtocolWrangler {
   }
 
   /**
-   * @returns {{ address: string, port: number }} The IP address and port of
-   * the interface which this instance listens on. This is always a frozen
-   * object.
+   * @returns {{ address: ?string, port: ?number, fd: ?number }} The IP address
+   * and port of the interface, _or_ the file descriptor, which this instance
+   * listens on. In the case of a file descriptor, `port` might be defined, in
+   * which case it is the "declared port" to report to clients, e.g. for
+   * logging.
    */
   get interface() {
     return this.#interfaceObject;

--- a/src/network-protocol/export/Request.js
+++ b/src/network-protocol/export/Request.js
@@ -193,6 +193,13 @@ export class Request {
    * @returns {HostInfo} Info about the `Host` header (or equivalent). If there
    * is no header (etc.), it is treated as if it were specified as just
    * `localhost`.
+   *
+   * The `port` of the returned object is as follows:
+   *
+   * * If the `Host` header has a port, use that.
+   * * If the connection has a "declared listening port," use that.
+   * * If the connection has a known listening port, use that.
+   * * Otherwise, use `0` for the port.
    */
   get host() {
     if (!this.#host) {


### PR DESCRIPTION
This PR allows FD interfaces to define what port they listen on. This is just for logging purposes.