### PR TITLE
Time for `Moment`s

### DIFF
--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { Moment } from '@this/data-values';
 import { IntfTimeSource, StdTimeSource } from '@this/metacomp';
 import { MustBe } from '@this/typey';
 
@@ -204,7 +205,7 @@ export class TokenBucket {
    *   is, the quantity of tokens that could potentially be reserved for new
    *   grant waiters. If this instance has no limit on the queue size, then
    *   this is `Number.POSITIVE_INFINITY`.
-   * * `{number} nowSec` -- The time as of the snapshot, according to this
+   * * `{Moment} now` -- The time as of the snapshot, according to this
    *   instance's time source.
    * * `{number} waiterCount` -- The number of queued (awaited) grant requests.
    *
@@ -214,7 +215,7 @@ export class TokenBucket {
     return {
       availableBurstSize: this.#lastBurstSize,
       availableQueueSize: this.#maxQueueSize - this.#queueSize,
-      nowSec:             this.#lastNowSec,
+      now:                new Moment(this.#lastNowSec),
       waiterCount:        this.#waiters.length,
     };
   }

--- a/src/async/package.json
+++ b/src/async/package.json
@@ -12,6 +12,7 @@
   },
 
   "dependencies": {
+    "@this/data-values": "*",
     "@this/metacomp": "*",
     "@this/typey": "*"
   }

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -38,13 +38,13 @@ class MockTimeSource extends IntfTimeSource {
       throw new Error(`MockTimeSource ended! (Time was ${this.#now.atSec}.)`);
     }
 
-    if (time <= this.#now.atSec) {
+    if (time.atSec <= this.#now.atSec) {
       return;
     }
 
     const mp = new ManualPromise();
     this.#timeouts.push({
-      at:      time,
+      at:      time.atSec,
       resolve: () => mp.resolve()
     });
 
@@ -735,7 +735,10 @@ describe('takeNow()', () => {
         flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 123, timeSource: time });
 
       const result = bucket.takeNow(123);
-      expect(result).toStrictEqual({ done: true, grant: 123, waitUntil: nowSec });
+      expect(result.done).toBeTrue();
+      expect(result.grant).toBe(123);
+      expect(result.waitUntil.atSec).toBe(nowSec);
+
       expect(bucket.latestState().availableBurstSize).toBe(0);
 
       time._end();
