### PR TITLE
New `MimeTypes` stuff.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
-* None.
+* Tweaked the contract of `contentType` bindings in configurations, to help
+  avoid ambiguity and confusion. Specifically, file extensions now need to start
+  with a dot.
 
 Other notable changes:
-* None.
+* Expanded `MimeTypes` to handle character set stuff.
 
 ###  v0.6.5 -- 2024-02-09
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -226,11 +226,11 @@ bindings:
 * `body` &mdash; Optional body contents to respond with. If specified, this must
   be either a string or a Node `Buffer` object.
 * `contentType` &mdash; Content type to report. This can be either a MIME type
-  or a commonly-understood extension (e.g., `txt` or `html`). This must be
-  specified if `body` is. If this is not specified but `filePath` is, then the
-  type is inferred from the extension on the path. If neither `body` nor
-  `filePath` is specified (that is, for an empty body), then this must not be
-  specified either.
+  per se (e.g. `text/plain`) or a commonly-understood extension (with leading
+  dot, e.g., `.txt` or `.html`). This must be specified if `body` is. If this is
+  not specified but `filePath` is, then the type is inferred from the extension
+  on the path. If neither `body` nor `filePath` is specified (that is, for an
+  empty body), then this must not be specified either.
 * `etag` &mdash; ETag-generating options. If present and not `false`, the
   response comes with an `ETag` header. See "ETag Configuration" below for
   details.

--- a/src/builtin-applications/export/SimpleResponse.js
+++ b/src/builtin-applications/export/SimpleResponse.js
@@ -143,7 +143,7 @@ export class SimpleResponse extends BaseApplication {
       } else if (filePath !== null) {
         this.#filePath    = Paths.checkAbsolutePath(filePath);
         this.#contentType = (contentType === null)
-          ? MimeTypes.typeFromExtension(filePath)
+          ? MimeTypes.typeFromPathExtension(filePath)
           : MimeTypes.typeFromExtensionOrType(contentType);
       } else {
         // It's an empty body.

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -106,7 +106,7 @@ export class StaticFiles extends BaseApplication {
       this.#notFoundOptions = {
         ...(StaticFiles.#SEND_OPTIONS),
         body:        await fs.readFile(notFoundPath),
-        contentType: MimeTypes.typeFromExtension(notFoundPath)
+        contentType: MimeTypes.typeFromPathExtension(notFoundPath)
       };
     }
   }

--- a/src/fs-util/export/Paths.js
+++ b/src/fs-util/export/Paths.js
@@ -26,7 +26,12 @@ export class Paths {
       '(?!.+/$)' +         // No slash at the end (after the first character).
       '/';                 // Starts with a slash.
 
-    return MustBe.string(value, pattern);
+    try {
+      return MustBe.string(value, pattern);
+    } catch {
+      // Better error message.
+      throw new Error(`Not an absolute path: ${value}`);
+    }
   }
 
   /**
@@ -42,6 +47,12 @@ export class Paths {
    */
   static checkFileName(value) {
     const pattern = /^(?![.]{1,2}$)[^/]+$/;
-    return MustBe.string(value, pattern);
+
+    try {
+      return MustBe.string(value, pattern);
+    } catch {
+      // Better error message.
+      throw new Error(`Not a file name: ${value}`);
+    }
   }
 }

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -600,7 +600,7 @@ export class Request {
 
     const headers = this.#makeResponseHeaders('cacheable', options, {
       'content-type': () => {
-        return MimeTypes.typeFromExtension(path);
+        return MimeTypes.typeFromPathExtension(path);
       }
     });
 

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -46,7 +46,8 @@ import { WranglerContext } from '#x/WranglerContext';
  * * `{Buffer|string|null} body` -- Body content to include. If passed as a
  *   `string`, the actual body gets encoded as UTF-8, and the `contentType` is
  *   adjusted if necessary to indicate that fact. This property is only
