### PR TITLE
Seconds to go!

### DIFF
--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -575,7 +575,7 @@ export class TokenBucket {
     const lastBurstSize = this.#lastBurstSize;
 
     if (lastBurstSize < this.#maxBurstSize) {
-      const elapsedTime   = now.subtract(this.#lastNow).secs;
+      const elapsedTime   = now.subtract(this.#lastNow).sec;
       const grant         = elapsedTime * this.#flowRatePerSec;
       this.#lastBurstSize = Math.min(lastBurstSize + grant, this.#maxBurstSize);
     }

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -21,14 +21,14 @@ async function checkGrant(grantPromise, expected) {
   expect(grant).toBeObject();
 
   const waitTimeSec = (expected.waitTime instanceof Duration)
-    ? expected.waitTime.secs
+    ? expected.waitTime.sec
     : expected.waitTime;
 
   expect(grant.done).toBe(expected.done);
   expect(grant.grant).toBe(expected.grant);
   expect(grant.reason).toBe(expected.reason);
   expect(grant.waitTime).toBeInstanceOf(Duration);
-  expect(grant.waitTime.secs).toBe(waitTimeSec);
+  expect(grant.waitTime.sec).toBe(waitTimeSec);
 }
 
 /**

--- a/src/builtin-services/export/MemoryMonitor.js
+++ b/src/builtin-services/export/MemoryMonitor.js
@@ -125,12 +125,14 @@ export class MemoryMonitor extends BaseService {
 
       let timeoutMsec = checkMsec;
       if (snapshot.actionAt) {
-        const msecUntilAction = snapshot.actionAt.subtract(snapshot.at).secs * 1000;
-        const msecUntilCheck  = Math.min(
+        const msecUntilAction =
+          snapshot.actionAt.subtract(snapshot.at).sec * 1000;
+        const msecUntilCheck = Math.min(
           checkMsec,
           Math.max(
             msecUntilAction * MemoryMonitor.#TROUBLE_CHECK_FRACTION,
             MemoryMonitor.#MIN_TROUBLE_CHECK_MSEC));
+
         timeoutMsec = msecUntilCheck;
       }
 

--- a/src/builtin-services/export/RateLimiter.js
+++ b/src/builtin-services/export/RateLimiter.js
@@ -137,7 +137,7 @@ export class RateLimiter extends BaseService {
     }
 
     const got = await bucket.requestGrant(1);
-    if (got.waitTime.secs > 0) {
+    if (got.waitTime.sec > 0) {
       logger?.rateLimiterWaited(got.waitTime);
     }
 

--- a/src/builtin-services/private/RateLimitedStream.js
+++ b/src/builtin-services/private/RateLimitedStream.js
@@ -230,7 +230,7 @@ export class RateLimitedStream {
       const grantResult = await this.#bucket.requestGrant(
         { minInclusive: 1, maxInclusive: remaining });
 
-      if (grantResult.waitTime.secs !== 0) {
+      if (grantResult.waitTime.sec !== 0) {
         this.#logger?.waited(grantResult.waitTime);
       }
 

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -21,10 +21,10 @@ export class Duration {
   /**
    * Constructs an instance.
    *
-   * @param {number} secs The number of seconds to represent. Must be finite.
+   * @param {number} sec The number of seconds to represent. Must be finite.
    */
-  constructor(secs) {
-    this.#sec = MustBe.number(secs, { finite: true });
+  constructor(sec) {
+    this.#sec = MustBe.number(sec, { finite: true });
     Object.freeze(this);
   }
 
@@ -146,7 +146,7 @@ export class Duration {
       }
     }
 
-    // Convert `secs` to `BigInt`, because that makes the calculations much more
+    // We use bigints here because that makes the calculations much more
     // straightforward.
     const outputTenths = (durationSec < ((60 * 60) - 0.05));
     const totalTenths  = outputTenths

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -148,38 +148,38 @@ export class Duration {
 
     // We use bigints here because that makes the calculations much more
     // straightforward.
-    const outputTenths = (durationSec < ((60 * 60) - 0.05));
-    const totalTenths  = outputTenths
+    const outputTenth = (durationSec < ((60 * 60) - 0.05));
+    const totalTenths = outputTenth
       ? BigInt(Math.round(durationSec * 10))
       : BigInt(Math.round(durationSec) * 10);
 
-    const tenths = totalTenths % 10n;
-    const secs   = (totalTenths / 10n) % 60n;
-    const mins   = (totalTenths / (10n * 60n)) % 60n;
-    const hours  = (totalTenths / (10n * 60n * 60n)) % 24n;
-    const days   = totalTenths / (10n * 60n * 60n * 24n);
+    const tenth = totalTenths % 10n;
+    const sec   = (totalTenths / 10n) % 60n;
+    const min   = (totalTenths / (10n * 60n)) % 60n;
+    const hour  = (totalTenths / (10n * 60n * 60n)) % 24n;
+    const day   = totalTenths / (10n * 60n * 60n * 24n);
 
     const parts = [];
 
-    if (days > 0) {
-      parts.push(days, 'd ', hours);
-    } else if (hours > 0) {
-      parts.push(hours);
+    if (day > 0) {
+      parts.push(day, 'd ', hour);
+    } else if (hour > 0) {
+      parts.push(hour);
     }
     parts.push(':');
 
-    if (mins < 10) {
+    if (min < 10) {
       parts.push('0');
     }
-    parts.push(mins, ':');
+    parts.push(min, ':');
 
-    if (secs < 10) {
+    if (sec < 10) {
       parts.push('0');
     }
-    parts.push(secs);
+    parts.push(sec);
 
-    if (outputTenths) {
-      parts.push('.', tenths);
+    if (outputTenth) {
+      parts.push('.', tenth);
     }
 
     return parts.join('');

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -29,7 +29,7 @@ export class Duration {
   }
 
   /** @returns {number} The number of seconds being represented. */
-  get secs() {
+  get sec() {
     return this.#sec;
   }
 
@@ -91,7 +91,7 @@ export class Duration {
    */
   static plainObjectFromSec(durationSec) {
     return {
-      secs:     durationSec,
+      sec:      durationSec,
       duration: Duration.stringFromSec(durationSec)
     };
   }

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -16,7 +16,7 @@ import { Struct } from '#x/Struct';
  */
 export class Duration {
   /** @type {number} The number of seconds being represented. */
-  #secs;
+  #sec;
 
   /**
    * Constructs an instance.
@@ -24,13 +24,13 @@ export class Duration {
    * @param {number} secs The number of seconds to represent. Must be finite.
    */
   constructor(secs) {
-    this.#secs = MustBe.number(secs, { finite: true });
+    this.#sec = MustBe.number(secs, { finite: true });
     Object.freeze(this);
   }
 
   /** @returns {number} The number of seconds being represented. */
   get secs() {
-    return this.#secs;
+    return this.#sec;
   }
 
   /**
@@ -42,7 +42,7 @@ export class Duration {
    * @returns {object} Friendly compound object.
    */
   toPlainObject() {
-    return Duration.plainObjectFromSec(this.#secs);
+    return Duration.plainObjectFromSec(this.#sec);
   }
 
   /**
@@ -55,7 +55,7 @@ export class Duration {
    * @returns {string} The friendly form.
    */
   toString(options = {}) {
-    return Duration.stringFromSec(this.#secs, options);
+    return Duration.stringFromSec(this.#sec, options);
   }
 
   /**
@@ -67,9 +67,9 @@ export class Duration {
     // Note: This is included for the convenience of humans who happen to be
     // looking at logs (etc.), but is not actually used when reconstructing an
     // instance. TODO: Re-evaluate this tactic.
-    const str = Duration.stringFromSec(this.#secs);
+    const str = Duration.stringFromSec(this.#sec);
 
-    return new Struct(Duration, null, this.#secs, str);
+    return new Struct(Duration, null, this.#sec, str);
   }
 
 

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -267,14 +267,14 @@ export class Moment {
     const date    = when.getUTCDate();
     const month   = when.getUTCMonth();
     const year    = when.getUTCFullYear();
-    const hours   = when.getUTCHours();
-    const mins    = when.getUTCMinutes();
-    const secs    = when.getUTCSeconds();
+    const hour    = when.getUTCHours();
+    const min     = when.getUTCMinutes();
+    const sec     = when.getUTCSeconds();
     const timeSep = colons ? ':' : '';
     const frac    = (decimals === 0) ? '' : makeFrac();
 
     return '' +
       `${year}${td(month + 1)}${td(date)}-` +
-      `${td(hours)}${timeSep}${td(mins)}${timeSep}${td(secs)}${frac}`;
+      `${td(hour)}${timeSep}${td(min)}${timeSep}${td(sec)}${frac}`;
   }
 }

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -66,18 +66,18 @@ export class Moment {
    */
   add(duration) {
     MustBe.instanceOf(duration, Duration);
-    return new Moment(this.#atSec + duration.secs);
+    return new Moment(this.#atSec + duration.sec);
   }
 
   /**
-   * Gets the sum `this + secs` as a new instance of this class.
+   * Gets the sum `this + sec` as a new instance of this class.
    *
-   * @param {number} secs Number of seconds to add.
+   * @param {number} sec Number of seconds to add.
    * @returns {Moment} The summed result.
    */
-  addSec(secs) {
-    MustBe.number(secs, { finite: true });
-    return new Moment(this.#atSec + secs);
+  addSec(sec) {
+    MustBe.number(sec, { finite: true });
+    return new Moment(this.#atSec + sec);
   }
 
   /**

--- a/src/data-values/tests/Duration.test.js
+++ b/src/data-values/tests/Duration.test.js
@@ -32,11 +32,11 @@ describe('constructor()', () => {
   });
 });
 
-describe('.secs', () => {
+describe('.sec', () => {
   test('returns the value from the constructor', () => {
-    expect(new Duration(0).secs).toBe(0);
-    expect(new Duration(123).secs).toBe(123);
-    expect(new Duration(456.789).secs).toBe(456.789);
+    expect(new Duration(0).sec).toBe(0);
+    expect(new Duration(123).sec).toBe(123);
+    expect(new Duration(456.789).sec).toBe(456.789);
   });
 });
 
@@ -48,7 +48,7 @@ ${'toPlainObject'}      | ${false}  | ${true}
 ${'toString'}           | ${false}  | ${false}
 `('$method()', ({ method, isStatic, returnsObject }) => {
   test.each`
-  secs                 | duration
+  sec                  | duration
   ${-999.123}          | ${'-999.123 sec'}
   ${-1}                | ${'-1.000 sec'}
   ${0}                 | ${'0 sec (instantaneous)'}
@@ -108,13 +108,13 @@ ${'toString'}           | ${false}  | ${false}
   ${127353}            | ${'1d 11:22:33'}
   ${49021687.1}        | ${'567d 9:08:07'}
   ${49021687.9}        | ${'567d 9:08:08'}
-  `('with ($secs)', ({ secs, duration }) => {
+  `('with ($sec)', ({ sec, duration }) => {
     const result = isStatic
-      ? Duration[method](secs)
-      : new Duration(secs)[method]();
+      ? Duration[method](sec)
+      : new Duration(sec)[method]();
 
     if (returnsObject) {
-      expect(result).toStrictEqual({ secs, duration });
+      expect(result).toStrictEqual({ sec, duration });
     } else {
       expect(result).toBe(duration);
     }
@@ -125,7 +125,7 @@ ${'toString'}           | ${false}  | ${false}
 // `options` behavior.
 describe('stringFromSec()', () => {
   test.each`
-  secs             | options              | duration
+  sec              | options              | duration
   ${-1.23}         | ${undefined}         | ${'-1.230 sec'}
   ${0}             | ${undefined}         | ${'0 sec (instantaneous)'}
   ${9.876}         | ${undefined}         | ${'9.876 sec'}
@@ -144,14 +144,14 @@ describe('stringFromSec()', () => {
   ${0.09876}       | ${{ spaces: false }} | ${'98.760_msec'}
   ${0.00009876}    | ${{ spaces: false }} | ${'98.760_usec'}
   ${0.00000009876} | ${{ spaces: false }} | ${'98.760_nsec'}
-  `('with ($secs, $options)', ({ secs, options, duration }) => {
-    const result = Duration.stringFromSec(secs, options);
+  `('with ($sec, $options)', ({ sec, options, duration }) => {
+    const result = Duration.stringFromSec(sec, options);
     expect(result).toBe(duration);
   });
 });
 
 describe('.ZERO', () => {
   test('has the value `0`', () => {
-    expect(Duration.ZERO.secs).toBe(0);
+    expect(Duration.ZERO.sec).toBe(0);
   });
 });

--- a/src/data-values/tests/Moment.test.js
+++ b/src/data-values/tests/Moment.test.js
@@ -80,13 +80,13 @@ ${'add'}    | ${true}
 ${'addSec'} | ${false}
 `('$methodName()', ({ methodName, passDuration }) => {
   test.each`
-  moment        | secs       | expected
+  moment        | sec        | expected
   ${12345}      | ${0}       | ${12345}
   ${10000000}   | ${54321}   | ${10054321}
   ${1600000000} | ${-999888} | ${1599000112}
-  `('works given ($moment, $secs)', ({ moment, secs, expected }) => {
+  `('works given ($moment, $sec)', ({ moment, sec, expected }) => {
     const mobj   = new Moment(moment);
-    const arg    = passDuration ? new Duration(secs) : secs;
+    const arg    = passDuration ? new Duration(sec) : sec;
     const result = mobj[methodName](arg);
 
     expect(result.atSec).toBe(expected);
@@ -103,7 +103,7 @@ describe('subtract()', () => {
     const moment1 = new Moment(m1);
     const moment2 = new Moment(m2);
     const diff    = moment1.subtract(moment2);
-    expect(diff.secs).toBe(expected);
+    expect(diff.sec).toBe(expected);
   });
 });
 

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -300,7 +300,7 @@ export class Cookies {
     }
 
     if (maxAge) {
-      result.push('; Max-Age=', Math.trunc(maxAge.secs));
+      result.push('; Max-Age=', Math.trunc(maxAge.sec));
     }
 
     if (partitioned) {


### PR DESCRIPTION
This PR renames almost all cases of `secs` and `*Secs` to be `sec` or `*Sec`, to hew to the dominant naming convention of this project.

There are a few remaining cases to fix, which are all in exposed configuration properties.