### PR TITLE
Time source renaming

### DIFF
--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -153,7 +153,7 @@ export class TokenBucket {
     }
 
     this.#lastBurstSize = MustBe.number(initialBurstSize, { minInclusive: 0, maxInclusive: maxBurstSize });
-    this.#lastNow       = this.#timeSource.now();
+    this.#lastNow       = this.#timeSource.nowSec();
   }
 
   /**
@@ -355,7 +355,7 @@ export class TokenBucket {
    *   time source until the request would be expected to be granted, if this
    *   were an asynchronously-requested grant, as if by {@link #requestGrant}
    *   (see which). If `done === true`, then this will be a time at or before
-   *   the time source's `now()`.
+   *   the time source's `nowSec()`.
    *
    * If the `minInclusive` request is non-zero, then this method will only ever
    * return `done === true` if there is no immediate contention for tokens
@@ -570,7 +570,7 @@ export class TokenBucket {
    * topping-up.
    */
   #topUpBucket() {
-    const nowSec        = this.#timeSource.now();
+    const nowSec        = this.#timeSource.nowSec();
     const lastBurstSize = this.#lastBurstSize;
 
     if (lastBurstSize < this.#maxBurstSize) {

--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -205,7 +205,7 @@ export class TokenBucket {
    *   is, the quantity of tokens that could potentially be reserved for new
    *   grant waiters. If this instance has no limit on the queue size, then
    *   this is `Number.POSITIVE_INFINITY`.
-   * * `{number} now` -- The time as of the snapshot, according to this
+   * * `{number} nowSec` -- The time as of the snapshot, according to this
    *   instance's time source.
    * * `{number} waiterCount` -- The number of queued (awaited) grant requests.
    *
@@ -215,7 +215,7 @@ export class TokenBucket {
     return {
       availableBurstSize: this.#lastBurstSize,
       availableQueueSize: this.#maxQueueSize - this.#queueSize,
-      now:                this.#lastNow,
+      nowSec:             this.#lastNow,
       waiterCount:        this.#waiters.length,
     };
   }
@@ -570,16 +570,16 @@ export class TokenBucket {
    * topping-up.
    */
   #topUpBucket() {
-    const now           = this.#timeSource.now();
+    const nowSec        = this.#timeSource.now();
     const lastBurstSize = this.#lastBurstSize;
 
     if (lastBurstSize < this.#maxBurstSize) {
-      const elapsedTime   = now - this.#lastNow;
+      const elapsedTime   = nowSec - this.#lastNow;
       const grant         = elapsedTime * this.#flowRatePerSec;
       this.#lastBurstSize = Math.min(lastBurstSize + grant, this.#maxBurstSize);
     }
 
-    this.#lastNow = now;
+    this.#lastNow = nowSec;
   }
 
   /**

--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -22,8 +22,7 @@ import { Threadlet } from '#x/Threadlet';
  * "leaky bucket as queue," where token grant requests are queued up and
  * processed at a steady token flow rate.
  *
- * This class defines neither the token (bucket volume) units nor the time
- * units (though there is a sensible default for the latter). It is up to
+ * This class does not define the token (bucket volume) unit. It is up to
  * clients to use whatever makes sense in their context.
  */
 export class TokenBucket {

--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -83,8 +83,8 @@ export class TokenBucket {
    * Constructs an instance.
    *
    * @param {object} options Configuration options.
-   * @param {number} options.flowRatePerSec Token flow rate (a/k/a bucket fill rate),
-   *   that is, how quickly the bucket gets filled, in tokens per second. This
+   * @param {number} options.flowRatePerSec Token flow rate (a/k/a bucket fill
+   *   rate), that is, how quickly the bucket gets filled, in tokens per second.
    *   This defines the steady state "flow rate" allowed by the instance. Must
    *   be a finite positive number. This is a required "option."
    * @param {number} [options.initialBurstSize] The

--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -35,7 +35,7 @@ export class TokenBucket {
 
   /**
    * @type {number} Token flow rate (a/k/a bucket fill rate), in tokens per
-   * arbitrary time unit (tokens / ATU).
+   * second.
    */
   #flowRate;
 
@@ -85,10 +85,9 @@ export class TokenBucket {
    *
    * @param {object} options Configuration options.
    * @param {number} options.flowRate Token flow rate (a/k/a bucket fill rate),
-   *   that is, how quickly the bucket gets filled, in tokens per arbitrary time
-   *   unit (tokens / ATU). This defines the steady state "flow rate" allowed by
-   *   the instance. Must be a finite positive number. This is a required
-   *   "option."
+   *   that is, how quickly the bucket gets filled, in tokens per second. This
+   *   This defines the steady state "flow rate" allowed by the instance. Must
+   *   be a finite positive number. This is a required "option."
    * @param {number} [options.initialBurstSize] The
    *   instantaneously available burst size, in tokens, at the moment of
    *   construction. Defaults to `maxBurstSize` (that is, able to be maximally
@@ -272,8 +271,8 @@ export class TokenBucket {
    *     call to {@link #denyAllRequests} which is currently in progress.
    *   * `full` -- This request would cause the waiter queue to be too large
    *     (including the case where `maxQueueSize === 0`).
-   * * `{number} waitTime` -- The amount of time (in ATU) that was spent waiting
-   *   for the grant.
+   * * `{number} waitTime` -- The amount of time (in seconds) that was spent
+   *   waiting for the grant.
    *
    * @param {number|object} quantity Requested quantity of tokens, as described
    *   above.

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -165,7 +165,7 @@ describe('constructor()', () => {
     const ts = new MockTimeSource(321);
     const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, timeSource: ts });
     expect(bucket.config.timeSource).toBe(ts);
-    expect(bucket.latestState().now).toBe(321);
+    expect(bucket.latestState().nowSec).toBe(321);
   });
 
   test('produces an instance which (apparently) uses the default time source if not passed `timeSource`', () => {
@@ -653,7 +653,7 @@ describe('latestState()', () => {
   test('has exactly the expected properties', () => {
     const bucket = new TokenBucket({ flowRatePerSec: 123, maxBurstSize: 100000 });
     expect(bucket.latestState()).toContainAllKeys([
-      'availableBurstSize', 'availableQueueSize', 'now', 'waiterCount'
+      'availableBurstSize', 'availableQueueSize', 'nowSec', 'waiterCount'
     ]);
   });
 
@@ -663,7 +663,7 @@ describe('latestState()', () => {
       flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 100, timeSource: time });
 
     const baseResult = bucket.latestState();
-    expect(baseResult.now).toBe(900);
+    expect(baseResult.nowSec).toBe(900);
     expect(baseResult.availableBurstSize).toBe(100);
 
     time._setTime(901);
@@ -784,7 +784,7 @@ describe('takeNow()', () => {
 
       const latest = bucket.latestState();
       expect(latest.availableBurstSize).toBe(0);
-      expect(latest.now).toBe(1001);
+      expect(latest.nowSec).toBe(1001);
 
       time._end();
     });

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -363,9 +363,9 @@ describe('denyAllRequests()', () => {
     expect(PromiseState.isFulfilled(result1)).toBeTrue();
     expect(PromiseState.isFulfilled(result2)).toBeTrue();
     expect(PromiseState.isFulfilled(result3)).toBeTrue();
-    expect(await result1).toStrictEqual({ done: false, grant: 0, reason: 'stopping', waitTime: 987 });
-    expect(await result2).toStrictEqual({ done: false, grant: 0, reason: 'stopping', waitTime: 987 });
-    expect(await result3).toStrictEqual({ done: false, grant: 0, reason: 'stopping', waitTime: 987 });
+    expect(await result1).toStrictEqual({ done: false, grant: 0, reason: 'stopping', waitTimeSec: 987 });
+    expect(await result2).toStrictEqual({ done: false, grant: 0, reason: 'stopping', waitTimeSec: 987 });
+    expect(await result3).toStrictEqual({ done: false, grant: 0, reason: 'stopping', waitTimeSec: 987 });
 
     time._end();
   });
@@ -381,7 +381,7 @@ describe('requestGrant()', () => {
       const result = bucket.requestGrant(123);
       expect(bucket.latestState().availableBurstSize).toBe(0);
       expect(bucket.latestState().waiterCount).toBe(0);
-      expect(await result).toStrictEqual({ done: true, grant: 123, reason: 'grant', waitTime: 0 });
+      expect(await result).toStrictEqual({ done: true, grant: 123, reason: 'grant', waitTimeSec: 0 });
 
       time._end();
     });
@@ -395,7 +395,7 @@ describe('requestGrant()', () => {
       const result = bucket.requestGrant(300);
       expect(bucket.latestState().availableBurstSize).toBe(21);
       expect(bucket.latestState().waiterCount).toBe(0);
-      expect(await result).toStrictEqual({ done: true, grant: 300, reason: 'grant', waitTime: 0 });
+      expect(await result).toStrictEqual({ done: true, grant: 300, reason: 'grant', waitTimeSec: 0 });
 
       time._end();
     });
@@ -408,7 +408,7 @@ describe('requestGrant()', () => {
       const result = bucket.requestGrant({ minInclusive: 0, maxInclusive: 25 });
       expect(bucket.latestState().availableBurstSize).toBe(0);
       expect(bucket.latestState().waiterCount).toBe(0);
-      expect(await result).toStrictEqual({ done: true, grant: 0, reason: 'grant', waitTime: 0 });
+      expect(await result).toStrictEqual({ done: true, grant: 0, reason: 'grant', waitTimeSec: 0 });
 
       time._end();
     });
@@ -421,7 +421,7 @@ describe('requestGrant()', () => {
       const result = bucket.requestGrant({ minInclusive: 0, maxInclusive: 100 });
       expect(bucket.latestState().availableBurstSize).toBe(0);
       expect(bucket.latestState().waiterCount).toBe(0);
-      expect(await result).toStrictEqual({ done: true, grant: 96, reason: 'grant', waitTime: 0 });
+      expect(await result).toStrictEqual({ done: true, grant: 96, reason: 'grant', waitTimeSec: 0 });
 
       time._end();
     });
@@ -445,7 +445,7 @@ describe('requestGrant()', () => {
       expect(PromiseState.isPending(request1)).toBeTrue();
       expect(PromiseState.isFulfilled(request2)).toBeTrue();
 
-      expect(await request2).toStrictEqual({ done: true, grant: 0, reason: 'grant', waitTime: 0 });
+      expect(await request2).toStrictEqual({ done: true, grant: 0, reason: 'grant', waitTimeSec: 0 });
 
       // Get the bucket to quiesce.
       time._setTime(now + 1000);
@@ -470,7 +470,7 @@ describe('requestGrant()', () => {
       expect(bucket.latestState().waiterCount).toBe(1);
       await timers.setImmediate();
       expect(PromiseState.isFulfilled(request2)).toBeTrue();
-      expect(await request2).toStrictEqual({ done: false, grant: 0, reason: 'full', waitTime: 0 });
+      expect(await request2).toStrictEqual({ done: false, grant: 0, reason: 'full', waitTimeSec: 0 });
 
       // Get the bucket to quiesce.
       time._setTime(now + 1000);
@@ -495,7 +495,7 @@ describe('requestGrant()', () => {
       expect(bucket.latestState().waiterCount).toBe(1);
       await timers.setImmediate();
       expect(PromiseState.isFulfilled(request2)).toBeTrue();
-      expect(await request2).toStrictEqual({ done: false, grant: 0, reason: 'full', waitTime: 0 });
+      expect(await request2).toStrictEqual({ done: false, grant: 0, reason: 'full', waitTimeSec: 0 });
 
       // Get the bucket to quiesce.
       time._setTime(now + 1000);
@@ -516,7 +516,7 @@ describe('requestGrant()', () => {
       time._setTime(now + 321);
       await timers.setImmediate();
       expect(PromiseState.isFulfilled(request)).toBeTrue();
-      expect(await request).toStrictEqual({ done: true, grant: 50, reason: 'grant', waitTime: 321 });
+      expect(await request).toStrictEqual({ done: true, grant: 50, reason: 'grant', waitTimeSec: 321 });
 
       time._end();
     });
@@ -533,7 +533,7 @@ describe('requestGrant()', () => {
       time._setTime(now + 90909);
       await timers.setImmediate();
       expect(PromiseState.isFulfilled(request)).toBeTrue();
-      expect(await request).toStrictEqual({ done: true, grant: 100, reason: 'grant', waitTime: 90909 });
+      expect(await request).toStrictEqual({ done: true, grant: 100, reason: 'grant', waitTimeSec: 90909 });
 
       time._end();
     });
@@ -571,9 +571,9 @@ describe('requestGrant()', () => {
       expect(PromiseState.isFulfilled(request2)).toBeTrue();
       expect(PromiseState.isFulfilled(request3)).toBeTrue();
 
-      expect(await request1).toStrictEqual({ done: true, grant: 10, reason: 'grant', waitTime: 10 });
-      expect(await request2).toStrictEqual({ done: true, grant: 20, reason: 'grant', waitTime: 10 + 20 });
-      expect(await request3).toStrictEqual({ done: true, grant: 30, reason: 'grant', waitTime: 10 + 20 + 30 });
+      expect(await request1).toStrictEqual({ done: true, grant: 10, reason: 'grant', waitTimeSec: 10 });
+      expect(await request2).toStrictEqual({ done: true, grant: 20, reason: 'grant', waitTimeSec: 10 + 20 });
+      expect(await request3).toStrictEqual({ done: true, grant: 30, reason: 'grant', waitTimeSec: 10 + 20 + 30 });
 
       time._end();
     });

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -20,10 +20,6 @@ class MockTimeSource extends IntfTimeSource {
     this.#now = firstNow;
   }
 
-  get unitName() {
-    return 'some-unit';
-  }
-
   now() {
     if (this.#ended) {
       throw new Error(`MockTimeSource ended! (Time was ${this.#now}.)`);

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -20,7 +20,7 @@ class MockTimeSource extends IntfTimeSource {
     this.#nowSec = firstNow;
   }
 
-  now() {
+  nowSec() {
     if (this.#ended) {
       throw new Error(`MockTimeSource ended! (Time was ${this.#nowSec}.)`);
     }
@@ -669,7 +669,7 @@ describe('latestState()', () => {
     time._setTime(901);
     expect(bucket.latestState()).toStrictEqual(baseResult);
 
-    time.now = () => { throw new Error('oy!'); };
+    time.nowSec = () => { throw new Error('oy!'); };
     expect(() => bucket.latestState()).not.toThrow();
 
     time._end();

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -286,7 +286,9 @@ describe('constructor(<invalid>)', () => {
   });
 
   test('rejects invalid `maxQueueGrantSize` (`> maxQueueSize`)', () => {
-    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 10, maxQueueSize: 5, maxQueueGrantSize: 6 })).toThrow();
+    expect(() => new TokenBucket(
+      { flowRatePerSec: 1, maxBurstSize: 10, maxQueueSize: 5, maxQueueGrantSize: 6 }
+    )).toThrow();
   });
 
   test('rejects invalid `maxQueueGrantSize` (`> maxBurstSize`)', () => {

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -71,42 +71,42 @@ class MockTimeSource extends IntfTimeSource {
 describe('constructor()', () => {
   test.each`
     opts
-    ${{ flowRate: 1,      maxBurstSize: 1 }}
-    ${{ flowRate: 0.0001, maxBurstSize: 0.01 }}
-    ${{ flowRate: 109,    maxBurstSize: 200000 }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     initialBurstSize: 0 }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     initialBurstSize: 1 }}
-    ${{ flowRate: 1,      maxBurstSize: 10,    initialBurstSize: 10 }}
-    ${{ flowRate: 1,      maxBurstSize: 10,    initialBurstSize: 9 }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     maxQueueGrantSize: 0 }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     maxQueueGrantSize: 0.1 }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     maxQueueGrantSize: 1 }}
-    ${{ flowRate: 1,      maxBurstSize: 100,   maxQueueGrantSize: 1 }}
-    ${{ flowRate: 1,      maxBurstSize: 100,   maxQueueGrantSize: 50 }}
-    ${{ flowRate: 1,      maxBurstSize: 100,   maxQueueGrantSize: 99 }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     maxQueueSize: 1000 }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     maxQueueSize: 0 }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     maxQueueSize: 1 }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     maxQueueSize: 12.34 }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     partialTokens: false }}
-    ${{ flowRate: 12.3,   maxBurstSize: 123.4, partialTokens: false }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     partialTokens: true }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     timeSource: new StdTimeSource() }}
-    ${{ flowRate: 1,      maxBurstSize: 1,     timeSource: new MockTimeSource() }}
-    ${{ flowRate: 1, maxBurstSize: 1, initialBurstSize: 0.5, maxQueueGrantSize: 0.5,
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1 }}
+    ${{ flowRatePerSec: 0.0001, maxBurstSize: 0.01 }}
+    ${{ flowRatePerSec: 109,    maxBurstSize: 200000 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     initialBurstSize: 0 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     initialBurstSize: 1 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 10,    initialBurstSize: 10 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 10,    initialBurstSize: 9 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueGrantSize: 0 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueGrantSize: 0.1 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueGrantSize: 1 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 100,   maxQueueGrantSize: 1 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 100,   maxQueueGrantSize: 50 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 100,   maxQueueGrantSize: 99 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueSize: 1000 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueSize: 0 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueSize: 1 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueSize: 12.34 }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     partialTokens: false }}
+    ${{ flowRatePerSec: 12.3,   maxBurstSize: 123.4, partialTokens: false }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     partialTokens: true }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     timeSource: new StdTimeSource() }}
+    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     timeSource: new MockTimeSource() }}
+    ${{ flowRatePerSec: 1, maxBurstSize: 1, initialBurstSize: 0.5, maxQueueGrantSize: 0.5,
         maxQueueSize: 10, partialTokens: true, timeSource: new MockTimeSource() }}
   `('trivially accepts valid options: $opts', ({ opts }) => {
     expect(() => new TokenBucket(opts)).not.toThrow();
   });
 
   test('produces an instance with the `maxBurstSize` that was passed', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 123 });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 123 });
     expect(bucket.config.maxBurstSize).toBe(123);
   });
 
-  test('produces an instance with the `flowRate` that was passed', () => {
-    const bucket = new TokenBucket({ flowRate: 1234, maxBurstSize: 100000 });
-    expect(bucket.config.flowRate).toBe(1234);
+  test('produces an instance with the `flowRatePerSec` that was passed', () => {
+    const bucket = new TokenBucket({ flowRatePerSec: 1234, maxBurstSize: 100000 });
+    expect(bucket.config.flowRatePerSec).toBe(1234);
   });
 
   test.each`
@@ -116,18 +116,18 @@ describe('constructor()', () => {
     ${1}              | ${false}
     ${200}            | ${false}
   `('produces an instance with the `maxQueueGrantSize` that was passed: $maxQueueGrantSize', ({ maxQueueGrantSize, partialTokens }) => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 1000, maxQueueGrantSize, partialTokens });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1000, maxQueueGrantSize, partialTokens });
     expect(bucket.config.maxQueueGrantSize).toBe(maxQueueGrantSize);
   });
 
   test('rounds down a fractional `maxQueueGrantSize` if `partialTokens === false`', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 1000,
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1000,
       maxQueueGrantSize: 12.9, partialTokens: false });
     expect(bucket.config.maxQueueGrantSize).toBe(12);
   });
 
   test('has `maxQueueGrantSize === maxBurstSize` if not passed `maxQueueGrantSize`', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 10203 });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 10203 });
     expect(bucket.config.maxQueueGrantSize).toBe(10203);
   });
 
@@ -138,12 +138,12 @@ describe('constructor()', () => {
     ${1.5}
     ${10}
   `('produces an instance with the `maxQueueSize` that was passed: $maxQueueSize', ({ maxQueueSize }) => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 1, maxQueueSize });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, maxQueueSize });
     expect(bucket.config.maxQueueSize).toBe(maxQueueSize);
   });
 
   test('has `maxQueueSize === null` if not passed', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 1 });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1 });
     expect(bucket.config.maxQueueSize).toBeNull();
   });
 
@@ -152,54 +152,54 @@ describe('constructor()', () => {
     ${false}
     ${true}
   `('produces an instance with the `partialTokens` that was passed: $partialTokens', ({ partialTokens }) => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 1, partialTokens });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, partialTokens });
     expect(bucket.config.partialTokens).toBe(partialTokens);
   });
 
   test('has `partialTokens === false` if not passed', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 1 });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1 });
     expect(bucket.config.partialTokens).toBeFalse();
   });
 
   test('produces an instance which uses the `timeSource` that was passed', () => {
     const ts = new MockTimeSource(321);
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 1, timeSource: ts });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, timeSource: ts });
     expect(bucket.config.timeSource).toBe(ts);
     expect(bucket.latestState().now).toBe(321);
   });
 
   test('produces an instance which (apparently) uses the default time source if not passed `timeSource`', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 1 });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1 });
     expect(bucket.config.timeSource).toBeNull();
   });
 
   test('produces an instance with `availableBurstSize` equal to the passed `initialBurstSize`', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 100, initialBurstSize: 23 });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 100, initialBurstSize: 23 });
     expect(bucket.latestState().availableBurstSize).toBe(23);
   });
 
   test('has `availableBurstSize === maxBurstSize` if not passed `initialBurstSize`', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 123 });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 123 });
     expect(bucket.latestState().availableBurstSize).toBe(123);
   });
 
   test('produces an instance with `availableQueueSize === infinity` if passed `maxQueueSize === null`', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 100, maxQueueSize: null });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 100, maxQueueSize: null });
     expect(bucket.latestState().availableQueueSize).toBe(Number.POSITIVE_INFINITY);
   });
 
   test('produces an instance with `availableQueueSize === infinity` if not passed `maxQueueSize`', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 100 });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 100 });
     expect(bucket.latestState().availableQueueSize).toBe(Number.POSITIVE_INFINITY);
   });
 
   test('produces an instance with `availableQueueSize === maxQueueSize` for finite `maxQueueSize`', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 100, maxQueueSize: 9876 });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 100, maxQueueSize: 9876 });
     expect(bucket.latestState().availableQueueSize).toBe(9876);
   });
 
   test('produces an instance with no waiters', () => {
-    const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 100 });
+    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 100 });
     expect(bucket.latestState().waiterCount).toBe(0);
   });
 });