- *   available on methods that don't take a separate `body` argument.
+ *   available on methods that (a) could conceivably send a body, and (b) don't
+ *   have any other way to specify a body (e.g. through other arguments).
  * * `{?string} bodyExtra` -- Extra body content to include when wanting to
  *   _mostly_ use a default body. This is only available on {@link
  *   #sendMetaResponse}.

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -64,8 +64,10 @@ import { WranglerContext } from '#x/WranglerContext';
  *   subclass, {@link HttpHeaders}.
  * * `{?number} maxAgeMsec` -- Value to send back in the `max-age` property of
  *   the `Cache-Control` response header. Defaults to `0`.
- * * `{?number} statusCode` -- Response status code. This is only available on
- *   {@link #sendRedirect}.
+ * * `{?number} status` -- Response status code. This is only available on a
+ *   couple methods (as noted in their documentation) which (a) don't strongly
+ *   imply a status (or possible set thereof), and (b) don't have any other way
+ *   to specify a status (e.g. through other arguments).
  */
 export class Request {
   /**
@@ -780,8 +782,8 @@ export class Request {
    * @param {string} target Possibly-relative target URL.
    * @param {?object} [options] Options to control response behavior. See class
    *   header comment for more details.
-   * @param {?number} [options.statusCode] The status code to report. Defaults
-   *   to `302` ("Found").
+   * @param {?number} [options.status] The status code to report. Defaults to
+   *   `302` ("Found").
    * @returns {boolean} `true` when the response is completed.
    */
   async sendRedirect(target, options = null) {
@@ -808,8 +810,8 @@ export class Request {
    *
    * @param {?object} [options] Options to control response behavior. See class
    *   header comment for more details.
-   * @param {?number} [options.statusCode] The status code to report. Defaults
-   *   to `302` ("Found").
+   * @param {?number} [options.status] The status code to report. Defaults to
+   *   `302` ("Found").
    * @returns {boolean} `true` when the response is completed.
    */
   async sendRedirectBack(options = null) {

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -52,10 +52,10 @@ import { WranglerContext } from '#x/WranglerContext';
  *   _mostly_ use a default body. This is only available on {@link
  *   #sendMetaResponse}.
  * * `{?string} contentType` -- Content type of the body, in the form expected
- *   by {@link MimeTypes}. Required if `body` is present and ignored in all
- *   other cases. If this value starts with `text/` and/or the `body` is passed
- *   as a string, then the actual `Content-Type` header will indicate a charset
- *   of `utf-8`.
+ *   by {@link MimeTypes#typeFromExtensionOrType}. Required if `body` is present
+ *   and ignored in all other cases. If this value starts with `text/` and/or
+ *   the `body` is passed as a string, then the actual `Content-Type` header
+ *   will indicate a charset of `utf-8`.
  * * `{?Cookies} cookies` -- Cookies to include (via `Set-Cookie` headers) in
  *   the response, if any.
  * * `{?object} headers` -- Extra headers to include in the response, if any.
@@ -524,9 +524,8 @@ export class Request {
    *   not sending a body at all). If passed as a `string`, it is encoded as
    *   UTF-8, and the content type of the response will list that as the
    *   charset.
-   * @param {string} contentType Content type for the body. If this value starts
-   *   with `text/` and/or the `body` is passed as a string, then the actual
-   *   `Content-Type` header will indicate a charset of `utf-8`.
+   * @param {string} contentType Content type for the body, in a form as
+   *   described by this class's header comment.
    * @param {object} [options] Options to control response behavior. See class
    *   header comment for more details. Header-related options are only used
    *   for non-error responses.

--- a/src/net-util/export/MimeTypes.js
+++ b/src/net-util/export/MimeTypes.js
@@ -32,10 +32,11 @@ export class MimeTypes {
 
   /**
    * Returns the given string if it is a known MIME type, or acts like {@link
-   * #typeFromExtension} if it looks like a simple extension value (string of
-   * less than 10 characters with no dot or slash). If it is an extension that
-   * is unrecognized, this returns `'application/octet-stream'`. This throws an
-   * an error in other cases.
+   * #typeFromExtension} if it looks like a simple extension value (string
+   * consisting of a dot followed by one to ten characters, not including any
+   * other dots or slashes). If it is an extension that is unrecognized, this
+   * returns `'application/octet-stream'`. This throws an an error in all other
+   * cases.
    *
    * @param {string} extensionOrType File extension or MIME type.
    * @returns {string} The MIME type.
@@ -43,15 +44,17 @@ export class MimeTypes {
   static typeFromExtensionOrType(extensionOrType) {
     MustBe.string(extensionOrType);
 
-    if (/[./]/.test(extensionOrType)) {
+    if (/^\.[^./]{1,10}$/.test(extensionOrType)) {
+      const found = mime.getType(extensionOrType);
+      return found ?? 'application/octet-stream';
+    } else if (/^(?=.*[/])[a-zA-Z][-_.=/; a-zA-Z0-9]+$/.test(extensionOrType)) {
       const found = mime.getExtension(extensionOrType);
       if (!found) {
         throw new Error(`Unknown MIME type: ${extensionOrType}`);
       }
       return extensionOrType;
     } else {
-      const found = mime.getType(extensionOrType);
-      return found ?? 'application/octet-stream';
+      throw new Error(`Invalid syntax for MIME type or file extension: ${extensionOrType}`);
     }
   }
 }

--- a/src/net-util/export/MimeTypes.js
+++ b/src/net-util/export/MimeTypes.js
@@ -44,8 +44,8 @@ export class MimeTypes {
   }
 
   /**
-   * Returns the given string if it is a known MIME type, or acts like {@link
-   * #typeFromPathExtension} if it looks like a simple extension value (string
+   * Returns the given string if it is a known MIME type, or looks up the type
+   * for a file extension if that's what it looks like (specifically, a string
    * consisting of a dot followed by one to ten characters, not including any
    * other dots or slashes). If it is an extension that is unrecognized, this
    * returns `'application/octet-stream'`. This throws an an error in all other

--- a/src/net-util/export/MimeTypes.js
+++ b/src/net-util/export/MimeTypes.js
@@ -20,14 +20,27 @@ export class MimeTypes {
    * can be determined.
    *
    * @param {string} extensionOrPath File extension or path.
+   * @param {?object} [options] Options.
+   * @param {?string} [options.charSet] Character set to return _if_ the
+   *   returned type has the prefix `text/` or is otherwise considered to be
+   *   text. Defaults to `null`, that is, not to ever include a character set in
+   *   the result.
+   * @param {?boolean} [options.isText] Indicates that the type is definitely
+   *   text. If `true`, `options.charSet` is always used if present, and the
+   *   default type if no other type can be ascertained is `text/plain`.
+   *   Defaults to `false`.
    * @returns {string} The MIME type.
    */
-  static typeFromExtension(extensionOrPath) {
+  static typeFromExtension(extensionOrPath, options = {}) {
     MustBe.string(extensionOrPath);
+    const { charSet = null, isText = false } = MustBe.object(options);
 
-    const result = mime.getType(extensionOrPath);
+    const mimeType = mime.getType(extensionOrPath)
+      ?? (isText ? 'text/plain' : 'application/octet-stream');
 
-    return result ?? 'application/octet-stream';
+    return (charSet && (isText || /^text[/]/.test(mimeType)))
+      ? `${mimeType}; charset=${charSet}`
+      : mimeType;
   }
 
   /**

--- a/src/net-util/export/MimeTypes.js
+++ b/src/net-util/export/MimeTypes.js
@@ -14,12 +14,11 @@ import { MustBe } from '@this/typey';
  */
 export class MimeTypes {
   /**
-   * Gets the MIME type for the given extension (no dot or just initial dot in
-   * the given string) or extension of the given file path (dot in the middle of
-   * the string). This returns `'application/octet-stream'` if nothing better
-   * can be determined.
+   * Gets the MIME type for the filename extension on the given absolute path.
+   * This returns `'application/octet-stream'` if nothing better can be
+   * determined.
    *
-   * @param {string} extensionOrPath File extension or path.
+   * @param {string} absolutePath Absolute path to derive a MIME type from.
    * @param {?object} [options] Options.
    * @param {?string} [options.charSet] Character set to return _if_ the
    *   returned type has the prefix `text/` or is otherwise considered to be
@@ -31,11 +30,11 @@ export class MimeTypes {
    *   Defaults to `false`.
    * @returns {string} The MIME type.
    */
-  static typeFromExtension(extensionOrPath, options = {}) {
-    MustBe.string(extensionOrPath);
+  static typeFromPathExtension(absolutePath, options = {}) {
+    MustBe.string(absolutePath);
     const { charSet = null, isText = false } = MustBe.object(options);
 
-    const mimeType = mime.getType(extensionOrPath)
+    const mimeType = mime.getType(absolutePath)
       ?? (isText ? 'text/plain' : 'application/octet-stream');
 
     return (charSet && (isText || /^text[/]/.test(mimeType)))
@@ -45,7 +44,7 @@ export class MimeTypes {
 
   /**
    * Returns the given string if it is a known MIME type, or acts like {@link
-   * #typeFromExtension} if it looks like a simple extension value (string
+   * #typeFromPathExtension} if it looks like a simple extension value (string
    * consisting of a dot followed by one to ten characters, not including any
    * other dots or slashes). If it is an extension that is unrecognized, this
    * returns `'application/octet-stream'`. This throws an an error in all other

--- a/src/net-util/export/MimeTypes.js
+++ b/src/net-util/export/MimeTypes.js
@@ -3,6 +3,7 @@
 
 import mime from 'mime';
 
+import { Paths } from '@this/fs-util';
 import { MustBe } from '@this/typey';
 
 
@@ -31,7 +32,7 @@ export class MimeTypes {
    * @returns {string} The MIME type.
    */
   static typeFromPathExtension(absolutePath, options = {}) {
-    MustBe.string(absolutePath);
+    Paths.checkAbsolutePath(absolutePath);
     const { charSet = null, isText = false } = MustBe.object(options);
 
     const mimeType = mime.getType(absolutePath)

--- a/src/net-util/tests/MimeTypes.test.js
+++ b/src/net-util/tests/MimeTypes.test.js
@@ -5,32 +5,82 @@ import { MimeTypes } from '@this/net-util';
 
 
 describe('typeFromExtension()', () => {
-  test('finds the type given an extension without a dot', () => {
-    expect(MimeTypes.typeFromExtension('png')).toBe('image/png');
+  describe('with no config argument', () => {
+    test('finds the type given an extension without a dot', () => {
+      expect(MimeTypes.typeFromExtension('png')).toBe('image/png');
+    });
+
+    test('finds the type given an extension with a dot', () => {
+      expect(MimeTypes.typeFromExtension('.gif')).toBe('image/gif');
+    });
+
+    test('finds the type given a simple file name', () => {
+      expect(MimeTypes.typeFromExtension('florp.txt')).toBe('text/plain');
+    });
+
+    test('finds the type given a zero-directory absolute path', () => {
+      expect(MimeTypes.typeFromExtension('/boop.tar')).toBe('application/x-tar');
+    });
+
+    test('finds the type given a one-directory relative path', () => {
+      expect(MimeTypes.typeFromExtension('boop/zorch.jpg')).toBe('image/jpeg');
+    });
+
+    test('finds the type given a one-directory absolute path', () => {
+      expect(MimeTypes.typeFromExtension('/x/blonk.json')).toBe('application/json');
+    });
+
+    test('defaults to `application/octet-stream`', () => {
+      expect(MimeTypes.typeFromExtension('.abcdefgXYZ')).toBe('application/octet-stream');
+    });
   });
 
-  test('finds the type given an extension with a dot', () => {
-    expect(MimeTypes.typeFromExtension('.gif')).toBe('image/gif');
+  describe('with config `{ charSet: \'florp\' }`', () => {
+    const config = { charSet: 'florp' };
+
+    test('does not impact a non-text extension', () => {
+      expect(MimeTypes.typeFromExtension('.gif', config)).toBe('image/gif');
+    });
+
+    test('alters the result from a text extension', () => {
+      expect(MimeTypes.typeFromExtension('.text', config)).toBe('text/plain; charset=florp');
+    });
+
+    test('defaults to `application/octet-stream`', () => {
+      expect(MimeTypes.typeFromExtension('.abcdefgXYZ', config)).toBe('application/octet-stream');
+    });
   });
 
-  test('finds the type given a simple file name', () => {
-    expect(MimeTypes.typeFromExtension('florp.txt')).toBe('text/plain');
+  describe('with config `{ isText: true }`', () => {
+    const config = { isText: true };
+
+    test('does not impact a non-text extension', () => {
+      expect(MimeTypes.typeFromExtension('.gif', config)).toBe('image/gif');
+    });
+
+    test('does not impact a text extension', () => {
+      expect(MimeTypes.typeFromExtension('.text', config)).toBe('text/plain');
+    });
+
+    test('defaults to `text/plain`', () => {
+      expect(MimeTypes.typeFromExtension('.abcdefgXYZ', config)).toBe('text/plain');
+    });
   });
 
-  test('finds the type given a zero-directory absolute path', () => {
-    expect(MimeTypes.typeFromExtension('/boop.tar')).toBe('application/x-tar');
-  });
+  describe('with config `{ charSet: \'boop\', isText: true }`', () => {
+    const config = { charSet: 'boop', isText: true };
 
-  test('finds the type given a one-directory relative path', () => {
-    expect(MimeTypes.typeFromExtension('boop/zorch.jpg')).toBe('image/jpeg');
-  });
+    test('alters the result from a non0text extension', () => {
+      expect(MimeTypes.typeFromExtension('.png', config)).toBe('image/png; charset=boop');
+    });
 
-  test('finds the type given a one-directory absolute path', () => {
-    expect(MimeTypes.typeFromExtension('/x/blonk.json')).toBe('application/json');
-  });
+    test('alters the result from a text extension', () => {
+      expect(MimeTypes.typeFromExtension('.text', config)).toBe('text/plain; charset=boop');
+    });
 
-  test('defaults to `application/octet-stream`', () => {
-    expect(MimeTypes.typeFromExtension('.abcdefgXYZ')).toBe('application/octet-stream');
+    test('defaults to `text/plain` with the configured charset', () => {
+      expect(MimeTypes.typeFromExtension('.abcdefgXYZ', config)).toBe('text/plain; charset=boop');
+    });
   });
 });
 

--- a/src/net-util/tests/MimeTypes.test.js
+++ b/src/net-util/tests/MimeTypes.test.js
@@ -35,8 +35,32 @@ describe('typeFromExtension()', () => {
 });
 
 describe('typeFromExtensionOrType()', () => {
-  test('finds the type given an extension without a dot', () => {
-    expect(MimeTypes.typeFromExtensionOrType('js')).toBe('text/javascript');
+  // Failure cases: Wrong argument type.
+  test.each`
+  arg
+  ${null}
+  ${undefined}
+  ${false}
+  ${123}
+  ${['.x']}
+  ${{ a: 10 }}
+  ${new Map()}
+  `('throws given $arg', ({ arg }) => {
+    expect(() => MimeTypes.typeFromExtensionOrType(arg)).toThrow();
+  });
+
+  // Failure cases: Incorrect syntax.
+  test.each`
+  arg
+  ${''}
+  ${'txt'}               // Extensions are supposed to start with a dot.
+  ${'/application/json'} // MIME types don't start with a slash.
+  `('throws given $arg', ({ arg }) => {
+    expect(() => MimeTypes.typeFromExtensionOrType(arg)).toThrow(/^Invalid syntax/);
+  });
+
+  test('throws if given an unknown MIME type', () => {
+    expect(() => MimeTypes.typeFromExtensionOrType('text/florp')).toThrow(/^Unknown MIME type/);
   });
 
   test('confirms the existence of a given MIME type', () => {
@@ -45,7 +69,7 @@ describe('typeFromExtensionOrType()', () => {
   });
 
   test('defaults to `application/octet-stream` given an unknown extension', () => {
-    expect(MimeTypes.typeFromExtensionOrType('abcdefgXYZ')).toBe('application/octet-stream');
+    expect(MimeTypes.typeFromExtensionOrType('.abcdefgXYZ')).toBe('application/octet-stream');
   });
 
   test('preserves a charset if given', () => {

--- a/src/net-util/tests/MimeTypes.test.js
+++ b/src/net-util/tests/MimeTypes.test.js
@@ -132,21 +132,131 @@ describe('typeFromExtensionOrType()', () => {
     expect(() => MimeTypes.typeFromExtensionOrType(arg)).toThrow(/^Invalid syntax/);
   });
 
-  test('throws if given an unknown MIME type', () => {
-    expect(() => MimeTypes.typeFromExtensionOrType('text/florp')).toThrow(/^Unknown MIME type/);
+  describe('with no config argument', () => {
+    test('throws if given an unknown MIME type', () => {
+      expect(() => MimeTypes.typeFromExtensionOrType('text/florp')).toThrow(/^Unknown MIME type/);
+    });
+
+    test('confirms the existence of a given MIME type', () => {
+      const theType = 'image/jpeg';
+      expect(MimeTypes.typeFromExtensionOrType(theType)).toBe(theType);
+    });
+
+    test('finds the MIME type of a known extension', () => {
+      expect(MimeTypes.typeFromExtensionOrType('.png')).toBe('image/png');
+    });
+
+    test('defaults to `application/octet-stream` given an unknown extension', () => {
+      expect(MimeTypes.typeFromExtensionOrType('.abcdefgXYZ')).toBe('application/octet-stream');
+    });
+
+    test('preserves a charset if given', () => {
+      const theType = 'text/plain; charset=utf-8';
+      expect(MimeTypes.typeFromExtensionOrType(theType)).toBe(theType);
+    });
   });
 
-  test('confirms the existence of a given MIME type', () => {
-    const theType = 'image/jpeg';
-    expect(MimeTypes.typeFromExtensionOrType(theType)).toBe(theType);
+  describe('with config `{ charSet: \'florp\' }`', () => {
+    const config = { charSet: 'florp' };
+
+    test('alters a text MIME type', () => {
+      const theType  = 'text/plain';
+      const expected = `${theType}; charset=${config.charSet}`;
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(expected);
+    });
+
+    test('does not alter a non-text MIME type', () => {
+      const theType = 'image/jpeg';
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
+    });
+
+    test('finds the MIME type of a known non-text extension, as-is', () => {
+      expect(MimeTypes.typeFromExtensionOrType('.png', config)).toBe('image/png');
+    });
+
+    test('finds the MIME type of a known text extension, and adds the charset', () => {
+      const theType  = 'text/javascript';
+      const expected = `${theType}; charset=${config.charSet}`;
+      expect(MimeTypes.typeFromExtensionOrType('.js', config)).toBe(expected);
+    });
+
+    test('defaults to `application/octet-stream` given an unknown extension', () => {
+      expect(MimeTypes.typeFromExtensionOrType('.abcdefgXYZ', config)).toBe('application/octet-stream');
+    });
+
+    test('preserves a charset if given', () => {
+      const theType = 'text/plain; charset=utf-8';
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
+    });
   });
 
-  test('defaults to `application/octet-stream` given an unknown extension', () => {
-    expect(MimeTypes.typeFromExtensionOrType('.abcdefgXYZ')).toBe('application/octet-stream');
+  describe('with config `{ isText: true }`', () => {
+    const config = { isText: true };
+
+    test('does not alter a text MIME type', () => {
+      const theType  = 'text/plain';
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
+    });
+
+    test('does not alter a non-text MIME type', () => {
+      const theType = 'image/jpeg';
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
+    });
+
+    test('finds the MIME type of a known non-text extension, as-is', () => {
+      expect(MimeTypes.typeFromExtensionOrType('.png', config)).toBe('image/png');
+    });
+
+    test('finds the MIME type of a known text extension, as-is', () => {
+      expect(MimeTypes.typeFromExtensionOrType('.js', config)).toBe('text/javascript');
+    });
+
+    test('defaults to `text/plain` given an unknown extension', () => {
+      expect(MimeTypes.typeFromExtensionOrType('.abcdefgXYZ', config)).toBe('text/plain');
+    });
+
+    test('preserves a charset if given', () => {
+      const theType = 'text/plain; charset=utf-8';
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
+    });
   });
 
-  test('preserves a charset if given', () => {
-    const theType = 'text/plain; charset=utf-8';
-    expect(MimeTypes.typeFromExtensionOrType(theType)).toBe(theType);
+  describe('with config `{ charSet: \'boop\', isText: true }`', () => {
+    const config = { charSet: 'boop', isText: true };
+
+    test('alters a text MIME type', () => {
+      const theType  = 'text/plain';
+      const expected = `${theType}; charset=${config.charSet}`;
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(expected);
+    });
+
+    test('alters a non-text MIME type', () => {
+      const theType = 'image/jpeg';
+      const expected = `${theType}; charset=${config.charSet}`;
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(expected);
+    });
+
+    test('finds the MIME type of a known non-text extension, and alters it', () => {
+      const theType = 'image/png';
+      const expected = `${theType}; charset=${config.charSet}`;
+      expect(MimeTypes.typeFromExtensionOrType('.png', config)).toBe(expected);
+    });
+
+    test('finds the MIME type of a known text extension, and alters it', () => {
+      const theType  = 'text/javascript';
+      const expected = `${theType}; charset=${config.charSet}`;
+      expect(MimeTypes.typeFromExtensionOrType('.js', config)).toBe(expected);
+    });
+
+    test('defaults to `text/plain` with the charset given an unknown extension', () => {
+      const theType  = 'text/plain';
+      const expected = `${theType}; charset=${config.charSet}`;
+      expect(MimeTypes.typeFromExtensionOrType('.abcdefgXYZ', config)).toBe(expected);
+    });
+
+    test('preserves a charset if given', () => {
+      const theType = 'text/plain; charset=utf-8';
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
+    });
   });
 });

--- a/src/net-util/tests/MimeTypes.test.js
+++ b/src/net-util/tests/MimeTypes.test.js
@@ -1,0 +1,55 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { MimeTypes } from '@this/net-util';
+
+
+describe('typeFromExtension()', () => {
+  test('finds the type given an extension without a dot', () => {
+    expect(MimeTypes.typeFromExtension('png')).toBe('image/png');
+  });
+
+  test('finds the type given an extension with a dot', () => {
+    expect(MimeTypes.typeFromExtension('.gif')).toBe('image/gif');
+  });
+
+  test('finds the type given a simple file name', () => {
+    expect(MimeTypes.typeFromExtension('florp.txt')).toBe('text/plain');
+  });
+
+  test('finds the type given a zero-directory absolute path', () => {
+    expect(MimeTypes.typeFromExtension('/boop.tar')).toBe('application/x-tar');
+  });
+
+  test('finds the type given a one-directory relative path', () => {
+    expect(MimeTypes.typeFromExtension('boop/zorch.jpg')).toBe('image/jpeg');
+  });
+
+  test('finds the type given a one-directory absolute path', () => {
+    expect(MimeTypes.typeFromExtension('/x/blonk.json')).toBe('application/json');
+  });
+
+  test('defaults to `application/octet-stream`', () => {
+    expect(MimeTypes.typeFromExtension('.abcdefgXYZ')).toBe('application/octet-stream');
+  });
+});
+
+describe('typeFromExtensionOrType()', () => {
+  test('finds the type given an extension without a dot', () => {
+    expect(MimeTypes.typeFromExtensionOrType('js')).toBe('text/javascript');
+  });
+
+  test('confirms the existence of a given MIME type', () => {
+    const theType = 'image/jpeg';
+    expect(MimeTypes.typeFromExtensionOrType(theType)).toBe(theType);
+  });
+
+  test('defaults to `application/octet-stream` given an unknown extension', () => {
+    expect(MimeTypes.typeFromExtensionOrType('abcdefgXYZ')).toBe('application/octet-stream');
+  });
+
+  test('preserves a charset if given', () => {
+    const theType = 'text/plain; charset=utf-8';
+    expect(MimeTypes.typeFromExtensionOrType(theType)).toBe(theType);
+  });
+});

--- a/src/net-util/tests/MimeTypes.test.js
+++ b/src/net-util/tests/MimeTypes.test.js
@@ -4,34 +4,34 @@
 import { MimeTypes } from '@this/net-util';
 
 
-describe('typeFromExtension()', () => {
+describe('typeFromPathExtension()', () => {
   describe('with no config argument', () => {
     test('finds the type given an extension without a dot', () => {
-      expect(MimeTypes.typeFromExtension('png')).toBe('image/png');
+      expect(MimeTypes.typeFromPathExtension('png')).toBe('image/png');
     });
 
     test('finds the type given an extension with a dot', () => {
-      expect(MimeTypes.typeFromExtension('.gif')).toBe('image/gif');
+      expect(MimeTypes.typeFromPathExtension('.gif')).toBe('image/gif');
     });
 
     test('finds the type given a simple file name', () => {
-      expect(MimeTypes.typeFromExtension('florp.txt')).toBe('text/plain');
+      expect(MimeTypes.typeFromPathExtension('florp.txt')).toBe('text/plain');
     });
 
     test('finds the type given a zero-directory absolute path', () => {
-      expect(MimeTypes.typeFromExtension('/boop.tar')).toBe('application/x-tar');
+      expect(MimeTypes.typeFromPathExtension('/boop.tar')).toBe('application/x-tar');
     });
 
     test('finds the type given a one-directory relative path', () => {
-      expect(MimeTypes.typeFromExtension('boop/zorch.jpg')).toBe('image/jpeg');
+      expect(MimeTypes.typeFromPathExtension('boop/zorch.jpg')).toBe('image/jpeg');
     });
 
     test('finds the type given a one-directory absolute path', () => {
-      expect(MimeTypes.typeFromExtension('/x/blonk.json')).toBe('application/json');
+      expect(MimeTypes.typeFromPathExtension('/x/blonk.json')).toBe('application/json');
     });
 
     test('defaults to `application/octet-stream`', () => {
-      expect(MimeTypes.typeFromExtension('.abcdefgXYZ')).toBe('application/octet-stream');
+      expect(MimeTypes.typeFromPathExtension('.abcdefgXYZ')).toBe('application/octet-stream');
     });
   });
 
@@ -39,15 +39,15 @@ describe('typeFromExtension()', () => {
     const config = { charSet: 'florp' };
 
     test('does not impact a non-text extension', () => {
-      expect(MimeTypes.typeFromExtension('.gif', config)).toBe('image/gif');
+      expect(MimeTypes.typeFromPathExtension('.gif', config)).toBe('image/gif');
     });
 
     test('alters the result from a text extension', () => {
-      expect(MimeTypes.typeFromExtension('.text', config)).toBe('text/plain; charset=florp');
+      expect(MimeTypes.typeFromPathExtension('.text', config)).toBe('text/plain; charset=florp');
     });
 
     test('defaults to `application/octet-stream`', () => {
-      expect(MimeTypes.typeFromExtension('.abcdefgXYZ', config)).toBe('application/octet-stream');
+      expect(MimeTypes.typeFromPathExtension('.abcdefgXYZ', config)).toBe('application/octet-stream');
     });
   });
 
@@ -55,15 +55,15 @@ describe('typeFromExtension()', () => {
     const config = { isText: true };
 
     test('does not impact a non-text extension', () => {
-      expect(MimeTypes.typeFromExtension('.gif', config)).toBe('image/gif');
+      expect(MimeTypes.typeFromPathExtension('.gif', config)).toBe('image/gif');
     });
 
     test('does not impact a text extension', () => {
-      expect(MimeTypes.typeFromExtension('.text', config)).toBe('text/plain');
+      expect(MimeTypes.typeFromPathExtension('.text', config)).toBe('text/plain');
     });
 
     test('defaults to `text/plain`', () => {
-      expect(MimeTypes.typeFromExtension('.abcdefgXYZ', config)).toBe('text/plain');
+      expect(MimeTypes.typeFromPathExtension('.abcdefgXYZ', config)).toBe('text/plain');
     });
   });
 
@@ -71,15 +71,15 @@ describe('typeFromExtension()', () => {
     const config = { charSet: 'boop', isText: true };
 
     test('alters the result from a non0text extension', () => {
-      expect(MimeTypes.typeFromExtension('.png', config)).toBe('image/png; charset=boop');
+      expect(MimeTypes.typeFromPathExtension('.png', config)).toBe('image/png; charset=boop');
     });
 
     test('alters the result from a text extension', () => {
-      expect(MimeTypes.typeFromExtension('.text', config)).toBe('text/plain; charset=boop');
+      expect(MimeTypes.typeFromPathExtension('.text', config)).toBe('text/plain; charset=boop');
     });
 
     test('defaults to `text/plain` with the configured charset', () => {
-      expect(MimeTypes.typeFromExtension('.abcdefgXYZ', config)).toBe('text/plain; charset=boop');
+      expect(MimeTypes.typeFromPathExtension('.abcdefgXYZ', config)).toBe('text/plain; charset=boop');
     });
   });
 });


### PR DESCRIPTION
This PR is all about MIME types. The `MimeTypes` class now knows about character sets, and it got a bit more persnickety about its arguments. Due to the latter, the `contentType` configurations now require a file extension to be identified unambiguously by starting with a dot.