### PR TITLE
Configuration `sec`

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -346,7 +346,7 @@ bindings:
 * `checkSec` &mdash; How often to check for memory usage being over the
   defined limit, in seconds. Optional. Minimum `1` (which is frankly way too
   often). Default `5 * 60` (once every five minutes).
-* `gracePeriodSecs` &mdash; Once a memory limit has been reached, how long, in
+* `gracePeriodSec` &mdash; Once a memory limit has been reached, how long, in
   seconds, it is allowed to remain at or beyond the maximum before this service
   takes action. `0` (or `null`) to not have a grace period at all. Default `0`.
   **Note:**: When in the middle of a grace period, the service will check
@@ -367,7 +367,7 @@ const services = [
     name:            'memory',
     class:           'MemoryMonitor',
     checkSec:        5 * 60,
-    gracePeriodSecs: 60,
+    gracePeriodSec:  60,
     maxHeapBytes:    100 * 1024 * 1024,
     maxRssBytes:     150 * 1024 * 1024
   }

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -343,14 +343,14 @@ A service which occasionally checks the system's memory usage, and will force a
 period to allow momentary usage spikes. It accepts the following configuration
 bindings:
 
-* `checkSecs` &mdash; How often to check for memory usage being over the
+* `checkSec` &mdash; How often to check for memory usage being over the
   defined limit, in seconds. Optional. Minimum `1` (which is frankly way too
   often). Default `5 * 60` (once every five minutes).
 * `gracePeriodSecs` &mdash; Once a memory limit has been reached, how long, in
   seconds, it is allowed to remain at or beyond the maximum before this service
   takes action. `0` (or `null`) to not have a grace period at all. Default `0`.
   **Note:**: When in the middle of a grace period, the service will check
-  memory usage more often than `checkSecs` so as not to miss a significant dip.
+  memory usage more often than `checkSec` so as not to miss a significant dip.
 * `maxHeapBytes` &mdash; How many bytes of heap is considered "over limit," or
   `null` for no limit on this. The amount counted is `heapTotal + external` from
   `process.memoryUsage()`. Defaults to `null`. **Note:** In order to catch
