### PR TITLE
Etag `dataOnly`

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -547,6 +547,10 @@ is absent or `false` (if allowed), no ETags are generated. If it is specified as
 configuration. If it is specified as an object with bindings, the following
 properties are recognized:
 
+* `dataOnly` &mdash; Boolean indicating whether _only_ entity data should be
+  used to generate tags, as opposed to using metadata such as file names and
+  modification times. When `true`, filesystem-based applications/services use
+  file data. When `false`, they use metadata. Defaults to `false`.
 * `hashAlgorithm` &mdash; Algorithm to use to generate hashes. Allowed to be
   `sha1`, `sha256`, or `sha512`. Defaults to `sha256`.
 * `hashLength` Number of characters to use from a generated hash when producing

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -129,7 +129,7 @@ const applications = [
     class:         'StaticFiles',
     siteDirectory: filePath('../site'),
     notFoundPath:  filePath('../site-extra/not-found.html'),
-    etag:          { hashLength: 20 }
+    etag:          { dataOnly: true, hashLength: 20 }
   },
   {
     name:          'myStaticFunNo404',

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -78,7 +78,7 @@ export class StaticFiles extends BaseApplication {
 
       if (this.#etagGenerator) {
         options.headers['etag'] =
-          await this.#etagGenerator.etagFromFileStats(resolved.path);
+          await this.#etagGenerator.etagFromFile(resolved.path);
       }
 
       return await request.sendFile(resolved.path, options);

--- a/src/net-util/export/EtagGenerator.js
+++ b/src/net-util/export/EtagGenerator.js
@@ -35,6 +35,10 @@ export class EtagGenerator {
    *
    * @param {object} [options] Configuration options, or `null` to use all
    *   defaults.
+   * @param {boolean} [options.dataOnly] Only ever hash based on entity data,
+   *   not metadata such as path and modification time. If `true`, this disables
+   *   {@link #etagFromFileStats} and makes {@link #etagFromFile} use
+   *   {@link #etagFromFileData}. Defaults to `false`.
    * @param {?string} [options.hashAlgorithm] Algorithm to use to generate
    *   hashes. Allowed to be `sha1`, `sha256`, or `sha512`. Defaults to
    *  `sha256`.
@@ -55,6 +59,7 @@ export class EtagGenerator {
   constructor(options = null) {
     options = EtagGenerator.expandOptions(options);
 
+    this.#dataOnly         = options.dataOnly;
     this.#hashAlgorithm    = options.hashAlgorithm;
     this.#hashLengthStrong = options.hashLength.strong;
     this.#hashLengthWeak   = options.hashLength.weak;
@@ -240,11 +245,13 @@ export class EtagGenerator {
    */
   static expandOptions(options) {
     const {
+      dataOnly      = false,
       hashAlgorithm = 'sha256',
       hashLength    = null,
       tagForm       = 'vary'
     } = options ?? {};
 
+    MustBe.boolean(dataOnly);
     MustBe.string(hashAlgorithm, /^(sha1|sha256|sha512)$/);
     MustBe.string(tagForm, /^(strong|vary|weak)$/);
 
@@ -252,6 +259,7 @@ export class EtagGenerator {
       EtagGenerator.#checkHashLength(hashAlgorithm, hashLength);
 
       return {
+        dataOnly,
         hashAlgorithm,
         hashLength: { strong: hashLength, weak: hashLength },
         tagForm
@@ -263,6 +271,7 @@ export class EtagGenerator {
       EtagGenerator.#checkHashLength(hashAlgorithm, weak);
 
       return {
+        dataOnly,
         hashAlgorithm,
         hashLength: {
           strong: EtagGenerator.#checkHashLength(hashAlgorithm, strong),

--- a/src/net-util/tests/EtagGenerator.test.js
+++ b/src/net-util/tests/EtagGenerator.test.js
@@ -29,6 +29,14 @@ ${'expandOptions()'} | ${false}
 
   test.each`
   arg
+  ${false}
+  ${true}
+  `('accepts `dataOnly` as $arg', ({ arg }) => {
+    expect(() => doCall({ dataOnly: arg })).not.toThrow();
+  });
+
+  test.each`
+  arg
   ${'sha1'}
   ${'sha256'}
   ${'sha512'}

--- a/src/net-util/tests/EtagGenerator.test.js
+++ b/src/net-util/tests/EtagGenerator.test.js
@@ -143,6 +143,10 @@ describe('etagFromData()', () => {
   });
 });
 
+describe('etagFromFile()', () => {
+  // TODO
+});
+
 describe('etagFromFileData()', () => {
   const shortFilePath = new URL('fixtures/short-file.txt', import.meta.url).pathname;
   const longFilePath  = new URL('fixtures/long-file.txt', import.meta.url).pathname;

--- a/src/net-util/tests/EtagGenerator.test.js
+++ b/src/net-util/tests/EtagGenerator.test.js
@@ -260,4 +260,10 @@ describe('etagFromFileStats()', () => {
     const result = await eg.etagFromFileStats(shortFilePath);
     expect(result).toBe(`"${fullHash.slice(0, 15)}"`);
   });
+
+  test('fails when the instance is configured as data-only', async () => {
+    const eg = new EtagGenerator({ dataOnly: true });
+
+    await expect(eg.etagFromFileStats(shortFilePath)).toReject();
+  });
 });

--- a/src/net-util/tests/EtagGenerator.test.js
+++ b/src/net-util/tests/EtagGenerator.test.js
@@ -144,7 +144,13 @@ describe('etagFromData()', () => {
 });
 
 describe('etagFromFile()', () => {
-  // TODO
+  test('uses `etagFromFileStats` when configured as `dataOnly: false`', async () => {
+    // TODO
+  });
+
+  test('uses `etagFromFileData` when configured as `dataOnly: true`', async () => {
+    // TODO
+  });
 });
 
 describe('etagFromFileData()', () => {

--- a/src/net-util/tests/EtagGenerator.test.js
+++ b/src/net-util/tests/EtagGenerator.test.js
@@ -144,12 +144,22 @@ describe('etagFromData()', () => {
 });
 
 describe('etagFromFile()', () => {
-  test('uses `etagFromFileStats` when configured as `dataOnly: false`', async () => {
-    // TODO
+  const shortFilePath = new URL('fixtures/short-file.txt', import.meta.url).pathname;
+
+  test('uses `etagFromFileStats()` when configured as `dataOnly: false`', async () => {
+    const eg       = new EtagGenerator({ dataOnly: false });
+    const expected = await eg.etagFromFileStats(shortFilePath);
+    const result   = await eg.etagFromFile(shortFilePath);
+
+    expect(result).toBe(expected);
   });
 
-  test('uses `etagFromFileData` when configured as `dataOnly: true`', async () => {
-    // TODO
+  test('uses `etagFromFileData()` when configured as `dataOnly: true`', async () => {
+    const eg = new EtagGenerator({ dataOnly: true });
+    const expected = await eg.etagFromFileData(shortFilePath);
+    const result   = await eg.etagFromFile(shortFilePath);
+
+    expect(result).toBe(expected);
   });
 });
 


### PR DESCRIPTION
This PR adds data-vs-stats configuration to `EtagGenerator`, and lets `StaticFiles` take advantage of it.