@@ -750,7 +753,7 @@ describe('takeNow()', () => {
       const result = bucket.takeNow({ minInclusive: 10, maxInclusive: 110 });
       expect(result.done).toBeTrue();
       expect(result.grant).toBe(100);
-      expect(result.waitUntil).toBe(nowSec + 0);
+      expect(result.waitUntil.atSec).toBe(nowSec + 0);
 
       expect(bucket.latestState().availableBurstSize).toBe(0);
 
@@ -769,7 +772,7 @@ describe('takeNow()', () => {
       const result1 = bucket.takeNow({ minInclusive: 10, maxInclusive: 200 });
       expect(result1.done).toBeTrue();
       expect(result1.grant).toBe(75);
-      expect(result1.waitUntil).toBe(nowSec + 0);
+      expect(result1.waitUntil.atSec).toBe(nowSec + 0);
 
       expect(bucket.latestState().availableBurstSize).toBe(0);
 
@@ -787,7 +790,7 @@ describe('takeNow()', () => {
       const result = bucket.takeNow({ minInclusive: 0, maxInclusive: 10 });
       expect(result.done).toBeTrue();
       expect(result.grant).toBe(5);
-      expect(result.waitUntil).toBe(now1 + 0);
+      expect(result.waitUntil.atSec).toBe(now1 + 0);
 
       const latest = bucket.latestState();
       expect(latest.availableBurstSize).toBe(0);
@@ -805,7 +808,7 @@ describe('takeNow()', () => {
       const result = bucket.takeNow({ minInclusive: 2, maxInclusive: 91 });
       expect(result.done).toBeFalse();
       expect(result.grant).toBe(0);
-      expect(result.waitUntil).toBe(nowSec + (10 / 5));
+      expect(result.waitUntil.atSec).toBe(nowSec + (10 / 5));
 
       time._end();
     });
@@ -819,7 +822,7 @@ describe('takeNow()', () => {
       const result = bucket.takeNow({ minInclusive: 12, maxInclusive: 31 });
       expect(result.done).toBeFalse();
       expect(result.grant).toBe(0);
-      expect(result.waitUntil).toBe(nowSec + (20 - 5) / 10);
+      expect(result.waitUntil.atSec).toBe(nowSec + (20 - 5) / 10);
 
       time._end();
     });
@@ -882,7 +885,7 @@ describe('takeNow()', () => {
       const result = bucket.takeNow({ minInclusive: 0, maxInclusive: 26 });
       expect(result.done).toBeTrue();
       expect(result.grant).toBe(0);
-      expect(result.waitUntil).toBe(nowSec + 0);
+      expect(result.waitUntil.atSec).toBe(nowSec + 0);
 
       // Get the bucket to quiesce.
       time._setTime(nowSec + 1000);
@@ -906,7 +909,7 @@ describe('takeNow()', () => {
       const result = bucket.takeNow({ minInclusive: 700, maxInclusive: 1400 });
       expect(result.done).toBeFalse();
       expect(result.grant).toBe(0);
-      expect(result.waitUntil).toBe(nowSec + ((300 + 1000) / 10));
+      expect(result.waitUntil.atSec).toBe(nowSec + ((300 + 1000) / 10));
 
       // Get the bucket to quiesce.
       time._setTime(nowSec + 1000);
@@ -930,7 +933,7 @@ describe('takeNow()', () => {
       const result = bucket.takeNow({ minInclusive: 700, maxInclusive: 1400 });
       expect(result.done).toBeFalse();
       expect(result.grant).toBe(0);
-      expect(result.waitUntil).toBe(nowSec + ((300 + 1000 - 200) / 10));
+      expect(result.waitUntil.atSec).toBe(nowSec + ((300 + 1000 - 200) / 10));
 
       // Get the bucket to quiesce.
       time._setTime(nowSec + 1000);
@@ -962,7 +965,7 @@ describe('takeNow()', () => {
       const result = bucket.takeNow({ minInclusive: 0, maxInclusive: 5 });
       expect(result.done).toBeTrue();
       expect(result.grant).toBe(2);
-      expect(result.waitUntil).toBe(now1 + 0);
+      expect(result.waitUntil.atSec).toBe(now1 + 0);
 
       time._end();
     });

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -170,7 +170,7 @@ describe('constructor()', () => {
     const ts = new MockTimeSource(321);
     const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, timeSource: ts });
     expect(bucket.config.timeSource).toBe(ts);
-    expect(bucket.latestState().nowSec).toBe(321);
+    expect(bucket.latestState().now.atSec).toBe(321);
   });
 
   test('produces an instance which (apparently) uses the default time source if not passed `timeSource`', () => {
@@ -660,7 +660,7 @@ describe('latestState()', () => {
   test('has exactly the expected properties', () => {
     const bucket = new TokenBucket({ flowRatePerSec: 123, maxBurstSize: 100000 });
     expect(bucket.latestState()).toContainAllKeys([
-      'availableBurstSize', 'availableQueueSize', 'nowSec', 'waiterCount'
+      'availableBurstSize', 'availableQueueSize', 'now', 'waiterCount'
     ]);
   });
 
@@ -670,7 +670,7 @@ describe('latestState()', () => {
       flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 100, timeSource: time });
 
     const baseResult = bucket.latestState();
-    expect(baseResult.nowSec).toBe(900);
+    expect(baseResult.now.atSec).toBe(900);
     expect(baseResult.availableBurstSize).toBe(100);
 
     time._setTime(901);
@@ -791,7 +791,7 @@ describe('takeNow()', () => {
 
       const latest = bucket.latestState();
       expect(latest.availableBurstSize).toBe(0);
-      expect(latest.nowSec).toBe(1001);
+      expect(latest.now.atSec).toBe(1001);
 
       time._end();
     });

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -806,7 +806,9 @@ describe('takeNow()', () => {
       const nowSec = 91400;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 5, maxBurstSize: 10000, initialBurstSize: 75, maxQueueGrantSize: 50, timeSource: time });
+        flowRatePerSec: 5, maxBurstSize: 10000, initialBurstSize: 75,
+        maxQueueGrantSize: 50, timeSource: time
+      });
 
       // Notably, this is not supposed to be clamped to `maxQueueGrantSize`,
       // because this request isn't being queued (that is, there's no
@@ -841,7 +843,9 @@ describe('takeNow()', () => {
       const nowSec = 1000;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 5, maxBurstSize: 100, initialBurstSize: 0, maxQueueGrantSize: 10, timeSource: time });
+        flowRatePerSec: 5, maxBurstSize: 100, initialBurstSize: 0,
+        maxQueueGrantSize: 10, timeSource: time
+      });
 
       const result = bucket.takeNow({ minInclusive: 2, maxInclusive: 91 });
       checkTakeNow(result, { done: false, grant: 0, waitUntil: nowSec + (10/5) });
@@ -856,7 +860,9 @@ describe('takeNow()', () => {
       const nowSec = 1000;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 10, maxBurstSize: 100, initialBurstSize: 5, maxQueueGrantSize: 20, timeSource: time });
+        flowRatePerSec: 10, maxBurstSize: 100, initialBurstSize: 5,
+        maxQueueGrantSize: 20, timeSource: time
+      });
 
       const result = bucket.takeNow({ minInclusive: 12, maxInclusive: 31 });
       checkTakeNow(result, { done: false, grant: 0, waitUntil: nowSec + (20 - 5) / 10 });
@@ -877,7 +883,9 @@ describe('takeNow()', () => {
           const nowSec = 10;
           const time   = new MockTimeSource(nowSec);
           const bucket = new TokenBucket({
-            partialTokens: false, flowRatePerSec: 1, maxBurstSize: 100, initialBurstSize: available, timeSource: time });
+            partialTokens: false, flowRatePerSec: 1, maxBurstSize: 100,
+            initialBurstSize: available, timeSource: time
+          });
 
           const result = bucket.takeNow({ minInclusive, maxInclusive });
           checkTakeNow(result, { ...expected, waitUntil: 'any' });
@@ -933,7 +941,9 @@ describe('takeNow()', () => {
       const nowSec = 50015;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 10, maxBurstSize: 10000, initialBurstSize: 0, maxQueueGrantSize: 1000, timeSource: time });
+        flowRatePerSec: 10, maxBurstSize: 10000, initialBurstSize: 0,
+        maxQueueGrantSize: 1000, timeSource: time
+      });
 
       // Setup / baseline assumptions.
       const requestResult = bucket.requestGrant(300);
@@ -955,7 +965,9 @@ describe('takeNow()', () => {
       const nowSec = 60015;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 10, maxBurstSize: 10000, initialBurstSize: 200, maxQueueGrantSize: 1000, timeSource: time });
+        flowRatePerSec: 10, maxBurstSize: 10000, initialBurstSize: 200,
+        maxQueueGrantSize: 1000, timeSource: time
+      });
 
       // Setup / baseline assumptions.
       const requestResult = bucket.requestGrant(300);

--- a/src/builtin-services/export/RateLimiter.js
+++ b/src/builtin-services/export/RateLimiter.js
@@ -137,8 +137,8 @@ export class RateLimiter extends BaseService {
     }
 
     const got = await bucket.requestGrant(1);
-    if (got.waitTimeSec > 0) {
-      logger?.rateLimiterWaited(got.waitTimeSec);
+    if (got.waitTime.secs > 0) {
+      logger?.rateLimiterWaited(got.waitTime);
     }
 
     if (!got.done) {

--- a/src/builtin-services/private/RateLimitedStream.js
+++ b/src/builtin-services/private/RateLimitedStream.js
@@ -230,8 +230,8 @@ export class RateLimitedStream {
       const grantResult = await this.#bucket.requestGrant(
         { minInclusive: 1, maxInclusive: remaining });
 
-      if (grantResult.waitTimeSec !== 0) {
-        this.#logger?.waited(grantResult.waitTimeSec);
+      if (grantResult.waitTime.secs !== 0) {
+        this.#logger?.waited(grantResult.waitTime);
       }
 
       if (!grantResult.done) {

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -77,6 +77,9 @@ export class Duration {
   // Static members
   //
 
+  /** @type {Duration} Instance with value of `0`. */
+  static ZERO = new Duration(0);
+
   /**
    * Makes a friendly plain object representing a time duration, with both an
    * exact number of seconds (the original value) and a human-oriented string

--- a/src/data-values/tests/Duration.test.js
+++ b/src/data-values/tests/Duration.test.js
@@ -153,5 +153,5 @@ describe('stringFromSecs()', () => {
 describe('.ZERO', () => {
   test('has the value `0`', () => {
     expect(Duration.ZERO.secs).toBe(0);
-  })
+  });
 });

--- a/src/data-values/tests/Duration.test.js
+++ b/src/data-values/tests/Duration.test.js
@@ -149,3 +149,9 @@ describe('stringFromSecs()', () => {
     expect(result).toBe(duration);
   });
 });
+
+describe('.ZERO', () => {
+  test('has the value `0`', () => {
+    expect(Duration.ZERO.secs).toBe(0);
+  })
+});

--- a/src/metacomp/export/IntfTimeSource.js
+++ b/src/metacomp/export/IntfTimeSource.js
@@ -1,16 +1,27 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { Moment } from '@this/data-values';
 import { Methods } from '@this/typey';
 
 
 /**
- * Interface for accessing a source of time information.
+ * Interface for accessing and utilizing a source of time information.
  *
  * @interface
  */
 export class IntfTimeSource {
   // Note: The default constructor is fine.
+
+  /**
+   * Gets the current time.
+   *
+   * @abstract
+   * @returns {Moment} The current time.
+   */
+  now() {
+    return Methods.abstract();
+  }
 
   /**
    * Gets the current time, as a standard Unix Epoch time in seconds (_not_

--- a/src/metacomp/export/IntfTimeSource.js
+++ b/src/metacomp/export/IntfTimeSource.js
@@ -35,7 +35,7 @@ export class IntfTimeSource {
   }
 
   /**
-   * Async-returns `null` when {@link #nowSec} would return a value at or beyond
+   * Async-returns `null` when {@link #now} would return a value at or beyond
    * the given time, with the hope that the actual time will be reasonably
    * close.
    *
@@ -43,7 +43,7 @@ export class IntfTimeSource {
    * not a duration.
    *
    * @abstract
-   * @param {number} time The time after which this method is to async-return.
+   * @param {Moment} time The time after which this method is to async-return.
    * @returns {null} `null`, always.
    */
   async waitUntil(time) {

--- a/src/metacomp/export/StdTimeSource.js
+++ b/src/metacomp/export/StdTimeSource.js
@@ -28,7 +28,7 @@ export class StdTimeSource extends IntfTimeSource {
   /** @override */
   async waitUntil(time) {
     for (;;) {
-      const delay = time - this.now().atSec;
+      const delay = time.atSec - this.now().atSec;
       if ((delay <= 0) || !Number.isFinite(delay)) {
         break;
       }

--- a/src/metacomp/export/StdTimeSource.js
+++ b/src/metacomp/export/StdTimeSource.js
@@ -3,6 +3,8 @@
 
 import * as timers from 'node:timers/promises';
 
+import { Moment } from '@this/data-values';
+
 import { IntfTimeSource } from '#x/IntfTimeSource';
 
 
@@ -14,14 +16,19 @@ export class StdTimeSource extends IntfTimeSource {
   // Note: The default constructor is fine.
 
   /** @override */
+  now() {
+    return new Moment(Date.now() * StdTimeSource.#SECS_PER_MSEC);
+  }
+
+  /** @override */
   nowSec() {
-    return Date.now() * StdTimeSource.#SECS_PER_MSEC;
+    return this.now().atSec;
   }
 
   /** @override */
   async waitUntil(time) {
     for (;;) {
-      const delay = time - this.nowSec();
+      const delay = time - this.now().atSec;
       if ((delay <= 0) || !Number.isFinite(delay)) {
         break;
       }

--- a/src/metacomp/package.json
+++ b/src/metacomp/package.json
@@ -12,6 +12,7 @@
   },
 
   "dependencies": {
+    "@this/data-values": "*",
     "@this/typey": "*"
   }
 }


### PR DESCRIPTION
This PR adds a `Moment`-returning `now()` to the interface `IntfTimeSource` (and all concrete implementations), and then switches `TokenBucket` to consistently use `Moment` and `Duration` instead of plain numbers.