@@ -366,7 +366,7 @@ const services = [
   {
     name:            'memory',
     class:           'MemoryMonitor',
-    checkSecs:       5 * 60,
+    checkSec:        5 * 60,
     gracePeriodSecs: 60,
     maxHeapBytes:    100 * 1024 * 1024,
     maxRssBytes:     150 * 1024 * 1024
@@ -577,7 +577,7 @@ following bindings:
 * `atSize` &mdash; Rotate when the file becomes the given size (in bytes) or
   greater. Optional, and if not specified (or if `null`), does not rotate based
   on size.
-* `checkSecs` &mdash; How often to check for a rotation condition, in seconds.
+* `checkSec` &mdash; How often to check for a rotation condition, in seconds.
   Optional, and if not specified (or if `null`), does not ever check at all.
   This is only meaningful if `atSize` is also specified. Default `5 * 60`.
 * `maxOldBytes` &mdash; How many bytes' worth of old (post-rotation) files

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -387,7 +387,7 @@ optionally on a periodic basis. It accepts the following configuration bindings:
   Optional and defaults to `false`. If `true`, whenever the file is written, it
   is read first and any process IDs found in it are kept if they are in fact
   still running.
-* `updateSecs` &mdash; How long to wait between each file update, in seconds.
+* `updateSec` &mdash; How long to wait between each file update, in seconds.
   Optional and defaults to "never." This is only meaningfully used when
   `multiprocess` is `true`.
 
@@ -398,7 +398,7 @@ const services = [
     class:        'ProcessIdFile',
     path:         '/path/to/var/run/process.txt',
     multiprocess: true,
-    updateSecs:   60 * 60
+    updateSec:    60 * 60
   }
 ];
 ```
@@ -413,7 +413,7 @@ configuration bindings:
 
 * `path` &mdash; Path to the file, with the final path component modified by
   infixing the process ID.
-* `updateSecs` &mdash; How many seconds to wait between each file update while
+* `updateSec` &mdash; How many seconds to wait between each file update while
   the system is running. Optional and defaults to "never."
 * `save` &mdash; Optional file preservation configuration. If not specified, no
   file preservation is done.
@@ -424,7 +424,7 @@ const services = [
     name:       'process',
     class:      'ProcessInfoFile',
     path:       '/path/to/var/run/process.json',
-    updateSecs: 5 * 60,
+    updateSec:  5 * 60,
     save:       { /* ... */ }
   }
 ];

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -40,7 +40,7 @@ const services = [
     name:       'process',
     class:      'ProcessInfoFile',
     path:       `${RUN_DIR}/process.json`,
-    updateSecs:  5 * 60,
+    updateSec:  5 * 60,
     save: {
       onStart:     true,
       onStop:      true,
@@ -52,7 +52,7 @@ const services = [
     class:        'ProcessIdFile',
     path:         `${RUN_DIR}/process.txt`,
     multiprocess: true,
-    updateSecs:   5 * 60
+    updateSec:   5 * 60
   },
   {
     name:   'syslog',

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -29,12 +29,12 @@ const hosts = [
 // Service definitions.
 const services = [
   {
-    name:            'memory',
-    class:           'MemoryMonitor',
-    checkSec:        10 * 60,
-    gracePeriodSecs: 60,
-    maxHeapBytes:    100 * 1024 * 1024,
-    maxRssBytes:     150 * 1024 * 1024
+    name:           'memory',
+    class:          'MemoryMonitor',
+    checkSec:       10 * 60,
+    gracePeriodSec: 60,
+    maxHeapBytes:   100 * 1024 * 1024,
+    maxRssBytes:    150 * 1024 * 1024
   },
   {
     name:       'process',

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -31,7 +31,7 @@ const services = [
   {
     name:            'memory',
     class:           'MemoryMonitor',
-    checkSecs:       10 * 60,
+    checkSec:        10 * 60,
     gracePeriodSecs: 60,
     maxHeapBytes:    100 * 1024 * 1024,
     maxRssBytes:     150 * 1024 * 1024
@@ -52,7 +52,7 @@ const services = [
     class:        'ProcessIdFile',
     path:         `${RUN_DIR}/process.txt`,
     multiprocess: true,
-    updateSec:   5 * 60
+    updateSec:    5 * 60
   },
   {
     name:   'syslog',
@@ -63,7 +63,7 @@ const services = [
       atSize:      1024 * 1024,
       onStart:     true,
       maxOldBytes: 10 * 1024 * 1024,
-      checkSecs:   60
+      checkSec:    60
     }
   },
   {
@@ -78,7 +78,7 @@ const services = [
       onStop:      true,
       maxOldBytes: 10 * 1024 * 1024,
       maxOldCount: 10,
-      checkSecs:   60
+      checkSec:    60
     }
   },
   {
@@ -88,7 +88,7 @@ const services = [
     rotate: {
       atSize:      10000,
       maxOldCount: 10,
-      checkSecs:   60
+      checkSec:    60
     }
   },
   {

--- a/src/builtin-services/export/MemoryMonitor.js
+++ b/src/builtin-services/export/MemoryMonitor.js
@@ -19,7 +19,7 @@ import { MustBe } from '@this/typey';
  * * `{?number} checkSec` -- How often to check things, in seconds, or `null`
  *   to use the default frequency. Minimum `1`. Defaults to `60` (once per
  *   minute).
- * * `{?number} gracePeriodSecs` -- Once a memory limit has been reached, how
+ * * `{?number} gracePeriodSec` -- Once a memory limit has been reached, how
  *   long it is allowed to remain at or beyond the maximum before this service
  *   takes action, or `null` not to have a grace period at all (equivalent to
  *   `0`). When in the middle of a grace period, the system checks more often
@@ -88,7 +88,7 @@ export class MemoryMonitor extends BaseService {
         || (maxRssBytes  && (snapshot.rss  >= maxRssBytes))) {
       if (!snapshot.troubleAt) {
         // We just transitioned to an "over limit" situation.
-        const actionAt = now.addSec(this.config.gracePeriodSecs);
+        const actionAt = now.addSec(this.config.gracePeriodSec);
         snapshot.troubleAt = now;
         snapshot.actionAt  = actionAt;
         this.logger?.overLimit({ actionAt });
@@ -172,7 +172,7 @@ export class MemoryMonitor extends BaseService {
     #checkSec;
 
     /** @type {number} Grace period before triggering an action, in seconds. */
-    #gracePeriodSecs;
+    #gracePeriodSec;
 
     /**
      * @type {?number} Maximum allowed size of heap usage, in bytes, or `null`
@@ -195,18 +195,18 @@ export class MemoryMonitor extends BaseService {
       super(config);
 
       const {
-        checkSec        = null,
-        gracePeriodSecs = null,
-        maxHeapBytes    = null,
-        maxRssBytes     = null
+        checkSec       = null,
+        gracePeriodSec = null,
+        maxHeapBytes   = null,
+        maxRssBytes    = null
       } = config;
 
       this.#checkSec = (checkSec === null)
         ? 5 * 60
         : MustBe.number(checkSec, { finite: true, minInclusive: 1 });
-      this.#gracePeriodSecs = (gracePeriodSecs === null)
+      this.#gracePeriodSec = (gracePeriodSec === null)
         ? 0
-        : MustBe.number(gracePeriodSecs, { finite: true, minInclusive: 0 });
+        : MustBe.number(gracePeriodSec, { finite: true, minInclusive: 0 });
       this.#maxHeapBytes = (maxHeapBytes === null)
         ? null
         : MustBe.number(maxHeapBytes, { finite: true, minInclusive: 1024 * 1024 });
@@ -223,8 +223,8 @@ export class MemoryMonitor extends BaseService {
     /**
      * @returns {number} Grace period before triggering an action, in seconds.
      */
-    get gracePeriodSecs() {
-      return this.#gracePeriodSecs;
+    get gracePeriodSec() {
+      return this.#gracePeriodSec;
     }
 
     /**

--- a/src/builtin-services/export/MemoryMonitor.js
+++ b/src/builtin-services/export/MemoryMonitor.js
@@ -16,14 +16,14 @@ import { MustBe } from '@this/typey';
  * Service which monitors the system's memory usage and can initiate shutdown
  * before a memory problem becomes dire. Configuration object details:
  *
- * * `{?number} checkSecs` -- How often to check things, in seconds, or `null`
+ * * `{?number} checkSec` -- How often to check things, in seconds, or `null`
  *   to use the default frequency. Minimum `1`. Defaults to `60` (once per
  *   minute).
  * * `{?number} gracePeriodSecs` -- Once a memory limit has been reached, how
  *   long it is allowed to remain at or beyond the maximum before this service
  *   takes action, or `null` not to have a grace period at all (equivalent to
  *   `0`). When in the middle of a grace period, the system checks more often
- *   than `checkSecs` so as not to miss a significant dip. Defaults to `null`.
+ *   than `checkSec` so as not to miss a significant dip. Defaults to `null`.
  * * `{?number} maxHeapBytes` -- How many bytes of heap is considered "over
  *   limit," or `null` for no limit on this. The amount counted is `heapTotal +
  *   external` from `process.memoryUsage()`. Defaults to `null`. **Note:** In
@@ -110,7 +110,7 @@ export class MemoryMonitor extends BaseService {
    * Runs the service thread.
    */
   async #run() {
-    const checkMsec = this.config.checkSecs * 1000;
+    const checkMsec = this.config.checkSec * 1000;
 
     while (!this.#runner.shouldStop()) {
       const snapshot = this.#takeSnapshot();
@@ -169,7 +169,7 @@ export class MemoryMonitor extends BaseService {
    */
   static #Config = class Config extends ServiceConfig {
     /** @type {number} How often to check, in seconds. */
-    #checkSecs;
+    #checkSec;
 
     /** @type {number} Grace period before triggering an action, in seconds. */
     #gracePeriodSecs;
@@ -195,15 +195,15 @@ export class MemoryMonitor extends BaseService {
       super(config);
 
       const {
-        checkSecs       = null,
+        checkSec        = null,
         gracePeriodSecs = null,
         maxHeapBytes    = null,
         maxRssBytes     = null
       } = config;
 
-      this.#checkSecs = (checkSecs === null)
+      this.#checkSec = (checkSec === null)
         ? 5 * 60
-        : MustBe.number(checkSecs, { finite: true, minInclusive: 1 });
+        : MustBe.number(checkSec, { finite: true, minInclusive: 1 });
       this.#gracePeriodSecs = (gracePeriodSecs === null)
         ? 0
         : MustBe.number(gracePeriodSecs, { finite: true, minInclusive: 0 });
@@ -216,8 +216,8 @@ export class MemoryMonitor extends BaseService {
     }
 
     /** @returns {number} How often to check, in seconds. */
-    get checkSecs() {
-      return this.#checkSecs;
+    get checkSec() {
+      return this.#checkSec;
     }
 
     /**

--- a/src/builtin-services/export/ProcessIdFile.js
+++ b/src/builtin-services/export/ProcessIdFile.js
@@ -23,7 +23,7 @@ import { MustBe } from '@this/typey';
  *   FileServiceConfig}.
  * * `{boolean} multiprocess` -- Allow multiple processes to be registered in a
  *   single file. Defaults to `false`.
- * * `{?number} updateSecs` -- How often to update the file, in seconds, or
+ * * `{?number} updateSec` -- How often to update the file, in seconds, or
  *   `null` to not perform updates. Defaults to `null`. It is recommended to
  *   have this be non-`null` when `multiprocess` is used, to minimize the chance
  *   of a concurrency tragedy leaving a messed up file around.
@@ -126,9 +126,9 @@ export class ProcessIdFile extends BaseService {
     while (!this.#runner.shouldStop()) {
       await this.#updateFile(true);
 
-      const { updateSecs } = this.config;
-      const updateTimeout  = updateSecs
-        ? [timers.setTimeout(updateSecs * 1000)]
+      const { updateSec } = this.config;
+      const updateTimeout = updateSec
+        ? [timers.setTimeout(updateSec * 1000)]
         : [];
 
       await this.#runner.raceWhenStopRequested(updateTimeout);
@@ -214,7 +214,7 @@ export class ProcessIdFile extends BaseService {
      * @type {?number} How often to update the info file, in seconds, or `null`
      * to not perform updates.
      */
-    #updateSecs;
+    #updateSec;
 
     /**
      * Constructs an instance.
@@ -227,9 +227,9 @@ export class ProcessIdFile extends BaseService {
       this.#multiprocess = (typeof config.multiprocess === 'boolean')
         ? config.multiprocess
         : MustBe.null(config.multiprocess ?? null);
-      this.#updateSecs = config.updateSecs
-        ? MustBe.number(config.updateSecs, { finite: true, minInclusive: 1 })
-        : MustBe.null(config.updateSecs ?? null);
+      this.#updateSec = config.updateSec
+        ? MustBe.number(config.updateSec, { finite: true, minInclusive: 1 })
+        : MustBe.null(config.updateSec ?? null);
     }
 
     /** @returns {boolean} Allow multiple processes to be listed in the file? */
@@ -241,8 +241,8 @@ export class ProcessIdFile extends BaseService {
      * @returns {?number} How often to update the info file, in seconds, or
      * `null` to not perform updates.
      */
-    get updateSecs() {
-      return this.#updateSecs;
+    get updateSec() {
+      return this.#updateSec;
     }
   };
 }

--- a/src/builtin-services/export/ProcessInfoFile.js
+++ b/src/builtin-services/export/ProcessInfoFile.js
@@ -249,12 +249,12 @@ export class ProcessInfoFile extends BaseService {
    * Updates {@link #contents} to reflect the latest conditions.
    */
   #updateContents() {
-    const updatedAtSecs = Date.now() / 1000;
+    const updatedAtSec = Date.now() / 1000;
 
     this.#contents.disposition = {
       running:   true,
-      updatedAt: new Moment(updatedAtSecs).toPlainObject(),
-      uptime:    new Duration(updatedAtSecs - this.#contents.startedAt.atSec).toPlainObject()
+      updatedAt: new Moment(updatedAtSec).toPlainObject(),
+      uptime:    new Duration(updatedAtSec - this.#contents.startedAt.atSec).toPlainObject()
     };
 
     Object.assign(this.#contents, ProcessInfo.ephemeralInfo);

--- a/src/builtin-services/export/ProcessInfoFile.js
+++ b/src/builtin-services/export/ProcessInfoFile.js
@@ -22,7 +22,7 @@ import { MustBe } from '@this/typey';
  *
  * * Bindings as defined by the superclass configuration, {@link
  *   FileServiceConfig}. Supports `save`.
- * * `{?number} updateSecs` -- How often to update the file, in seconds, or
+ * * `{?number} updateSec` -- How often to update the file, in seconds, or
  *   `null` to not perform updates. Defaults to `null`.
  *
  * **Note:** See {@link #ProcessIdFile} for a service which writes minimal
@@ -194,9 +194,9 @@ export class ProcessInfoFile extends BaseService {
       this.#updateContents();
       await this.#writeFile();
 
-      const { updateSecs } = this.config;
-      const updateTimeout = updateSecs
-        ? [timers.setTimeout(updateSecs * 1000)]
+      const { updateSec } = this.config;
+      const updateTimeout = updateSec
+        ? [timers.setTimeout(updateSec * 1000)]
         : [];
 
       await this.#runner.raceWhenStopRequested(updateTimeout);
@@ -294,7 +294,7 @@ export class ProcessInfoFile extends BaseService {
      * @type {?number} How often to update the info file, in seconds, or `null`
      * to not perform updates.
      */
-    #updateSecs;
+    #updateSec;
 
     /**
      * Constructs an instance.
@@ -304,17 +304,17 @@ export class ProcessInfoFile extends BaseService {
     constructor(config) {
       super(config);
 
-      this.#updateSecs = config.updateSecs
-        ? MustBe.number(config.updateSecs, { finite: true, minInclusive: 1 })
-        : MustBe.null(config.updateSecs ?? null);
+      this.#updateSec = config.updateSec
+        ? MustBe.number(config.updateSec, { finite: true, minInclusive: 1 })
+        : MustBe.null(config.updateSec ?? null);
     }
 
     /**
      * @returns {?number} How often to update the info file, in seconds, or
      * `null` to not perform updates.
      */
-    get updateSecs() {
-      return this.#updateSecs;
+    get updateSec() {
+      return this.#updateSec;
     }
   };
 }

--- a/src/sys-config/export/RotateConfig.js
+++ b/src/sys-config/export/RotateConfig.js
@@ -17,7 +17,7 @@ import { SaveConfig } from '#x/SaveConfig';
  * * `{?number} atSize` -- Rotate when the file becomes the given size (in
  *   bytes) or greater. If `null`, does not rotate based on size. Default
  *  `null`.
- * * `{?number} checkSecs` -- How often to check for a rotation condition, in
+ * * `{?number} checkSec` -- How often to check for a rotation condition, in
  *   seconds, or `null` to not check. This is only meaningful if `atSize` is
  *   also specified. Default `5 * 60`.
  */
@@ -29,7 +29,7 @@ export class RotateConfig extends SaveConfig {
    * @type {?number} How often to check for rotation eligibility, in seconds, if
    * at all.
    */
-  #checkSecs;
+  #checkSec;
 
   /**
    * Constructs an instance.
@@ -40,18 +40,18 @@ export class RotateConfig extends SaveConfig {
     super(config);
 
     const {
-      atSize      = null,
-      checkSecs   = 5 * 60
+      atSize   = null,
+      checkSec = 5 * 60
     } = config;
 
     this.#atSize = (atSize === null)
       ? null
       : MustBe.number(atSize, { finite: true, minInclusive: 1 });
-    this.#checkSecs = MustBe.number(checkSecs, { finite: true, minInclusive: 1 });
+    this.#checkSec = MustBe.number(checkSec, { finite: true, minInclusive: 1 });
 
     if (this.#atSize === null) {
-      // `checkSecs` is irrelevant in this case.
-      this.#checkSecs = null;
+      // `checkSec` is irrelevant in this case.
+      this.#checkSec = null;
     }
   }
 
@@ -67,7 +67,7 @@ export class RotateConfig extends SaveConfig {
    * @returns {?number} How often to check for rotation eligibility, in seconds,
    * or `null` not to ever check.
    */
-  get checkSecs() {
-    return this.#checkSecs;
+  get checkSec() {
+    return this.#checkSec;
   }
 }

--- a/src/sys-util/export/Rotator.js
+++ b/src/sys-util/export/Rotator.js
@@ -35,9 +35,9 @@ export class Rotator extends BaseFilePreserver {
 
     this.#config = MustBe.instanceOf(config, FileServiceConfig);
 
-    this.#checkMsec = (config.rotate.checkSecs === null)
+    this.#checkMsec = (config.rotate.checkSec === null)
       ? null
-      : config.rotate.checkSecs * 1000;
+      : config.rotate.checkSec * 1000;
   }
 
   /** @override */


### PR DESCRIPTION
This PR fixes the configuration property names to be `*Sec` instead of `*Secs`, for consistency with the rest of the system.