@@ -217,10 +217,10 @@ describe('constructor(<invalid>)', () => {
   });
 
   test('rejects missing `maxBurstSize`', () => {
-    expect(() => new TokenBucket({ flowRate: 1 })).toThrow();
+    expect(() => new TokenBucket({ flowRatePerSec: 1 })).toThrow();
   });
 
-  test('rejects missing `flowRate`', () => {
+  test('rejects missing `flowRatePerSec`', () => {
     expect(() => new TokenBucket({ maxBurstSize: 1 })).toThrow();
   });
 
@@ -237,11 +237,11 @@ describe('constructor(<invalid>)', () => {
     ${NaN}
     ${Number.POSITIVE_INFINITY}
   `('rejects invalid `maxBurstSize`: $maxBurstSize', ({ maxBurstSize }) => {
-    expect(() => new TokenBucket({ maxBurstSize, flowRate: 1 })).toThrow();
+    expect(() => new TokenBucket({ maxBurstSize, flowRatePerSec: 1 })).toThrow();
   });
 
   test.each`
-    flowRate
+    flowRatePerSec
     ${undefined}
     ${null}
     ${true}
@@ -252,8 +252,8 @@ describe('constructor(<invalid>)', () => {
     ${0}
     ${NaN}
     ${Number.POSITIVE_INFINITY}
-  `('rejects invalid `flowRate`: $flowRate', ({ flowRate }) => {
-    expect(() => new TokenBucket({ flowRate, maxBurstSize: 1 })).toThrow();
+  `('rejects invalid `flowRatePerSec`: $flowRatePerSec', ({ flowRatePerSec }) => {
+    expect(() => new TokenBucket({ flowRatePerSec, maxBurstSize: 1 })).toThrow();
   });
 
   test.each`
@@ -265,12 +265,12 @@ describe('constructor(<invalid>)', () => {
     ${-1}
     ${-0.1}
   `('rejects invalid `initialBurstSize`: $initialBurstSize', ({ initialBurstSize }) => {
-    expect(() => new TokenBucket({ flowRate: 1, maxBurstSize: 1, initialBurstSize })).toThrow();
+    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, initialBurstSize })).toThrow();
   });
 
   test('rejects invalid `initialBurstSize` (`> maxBurstSize`)', () => {
-    expect(() => new TokenBucket({ flowRate: 1, maxBurstSize: 1, initialBurstSize: 1.01 })).toThrow();
-    expect(() => new TokenBucket({ flowRate: 1, maxBurstSize: 1, initialBurstSize: 2 })).toThrow();
+    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, initialBurstSize: 1.01 })).toThrow();
+    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, initialBurstSize: 2 })).toThrow();
   });
 
   test.each`
@@ -282,16 +282,16 @@ describe('constructor(<invalid>)', () => {
     ${-1}
     ${-0.1}
   `('rejects invalid `maxQueueGrantSize`: $maxQueueGrantSize', ({ maxQueueGrantSize }) => {
-    expect(() => new TokenBucket({ flowRate: 1, maxBurstSize: 1000, maxQueueGrantSize })).toThrow();
+    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1000, maxQueueGrantSize })).toThrow();
   });
 
   test('rejects invalid `maxQueueGrantSize` (`> maxQueueSize`)', () => {
-    expect(() => new TokenBucket({ flowRate: 1, maxBurstSize: 10, maxQueueSize: 5, maxQueueGrantSize: 6 })).toThrow();
+    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 10, maxQueueSize: 5, maxQueueGrantSize: 6 })).toThrow();
   });
 
   test('rejects invalid `maxQueueGrantSize` (`> maxBurstSize`)', () => {
-    expect(() => new TokenBucket({ flowRate: 1, maxBurstSize: 1, maxQueueGrantSize: 1.01 })).toThrow();
-    expect(() => new TokenBucket({ flowRate: 1, maxBurstSize: 1, maxQueueGrantSize: 2 })).toThrow();
+    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, maxQueueGrantSize: 1.01 })).toThrow();
+    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, maxQueueGrantSize: 2 })).toThrow();
   });
 
   test.each`
@@ -302,7 +302,7 @@ describe('constructor(<invalid>)', () => {
     ${-1}
     ${Number.POSITIVE_INFINITY}
   `('rejects invalid `maxQueueSize`: $maxQueueSize', ({ maxQueueSize }) => {
-    expect(() => new TokenBucket({ flowRate: 1, maxBurstSize: 1, maxQueueSize })).toThrow();
+    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, maxQueueSize })).toThrow();
   });
 
   test.each`
@@ -312,7 +312,7 @@ describe('constructor(<invalid>)', () => {
     ${[false]}
     ${0}
   `('rejects invalid `partialTokens`: $partialTokens', ({ partialTokens }) => {
-    expect(() => new TokenBucket({ flowRate: 1, maxBurstSize: 1, partialTokens })).toThrow();
+    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, partialTokens })).toThrow();
   });
 
   test.each`
@@ -323,15 +323,15 @@ describe('constructor(<invalid>)', () => {
     ${IntfTimeSource /* supposed to be an instance, not a class */}
     ${MockTimeSource /* ditto */}
   `('rejects invalid `timeSource`: $timeSource', ({ timeSource }) => {
-    expect(() => new TokenBucket({ flowRate: 1, maxBurstSize: 1, timeSource })).toThrow();
+    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, timeSource })).toThrow();
   });
 });
 
 describe('.config', () => {
   test('has exactly the expected properties', () => {
-    const bucket = new TokenBucket({ flowRate: 123, maxBurstSize: 100000 });
+    const bucket = new TokenBucket({ flowRatePerSec: 123, maxBurstSize: 100000 });
     expect(bucket.config).toContainAllKeys([
-      'flowRate', 'maxBurstSize', 'maxQueueGrantSize', 'maxQueueSize',
+      'flowRatePerSec', 'maxBurstSize', 'maxQueueGrantSize', 'maxQueueSize',
       'partialTokens', 'timeSource'
     ]);
   });
@@ -341,7 +341,7 @@ describe('denyAllRequests()', () => {
   test('causes pending grant requests to in fact be denied', async () => {
     const time   = new MockTimeSource(10000);
     const bucket = new TokenBucket({
-      flowRate: 1, maxBurstSize: 1000, initialBurstSize: 0, timeSource: time });
+      flowRatePerSec: 1, maxBurstSize: 1000, initialBurstSize: 0, timeSource: time });
 
     // Setup / baseline assumptions.
     const result1 = bucket.requestGrant(1);
@@ -376,7 +376,7 @@ describe('requestGrant()', () => {
     test('synchronously grants a request that can be satisfied', async () => {
       const time   = new MockTimeSource(9001);
       const bucket = new TokenBucket({
-        flowRate: 1, maxBurstSize: 10000, initialBurstSize: 123, timeSource: time });
+        flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 123, timeSource: time });
 
       const result = bucket.requestGrant(123);
       expect(bucket.latestState().availableBurstSize).toBe(0);
@@ -389,7 +389,7 @@ describe('requestGrant()', () => {
     test('synchronously grants a request that can be satisfied, with `grant > maxQueueGrantSize`', async () => {
       const time   = new MockTimeSource(9002);
       const bucket = new TokenBucket({
-        flowRate: 1, maxBurstSize: 10000, maxGrantQueueSize: 10,
+        flowRatePerSec: 1, maxBurstSize: 10000, maxGrantQueueSize: 10,
         initialBurstSize: 321, timeSource: time });
 
       const result = bucket.requestGrant(300);
@@ -402,7 +402,7 @@ describe('requestGrant()', () => {
 
     test('synchronously grants `0` tokens with `minInclusive === 0` and no available burst', async () => {
       const time   = new MockTimeSource(9003);
-      const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 10000,
+      const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 10000,
         initialBurstSize: 0, timeSource: time });
 
       const result = bucket.requestGrant({ minInclusive: 0, maxInclusive: 25 });
@@ -415,7 +415,7 @@ describe('requestGrant()', () => {
 
     test('synchronously grants non-zero tokens with `minInclusive === 0` and non-zero `maxInclusive`', async () => {
       const time   = new MockTimeSource(9004);
-      const bucket = new TokenBucket({ flowRate: 1, maxBurstSize: 10000,
+      const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 10000,
         initialBurstSize: 96, timeSource: time });
 
       const result = bucket.requestGrant({ minInclusive: 0, maxInclusive: 100 });
@@ -432,7 +432,7 @@ describe('requestGrant()', () => {
       const now    = 12300;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 1, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
+        flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
 
       // Setup / basic assumptions.
       const request1 = bucket.requestGrant(10);
@@ -458,7 +458,7 @@ describe('requestGrant()', () => {
       const now    = 99000;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 1, maxBurstSize: 10000, maxQueueSize: 100,
+        flowRatePerSec: 1, maxBurstSize: 10000, maxQueueSize: 100,
         initialBurstSize: 0, timeSource: time });
 
       // Setup / basic assumptions.
@@ -483,7 +483,7 @@ describe('requestGrant()', () => {
       const now    = 89100;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 1, maxBurstSize: 10000, maxQueueSize: 100,
+        flowRatePerSec: 1, maxBurstSize: 10000, maxQueueSize: 100,
         initialBurstSize: 0, timeSource: time });
 
       // Setup / basic assumptions.
@@ -508,7 +508,7 @@ describe('requestGrant()', () => {
       const now    = 777000;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 1, maxBurstSize: 10000, maxQueueGrantSize: 100,
+        flowRatePerSec: 1, maxBurstSize: 10000, maxQueueGrantSize: 100,
         initialBurstSize: 0, timeSource: time });
 
       const request = bucket.requestGrant({ minInclusive: 25, maxInclusive: 50 });
@@ -525,7 +525,7 @@ describe('requestGrant()', () => {
       const now    = 888000;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 1, maxBurstSize: 10000, maxQueueGrantSize: 100,
+        flowRatePerSec: 1, maxBurstSize: 10000, maxQueueGrantSize: 100,
         initialBurstSize: 0, timeSource: time });
 
       const request = bucket.requestGrant({ minInclusive: 50, maxInclusive: 150 });
@@ -542,7 +542,7 @@ describe('requestGrant()', () => {
       const now    = 182100;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 1, maxBurstSize: 10000, maxQueueGrantSize: 100,
+        flowRatePerSec: 1, maxBurstSize: 10000, maxQueueGrantSize: 100,
         initialBurstSize: 0, timeSource: time });
 
       const request1 = bucket.requestGrant(10);
@@ -584,7 +584,7 @@ describe('requestGrant()', () => {
       const available = 12.34;
       const time   = new MockTimeSource(12312);
       const bucket = new TokenBucket({
-        partialTokens: false, flowRate: 1, maxBurstSize: 100,
+        partialTokens: false, flowRatePerSec: 1, maxBurstSize: 100,
         initialBurstSize: available, timeSource: time });
 
       const resultPromise = bucket.requestGrant({ minInclusive: 10, maxInclusive: 20 });
@@ -598,7 +598,7 @@ describe('requestGrant()', () => {
       const now    = 900;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        partialTokens: false, flowRate: 1, maxBurstSize: 100,
+        partialTokens: false, flowRatePerSec: 1, maxBurstSize: 100,
         maxQueueGrantSize: 10, initialBurstSize: 0, timeSource: time });
 
       const resultPromise = bucket.requestGrant({ minInclusive: 1.5, maxInclusive: 2.5 });
@@ -618,7 +618,7 @@ describe('requestGrant()', () => {
       const available = 12.34;
       const time   = new MockTimeSource(12312);
       const bucket = new TokenBucket({
-        partialTokens: true, flowRate: 1, maxBurstSize: 100,
+        partialTokens: true, flowRatePerSec: 1, maxBurstSize: 100,
         initialBurstSize: available, timeSource: time });
 
       const resultPromise = bucket.requestGrant({ minInclusive: 10, maxInclusive: 20 });
@@ -633,7 +633,7 @@ describe('requestGrant()', () => {
       const now    = 900;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        partialTokens: true, flowRate: 1, maxBurstSize: 100,
+        partialTokens: true, flowRatePerSec: 1, maxBurstSize: 100,
         maxQueueGrantSize: grant, initialBurstSize: 0, timeSource: time });
 
       const resultPromise = bucket.requestGrant({ minInclusive: 1, maxInclusive: 10 });
@@ -651,7 +651,7 @@ describe('requestGrant()', () => {
 
 describe('latestState()', () => {
   test('has exactly the expected properties', () => {
-    const bucket = new TokenBucket({ flowRate: 123, maxBurstSize: 100000 });
+    const bucket = new TokenBucket({ flowRatePerSec: 123, maxBurstSize: 100000 });
     expect(bucket.latestState()).toContainAllKeys([
       'availableBurstSize', 'availableQueueSize', 'now', 'waiterCount'
     ]);
@@ -660,7 +660,7 @@ describe('latestState()', () => {
   test('does not use the time source', () => {
     const time   = new MockTimeSource(900);
     const bucket = new TokenBucket({
-      flowRate: 1, maxBurstSize: 10000, initialBurstSize: 100, timeSource: time });
+      flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 100, timeSource: time });
 
     const baseResult = bucket.latestState();
     expect(baseResult.now).toBe(900);
@@ -676,14 +676,14 @@ describe('latestState()', () => {
   });
 
   test('indicates a lack of waiters, before any waiting has ever happened', () => {
-    const bucket = new TokenBucket({ flowRate: 123, maxBurstSize: 100000 });
+    const bucket = new TokenBucket({ flowRatePerSec: 123, maxBurstSize: 100000 });
     expect(bucket.latestState().waiterCount).toBe(0);
   });
 
   test('indicates the number of waiters and available queue size as the waiters wax and wane', async () => {
     const time   = new MockTimeSource(1000);
     const bucket = new TokenBucket({
-      flowRate: 1, maxBurstSize: 10000, initialBurstSize: 0, maxQueueSize: 1000,
+      flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 0, maxQueueSize: 1000,
       timeSource: time
     });
 
@@ -725,7 +725,7 @@ describe('takeNow()', () => {
       const now    = 98000;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 1, maxBurstSize: 10000, initialBurstSize: 123, timeSource: time });
+        flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 123, timeSource: time });
 
       const result = bucket.takeNow(123);
       expect(result).toStrictEqual({ done: true, grant: 123, waitUntil: now });
@@ -738,7 +738,7 @@ describe('takeNow()', () => {
       const now    = 43210;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 5, maxBurstSize: 10000, initialBurstSize: 100, timeSource: time });
+        flowRatePerSec: 5, maxBurstSize: 10000, initialBurstSize: 100, timeSource: time });
 
       const result = bucket.takeNow({ minInclusive: 10, maxInclusive: 110 });
       expect(result.done).toBeTrue();
@@ -754,7 +754,7 @@ describe('takeNow()', () => {
       const now    = 91400;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 5, maxBurstSize: 10000, initialBurstSize: 75, maxQueueGrantSize: 50, timeSource: time });
+        flowRatePerSec: 5, maxBurstSize: 10000, initialBurstSize: 75, maxQueueGrantSize: 50, timeSource: time });
 
       // Notably, this is not supposed to be clamped to `maxQueueGrantSize`,
       // because this request isn't being queued (that is, there's no
@@ -773,7 +773,7 @@ describe('takeNow()', () => {
       const now    = 1000;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 5, maxBurstSize: 100, initialBurstSize: 0, timeSource: time });
+        flowRatePerSec: 5, maxBurstSize: 100, initialBurstSize: 0, timeSource: time });
 
       const now1 = now + 1; // Enough for 5 tokens to become available.
       time._setTime(now1);
@@ -793,7 +793,7 @@ describe('takeNow()', () => {
       const now    = 1000;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 5, maxBurstSize: 100, initialBurstSize: 0, maxQueueGrantSize: 10, timeSource: time });
+        flowRatePerSec: 5, maxBurstSize: 100, initialBurstSize: 0, maxQueueGrantSize: 10, timeSource: time });
 
       const result = bucket.takeNow({ minInclusive: 2, maxInclusive: 91 });
       expect(result.done).toBeFalse();
@@ -807,7 +807,7 @@ describe('takeNow()', () => {
       const now    = 1000;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 10, maxBurstSize: 100, initialBurstSize: 5, maxQueueGrantSize: 20, timeSource: time });
+        flowRatePerSec: 10, maxBurstSize: 100, initialBurstSize: 5, maxQueueGrantSize: 20, timeSource: time });
 
       const result = bucket.takeNow({ minInclusive: 12, maxInclusive: 31 });
       expect(result.done).toBeFalse();
@@ -828,7 +828,7 @@ describe('takeNow()', () => {
       `('will not grant a partial token even if requested and "available": $minInclusive .. $maxInclusive with $available available',
         ({ available, minInclusive, maxInclusive, expected }) => {
           const bucket = new TokenBucket({
-            partialTokens: false, flowRate: 1, maxBurstSize: 100, initialBurstSize: available });
+            partialTokens: false, flowRatePerSec: 1, maxBurstSize: 100, initialBurstSize: available });
 
           const result = bucket.takeNow({ minInclusive, maxInclusive });
           expect(result.done).toBe(expected.done);
@@ -848,7 +848,7 @@ describe('takeNow()', () => {
           const now    = 226000;
           const time   = new MockTimeSource(now);
           const bucket = new TokenBucket({
-            partialTokens: true, flowRate: 1, maxBurstSize: 100, initialBurstSize: available,
+            partialTokens: true, flowRatePerSec: 1, maxBurstSize: 100, initialBurstSize: available,
             timeSource: time
           });
 
@@ -864,7 +864,7 @@ describe('takeNow()', () => {
       const now    = 226000;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 13, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
+        flowRatePerSec: 13, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
 
       // Setup / baseline assumptions.
       const requestResult = bucket.requestGrant(1300);
@@ -888,7 +888,7 @@ describe('takeNow()', () => {
       const now    = 50015;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 10, maxBurstSize: 10000, initialBurstSize: 0, maxQueueGrantSize: 1000, timeSource: time });
+        flowRatePerSec: 10, maxBurstSize: 10000, initialBurstSize: 0, maxQueueGrantSize: 1000, timeSource: time });
 
       // Setup / baseline assumptions.
       const requestResult = bucket.requestGrant(300);
@@ -912,7 +912,7 @@ describe('takeNow()', () => {
       const now    = 60015;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 10, maxBurstSize: 10000, initialBurstSize: 200, maxQueueGrantSize: 1000, timeSource: time });
+        flowRatePerSec: 10, maxBurstSize: 10000, initialBurstSize: 200, maxQueueGrantSize: 1000, timeSource: time });
 
       // Setup / baseline assumptions.
       const requestResult = bucket.requestGrant(300);
@@ -938,7 +938,7 @@ describe('takeNow()', () => {
       const now    = 1000;
       const time   = new MockTimeSource(now);
       const bucket = new TokenBucket({
-        flowRate: 1, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
+        flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
 
       // Setup / baseline expectations.
       const requestResult = bucket.requestGrant(1);

--- a/src/builtin-services/export/MemoryMonitor.js
+++ b/src/builtin-services/export/MemoryMonitor.js
@@ -115,7 +115,7 @@ export class MemoryMonitor extends BaseService {
     while (!this.#runner.shouldStop()) {
       const snapshot = this.#takeSnapshot();
 
-      if (snapshot.actionAt && (snapshot.actionAt.atSecs < snapshot.at.atSecs)) {
+      if (snapshot.actionAt && (snapshot.actionAt.atSec < snapshot.at.atSec)) {
         this.logger?.takingAction();
         // No `await`, because then the shutdown handler would end up deadlocked
         // with the stopping of this threadlet.

--- a/src/builtin-services/export/ProcessInfoFile.js
+++ b/src/builtin-services/export/ProcessInfoFile.js
@@ -218,7 +218,7 @@ export class ProcessInfoFile extends BaseService {
   async #stop(willReload) {
     const contents      = this.#contents;
     const stoppedAtSecs = Date.now() / 1000;
-    const uptimeSecs    = stoppedAtSecs - contents.startedAt.atSecs;
+    const uptimeSecs    = stoppedAtSecs - contents.startedAt.atSec;
 
     if (willReload) {
       contents.disposition = { reloading: true };
@@ -254,7 +254,7 @@ export class ProcessInfoFile extends BaseService {
     this.#contents.disposition = {
       running:   true,
       updatedAt: new Moment(updatedAtSecs).toPlainObject(),
-      uptime:    new Duration(updatedAtSecs - this.#contents.startedAt.atSecs).toPlainObject()
+      uptime:    new Duration(updatedAtSecs - this.#contents.startedAt.atSec).toPlainObject()
     };
 
     Object.assign(this.#contents, ProcessInfo.ephemeralInfo);

--- a/src/builtin-services/export/RateLimiter.js
+++ b/src/builtin-services/export/RateLimiter.js
@@ -243,8 +243,8 @@ export class RateLimiter extends BaseService {
         MustBe.number(maxQueueSize, { minInclusive: 0, maxInclusive: 1e100 });
       }
 
-      const flowRate = Config.#flowRatePerSecFrom(origFlowRate, timeUnit);
-      const result   = { flowRate, maxBurstSize, maxQueueSize };
+      const flowRatePerSec = Config.#flowRatePerSecFrom(origFlowRate, timeUnit);
+      const result   = { flowRatePerSec, maxBurstSize, maxQueueSize };
 
       if (maxQueueGrantSize !== null) {
         result.maxQueueGrantSize = maxQueueGrantSize;

--- a/src/builtin-services/export/RateLimiter.js
+++ b/src/builtin-services/export/RateLimiter.js
@@ -137,8 +137,8 @@ export class RateLimiter extends BaseService {
     }
 
     const got = await bucket.requestGrant(1);
-    if (got.waitTime > 0) {
-      logger?.rateLimiterWaited(got.waitTime);
+    if (got.waitTimeSec > 0) {
+      logger?.rateLimiterWaited(got.waitTimeSec);
     }
 
     if (!got.done) {

--- a/src/builtin-services/private/RateLimitedStream.js
+++ b/src/builtin-services/private/RateLimitedStream.js
@@ -230,8 +230,8 @@ export class RateLimitedStream {
       const grantResult = await this.#bucket.requestGrant(
         { minInclusive: 1, maxInclusive: remaining });
 
-      if (grantResult.waitTime !== 0) {
-        this.#logger?.waited(grantResult.waitTime);
+      if (grantResult.waitTimeSec !== 0) {
+        this.#logger?.waited(grantResult.waitTimeSec);
       }
 
       if (!grantResult.done) {

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -26,18 +26,18 @@ export class Moment {
    * @type {number} The moment being represented, in the form of seconds since
    * the Unix Epoch.
    */
-  #atSecs;
+  #atSec;
 
   /**
    * Constructs an instance.
    *
-   * @param {number|bigint} atSecs The moment to represent, in the form of
+   * @param {number|bigint} atSec The moment to represent, in the form of
    *   seconds since the Unix Epoch. Must be finite.
    */
-  constructor(atSecs) {
-    this.#atSecs = (typeof atSecs === 'bigint')
-      ? Number(atSecs)
-      : MustBe.number(atSecs, { finite: true });
+  constructor(atSec) {
+    this.#atSec = (typeof atSec === 'bigint')
+      ? Number(atSec)
+      : MustBe.number(atSec, { finite: true });
 
     Object.freeze(this);
   }
@@ -47,15 +47,15 @@ export class Moment {
    * since the Unix Epoch.
    */
   get atMsec() {
-    return this.#atSecs * 1000;
+    return this.#atSec * 1000;
   }
 
   /**
    * @returns {number} The moment being represented, in the form of seconds
    * since the Unix Epoch.
    */
-  get atSecs() {
-    return this.#atSecs;
+  get atSec() {
+    return this.#atSec;
   }
 
   /**
@@ -66,7 +66,7 @@ export class Moment {
    */
   add(duration) {
     MustBe.instanceOf(duration, Duration);
-    return new Moment(this.#atSecs + duration.secs);
+    return new Moment(this.#atSec + duration.secs);
   }
 
   /**
@@ -77,7 +77,7 @@ export class Moment {
    */
   addSecs(secs) {
     MustBe.number(secs, { finite: true });
-    return new Moment(this.#atSecs + secs);
+    return new Moment(this.#atSec + secs);
   }
 
   /**
@@ -90,7 +90,7 @@ export class Moment {
    */
   equals(other) {
     return (other instanceof Moment)
-      && (this.#atSecs === other.#atSecs);
+      && (this.#atSec === other.#atSec);
   }
 
   /**
@@ -101,7 +101,7 @@ export class Moment {
    */
   isAfter(other) {
     MustBe.instanceOf(other, Moment);
-    return this.#atSecs > other.#atSecs;
+    return this.#atSec > other.#atSec;
   }
 
   /**
@@ -112,7 +112,7 @@ export class Moment {
    */
   isBefore(other) {
     MustBe.instanceOf(other, Moment);
-    return this.#atSecs < other.#atSecs;
+    return this.#atSec < other.#atSec;
   }
 
   /**
@@ -123,7 +123,7 @@ export class Moment {
    */
   subtract(other) {
     MustBe.instanceOf(other, Moment);
-    return new Duration(this.#atSecs - other.#atSecs);
+    return new Duration(this.#atSec - other.#atSec);
   }
 
   /**
@@ -133,7 +133,7 @@ export class Moment {
    * @returns {string} The HTTP standard form.
    */
   toHttpString() {
-    return Moment.httpStringFromSecs(this.#atSecs);
+    return Moment.httpStringFromSecs(this.#atSec);
   }
 
   /**
@@ -146,7 +146,7 @@ export class Moment {
    * @returns {object} Friendly representation object.
    */
   toPlainObject(options = {}) {
-    return Moment.plainObjectFromSecs(this.#atSecs, options);
+    return Moment.plainObjectFromSecs(this.#atSec, options);
   }
 
   /**
@@ -159,7 +159,7 @@ export class Moment {
    * @returns {string} The friendly time string.
    */
   toString(options = {}) {
-    return Moment.stringFromSecs(this.#atSecs, options);
+    return Moment.stringFromSecs(this.#atSec, options);
   }
 
   /**
@@ -173,7 +173,7 @@ export class Moment {
     // instance. TODO: Re-evaluate this tactic.
     const str = this.toString({ decimals: 6 });
 
-    return new Struct(Moment, null, this.#atSecs, str);
+    return new Struct(Moment, null, this.#atSec, str);
   }
 
 
@@ -201,16 +201,16 @@ export class Moment {
    * **Note:** The HTTP standard, RFC 9110 section 5.6.7 in particular, is very
    * specific about the format.
    *
-   * @param {number|bigint} atSecs Time in the form of seconds since the Unix
+   * @param {number|bigint} atSec Time in the form of seconds since the Unix
    *   Epoch.
    * @returns {string} The HTTP standard form.
    */
-  static httpStringFromSecs(atSecs) {
-    atSecs = (typeof atSecs === 'bigint')
-      ? Number(atSecs)
-      : MustBe.number(atSecs, { finite: true });
+  static httpStringFromSecs(atSec) {
+    atSec = (typeof atSec === 'bigint')
+      ? Number(atSec)
+      : MustBe.number(atSec, { finite: true });
 
-    return new Date(atSecs * 1000).toUTCString();
+    return new Date(atSec * 1000).toUTCString();
   }
 
   /**
@@ -218,16 +218,16 @@ export class Moment {
    * represents both seconds since the Unix Epoch as well as a string indicating
    * the date-time in UTC.
    *
-   * @param {number} atSecs The moment to represent, in the form of seconds
+   * @param {number} atSec The moment to represent, in the form of seconds
    *   since the Unix Epoch.
    * @param {object} [options] Formatting options, as with {@link
    *   #stringFromSecs}.
    * @returns {object} Friendly representation object.
    */
-  static plainObjectFromSecs(atSecs, options = {}) {
+  static plainObjectFromSecs(atSec, options = {}) {
     return {
-      atSecs,
-      utc: Moment.stringFromSecs(atSecs, options)
+      atSec,
+      utc: Moment.stringFromSecs(atSec, options)
     };
   }
 
@@ -235,7 +235,7 @@ export class Moment {
    * Makes a date-time string in a reasonably pithy and understandable form. The
    * result is a string representing the date-time in UTC.
    *
-   * @param {number} atSecs Time in the form of seconds since the Unix Epoch.
+   * @param {number} atSec Time in the form of seconds since the Unix Epoch.
    * @param {object} [options] Formatting options.
    * @param {boolean} [options.colons] Use colons to separate the
    *   time-of-day components?
@@ -243,7 +243,7 @@ export class Moment {
    *    of precision. **Note:** Fractions of seconds are truncated, not rounded.
    * @returns {string} The friendly time string.
    */
-  static stringFromSecs(atSecs, options = {}) {
+  static stringFromSecs(atSec, options = {}) {
     const { colons = true, decimals = 0 } = options;
 
     // Formats a number as *t*wo *d*igits.
@@ -253,17 +253,17 @@ export class Moment {
 
     // Creates the fractional seconds part of the string.
     const makeFrac = () => {
-      // Non-obvious: If you take `atSecs % 1` and then operate on the remaining
+      // Non-obvious: If you take `atSec % 1` and then operate on the remaining
       // fraction, you can end up with a string representation that's off by 1,
       // because of floating point (im)precision. That's why we _don't_ do that.
       const tenPower = 10 ** decimals;
-      const frac     = Math.floor(atSecs * tenPower % tenPower);
+      const frac     = Math.floor(atSec * tenPower % tenPower);
       const result   = frac.toString().padStart(decimals, '0');
 
       return `.${result}`;
     };
 
-    const when    = new Date(atSecs * 1000);
+    const when    = new Date(atSec * 1000);
     const date    = when.getUTCDate();
     const month   = when.getUTCMonth();
     const year    = when.getUTCFullYear();

--- a/src/data-values/tests/Moment.test.js
+++ b/src/data-values/tests/Moment.test.js
@@ -31,15 +31,15 @@ describe('constructor()', () => {
   });
 });
 
-describe('.atSecs', () => {
+describe('.atSec', () => {
   test('returns the value from the constructor', () => {
-    expect(new Moment(0).atSecs).toBe(0);
-    expect(new Moment(123).atSecs).toBe(123);
-    expect(new Moment(456.789).atSecs).toBe(456.789);
+    expect(new Moment(0).atSec).toBe(0);
+    expect(new Moment(123).atSec).toBe(123);
+    expect(new Moment(456.789).atSec).toBe(456.789);
   });
 
   test('returns a converted bigint', () => {
-    expect(new Moment(123999n).atSecs).toBe(123999);
+    expect(new Moment(123999n).atSec).toBe(123999);
   });
 });
 
@@ -89,7 +89,7 @@ ${'addSecs'} | ${false}
     const arg    = passDuration ? new Duration(secs) : secs;
     const result = mobj[methodName](arg);
 
-    expect(result.atSecs).toBe(expected);
+    expect(result.atSec).toBe(expected);
   });
 });
 
@@ -114,7 +114,7 @@ ${'toHttpString'}         | ${false}
 `('$method()', ({ method, isStatic }) => {
   // Failure cases.
   test.each`
-  atSecs
+  atSec
   ${NaN}
   ${+Infinity}
   ${-Infinity}
@@ -122,11 +122,11 @@ ${'toHttpString'}         | ${false}
   ${null}
   ${'12345'}
   ${[12345]}
-  `('fails given $atSecs', ({ atSecs }) => {
+  `('fails given $atSec', ({ atSec }) => {
     const doIt = () => {
       return isStatic
-        ? Moment[method](atSecs)
-        : new Moment(atSecs)[method]();
+        ? Moment[method](atSec)
+        : new Moment(atSec)[method]();
     };
 
     expect(doIt).toThrow();
@@ -134,7 +134,7 @@ ${'toHttpString'}         | ${false}
 
   // Success cases.
   test.each`
-  atSecs        | expected
+  atSec         | expected
   ${0}          | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
   ${0.00001}    | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
   ${0.1}        | ${'Thu, 01 Jan 1970 00:00:00 GMT'}
@@ -162,10 +162,10 @@ ${'toHttpString'}         | ${false}
   ${1004527353} | ${'Wed, 31 Oct 2001 11:22:33 GMT'}
   ${1004577804} | ${'Thu, 01 Nov 2001 01:23:24 GMT'}
   ${1007885236} | ${'Sun, 09 Dec 2001 08:07:16 GMT'}
-  `('with ($atSecs)', ({ atSecs, expected }) => {
+  `('with ($atSec)', ({ atSec, expected }) => {
     const result = isStatic
-      ? Moment[method](atSecs)
-      : new Moment(atSecs)[method]();
+      ? Moment[method](atSec)
+      : new Moment(atSec)[method]();
 
     expect(result).toBe(expected);
   });
@@ -179,7 +179,7 @@ ${'toPlainObject'}        | ${false}  | ${true}
 ${'toString'}             | ${false}  | ${false}
 `('$method()', ({ method, isStatic, returnsObject }) => {
   test.each`
-  atSecs              | options                           | expected
+  atSec               | options                           | expected
   ${0}                | ${undefined}                      | ${'19700101-00:00:00'}
   ${-14195365}        | ${undefined}                      | ${'19690720-16:50:35'}
   ${1666016999.99999} | ${undefined}                      | ${'20221017-14:29:59'}
@@ -207,13 +207,13 @@ ${'toString'}             | ${false}  | ${false}
   ${1673916141.1234}  | ${{ colons: true }}               | ${'20230117-00:42:21'}
   ${1673916141.1234}  | ${{ colons: true, decimals: 1 }}  | ${'20230117-00:42:21.1'}
   ${1673916141.1234}  | ${{ colons: true, decimals: 2 }}  | ${'20230117-00:42:21.12'}
-  `('with ($atSecs, $options)', ({ atSecs, options, expected }) => {
+  `('with ($atSec, $options)', ({ atSec, options, expected }) => {
     const result = isStatic
-      ? Moment[method](atSecs, options)
-      : new Moment(atSecs)[method](options);
+      ? Moment[method](atSec, options)
+      : new Moment(atSec)[method](options);
 
     if (returnsObject) {
-      expect(result).toStrictEqual({ atSecs, utc: expected });
+      expect(result).toStrictEqual({ atSec, utc: expected });
     } else {
       expect(result).toBe(expected);
     }
@@ -224,7 +224,7 @@ describe('fromMsec()', () => {
   test('produces an instance with 1/1000 the given value', () => {
     for (let atMsec = -12345; atMsec < 1999988877; atMsec += 10000017) {
       const result = Moment.fromMsec(atMsec);
-      expect(result.atSecs).toBe(atMsec / 1000);
+      expect(result.atSec).toBe(atMsec / 1000);
     }
   });
 });

--- a/src/host/export/KeepRunning.js
+++ b/src/host/export/KeepRunning.js
@@ -66,7 +66,7 @@ export class KeepRunning {
    * stop.
    */
   async #keepRunning() {
-    const startedAtSecs = ProcessInfo.allInfo.startedAt.atSecs;
+    const startedAtSecs = ProcessInfo.allInfo.startedAt.atSec;
 
     this.#logger.running();
 

--- a/src/loggy/export/BaseLoggingEnvironment.js
+++ b/src/loggy/export/BaseLoggingEnvironment.js
@@ -122,11 +122,11 @@ export class BaseLoggingEnvironment {
    */
   now() {
     const result = MustBe.instanceOf(this._impl_now(), Moment);
-    const atSecs = result.atSecs;
+    const atSec = result.atSec;
 
-    if (atSecs < BaseLoggingEnvironment.MIN_REASONABLE_NOW_SEC) {
+    if (atSec < BaseLoggingEnvironment.MIN_REASONABLE_NOW_SEC) {
       throw new Error('Too small to be a reasonable "now."');
-    } else if (atSecs > BaseLoggingEnvironment.MAX_REASONABLE_NOW_SEC) {
+    } else if (atSec > BaseLoggingEnvironment.MAX_REASONABLE_NOW_SEC) {
       throw new Error('Too large to be a reasonable "now."');
     }
 

--- a/src/loggy/export/IdGenerator.js
+++ b/src/loggy/export/IdGenerator.js
@@ -27,11 +27,11 @@ export class IdGenerator {
   /**
    * Makes a new ID.
    *
-   * @param {number} nowSecs The current time in _seconds_.
+   * @param {number} nowSec The current time in _seconds_.
    * @returns {string} An appropriately-constructed ID.
    */
-  makeId(nowSecs) {
-    const minuteNumber = Math.trunc(nowSecs * IdGenerator.#MINS_PER_SEC) & 0xfffff;
+  makeId(nowSec) {
+    const minuteNumber = Math.trunc(nowSec * IdGenerator.#MINS_PER_SEC) & 0xfffff;
 
     if (minuteNumber !== this.#minuteNumber) {
       this.#minuteNumber   = minuteNumber;
@@ -41,7 +41,7 @@ export class IdGenerator {
     const sequenceNumber = this.#sequenceNumber;
     this.#sequenceNumber++;
 
-    const preStr = IdGenerator.#makePrefix(nowSecs, sequenceNumber);
+    const preStr = IdGenerator.#makePrefix(nowSec, sequenceNumber);
     const minStr = minuteNumber.toString(16).padStart(5, '0');
     const seqStr = (sequenceNumber < 0x10000)
       ? sequenceNumber.toString(16).padStart(4, '0')
@@ -58,12 +58,12 @@ export class IdGenerator {
   /**
    * Makes a prefix string based on a time value and sequence number.
    *
-   * @param {number} nowSecs Recent time value in seconds.
+   * @param {number} nowSec Recent time value in seconds.
    * @param {number} sequenceNumber Recent / current sequence number.
    * @returns {string} A prefix string.
    */
-  static #makePrefix(nowSecs, sequenceNumber) {
-    const base   = (nowSecs * 1000) + (sequenceNumber * ((26 * 3) + 1));
+  static #makePrefix(nowSec, sequenceNumber) {
+    const base   = (nowSec * 1000) + (sequenceNumber * ((26 * 3) + 1));
     const digit1 = base % 26;
     const digit2 = Math.trunc(base / 26) % 26;
     const char1  = String.fromCharCode(digit1 + this.#LOWERCASE_A);

--- a/src/loggy/export/StdLoggingEnvironment.js
+++ b/src/loggy/export/StdLoggingEnvironment.js
@@ -24,7 +24,7 @@ export class StdLoggingEnvironment extends BaseLoggingEnvironment {
   /** @type {bigint} Last result from `hrtime.bigint()`. */
   #lastHrtimeNsec = -1n;
 
-  /** @type {bigint} Last result from {@link #nowSecs}, as a `bigint`. */
+  /** @type {bigint} Last result from {@link #nowSec}, as a `bigint`. */
   #lastNowNsec = -1n;
 
   /**
@@ -45,7 +45,7 @@ export class StdLoggingEnvironment extends BaseLoggingEnvironment {
 
   /** @override */
   _impl_makeId() {
-    return this.#idGenerator.makeId(this.#nowSecs());
+    return this.#idGenerator.makeId(this.#nowSec());
   }
 
   /** @override */
@@ -56,7 +56,7 @@ export class StdLoggingEnvironment extends BaseLoggingEnvironment {
 
   /** @override */
   _impl_now() {
-    return new Moment(this.#nowSecs());
+    return new Moment(this.#nowSec());
   }
 
   /**
@@ -64,7 +64,7 @@ export class StdLoggingEnvironment extends BaseLoggingEnvironment {
    *
    * @returns {number} "Now," as a number of seconds.
    */
-  #nowSecs() {
+  #nowSec() {
     // What's going on here: We attempt to use `hrtime()` -- which has nsec
     // precision but an arbitrary zero-time, and which we don't assume runs at
     // exactly (effective) wall-clock rate -- to improve on the precision of

--- a/src/metacomp/export/IntfTimeSource.js
+++ b/src/metacomp/export/IntfTimeSource.js
@@ -12,14 +12,9 @@ import { Methods } from '@this/typey';
 export class IntfTimeSource {
   // Note: The default constructor is fine.
 
-  /** @returns {string} The name of the unit which this instance uses. */
-  get unitName() {
-    return Methods.abstract();
-  }
-
   /**
-   * Gets the current time, in arbitrary time units (ATU) which have elapsed
-   * since an arbitrary base time.
+   * Gets the current time, as a standard Unix Epoch time in seconds (_not_
+   * milliseconds).
    *
    * @abstract
    * @returns {number} The current time.

--- a/src/metacomp/export/IntfTimeSource.js
+++ b/src/metacomp/export/IntfTimeSource.js
@@ -19,12 +19,12 @@ export class IntfTimeSource {
    * @abstract
    * @returns {number} The current time.
    */
-  now() {
+  nowSec() {
     return Methods.abstract();
   }
 
   /**
-   * Async-returns `null` when {@link #now} would return a value at or beyond
+   * Async-returns `null` when {@link #nowSec} would return a value at or beyond
    * the given time, with the hope that the actual time will be reasonably
    * close.
    *

--- a/src/metacomp/export/StdTimeSource.js
+++ b/src/metacomp/export/StdTimeSource.js
@@ -8,16 +8,10 @@ import { IntfTimeSource } from '#x/IntfTimeSource';
 
 /**
  * Standard implementation of {@link #IntfTimeSource}, which uses "wall time"
- * as provided by the JavaScript / Node implementation, and for which the ATU
- * is actually a second (_not_ a msec).
+ * as provided by the JavaScript / Node implementation.
  */
 export class StdTimeSource extends IntfTimeSource {
   // Note: The default constructor is fine.
-
-  /** @override */
-  get unitName() {
-    return 'seconds';
-  }
 
   /** @override */
   now() {

--- a/src/metacomp/export/StdTimeSource.js
+++ b/src/metacomp/export/StdTimeSource.js
@@ -14,14 +14,14 @@ export class StdTimeSource extends IntfTimeSource {
   // Note: The default constructor is fine.
 
   /** @override */
-  now() {
+  nowSec() {
     return Date.now() * StdTimeSource.#SECS_PER_MSEC;
   }
 
   /** @override */
   async waitUntil(time) {
     for (;;) {
-      const delay = time - this.now();
+      const delay = time - this.nowSec();
       if ((delay <= 0) || !Number.isFinite(delay)) {
         break;
       }

--- a/src/sys-config/export/FileServiceConfig.js
+++ b/src/sys-config/export/FileServiceConfig.js
@@ -156,7 +156,7 @@ export class FileServiceConfig extends ServiceConfig {
     }
 
     // File already existed; just update the modification time.
-    const now = new Date();
-    await fs.utimes(path, now, now);
+    const dateNow = new Date();
+    await fs.utimes(path, dateNow, dateNow);
   }
 }


### PR DESCRIPTION
This PR renames a bunch of `now`s in the system that refer to numerical seconds to instead be `nowSec`. This is to avoid confustion with other `now`s that refer to `Moment` instances, and to make room to introduce such `now`s along side of the now-`nowSec` things.

This also fixed some pre-existing `nowSecs` and `atSecs` to be `nowSec` and `atSec` instead. This is for plural consistency with other pre-existing properties called `*Msec` (and not `*Msecs`).