### PR TITLE
Responses!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Breaking changes:
   with a dot.
 
 Other notable changes:
+* New class `HttpResponse` to encapsulate data required to make an HTTP(ish)
+  response and to handle much of the mechanics of actually producing a response.
+* Rewrote `Request.sendFile()` to no longer use Express-specific functionality.
 * Expanded `MimeTypes` to handle character set stuff.
 
 ###  v0.6.5 -- 2024-02-09

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -108,11 +108,11 @@ const services = [
       maxQueueSize: 100
     },
     data: {
-      maxBurstSize:      500000,
-      flowRate:          10000,
+      maxBurstSize:      1024 * 1024,      // 1MB.
+      flowRate:          100 * 1024,       // 100kB.
       timeUnit:          'second',
-      maxQueueGrantSize: 10000,
-      maxQueueSize:      1000000
+      maxQueueGrantSize: 50 * 1024,       // 50kB.
+      maxQueueSize:      2 * 1024 * 1024  // 2MB.
     }
   }
 ];

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -162,7 +162,8 @@ const applications = [
     name:        'responseTwo',
     class:       'SimpleResponse',
     contentType: 'text/html',
-    body:        '<html><body><h1>Two!</h1></body></html>\n'
+    body:        '<html><body><h1>Two!</h1></body></html>\n',
+    etag:        true
   }
 ];
 

--- a/etc/example-setup/site/index.html
+++ b/etc/example-setup/site/index.html
@@ -6,4 +6,28 @@
 <body>
     <h1>Hello!</h1>
 </body>
+
+<ul>
+  <li><a href="avec-index">avec-index/</a></li>
+  <li>florp/
+    <ul>
+      <li><a href="florp/boop.html">boop.html</a></li>
+    </ul>
+  </li>
+  <li>resp/
+    <ul>
+      <li><a href="resp/empty-body">empty-body</a></li>
+      <li><a href="resp/no-body">no-body</a></li>
+      <li><a href="resp/one">one</a></li>
+      <li><a href="resp/two">two</a></li>
+    </ul>
+  </li>
+  <li>subdir/
+    <ul>
+      <li><a href="subdir/one.txt">one.txt</a></li>
+      <li><a href="subdir/two.txt">two.txt</a></li>
+    </ul>
+  </li>
+</ul>
+
 </html>

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -423,12 +423,12 @@ export class Request {
    * @returns {object} Loggable information about the response.
    */
   async getLoggableResponseInfo() {
-    let requestError = null;
+    let responseError = null;
 
     try {
       await this.whenResponseDone();
     } catch (e) {
-      requestError = e;
+      responseError = e;
     }
 
     const connectionError = this.#outerContext.socket.errored ?? null;
@@ -438,7 +438,7 @@ export class Request {
     const contentLength   = headers['content-length'] ?? 0;
 
     const result = {
-      ok: !(requestError || connectionError),
+      ok: !(responseError || connectionError),
       contentLength,
       statusCode,
       headers: Request.#sanitizeResponseHeaders(headers),
@@ -447,11 +447,11 @@ export class Request {
     const fullErrors = [];
     let   errorStr   = null;
 
-    if (requestError) {
-      const code = Request.#extractErrorCode(requestError);
+    if (responseError) {
+      const code = Request.#extractErrorCode(responseError);
 
-      fullErrors.push(requestError);
-      result.requestError = code;
+      fullErrors.push(responseError);
+      result.responseError = code;
       errorStr = code;
     }
 

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -1079,38 +1079,6 @@ export class Request {
   }
 
   /**
-   * Kicks off the response procedure by emitting the status code and response
-   * headers. This is _approximately_ a wrapper around
-   * `HttpResponse.writeHead()` (and similar), meant to hide all the
-   * shouldn't-be-differences between the concrete protocol implementations.
-   *
-   * @param {number} statusCode The HTTP(ish) status code.
-   * @param {HttpHeaders} headers Response headers.
-   */
-  #writeHead(statusCode, headers) {
-    const res = this.#expressResponse;
-
-    res.status(statusCode);
-
-    // We'd love to use `response.setHeaders()` here, but as of this writing
-    // (checked on Node 21.4), there are three issues which prevent its use:
-    //
-    // * It is not implemented on `Http2ServerResponse`. This is filed as Node
-    //   issue #51573 <https://github.com/nodejs/node/issues/51573>.
-    // * Calling it on a `Headers` object will cause it to fail to handle
-    //   multiple `Set-Cookies` headers correctly. This is filed as Node issue
-    //   #51599 <https://github.com/nodejs/node/issues/51599>.
-    // * When used on an HTTP1 server (that is not the HTTP2 protocol), it
-    //   forces header names to lower case. Though not against the spec, it is
-    //   atypical to send lowercased headers in HTTP1.
-
-    const entries = headers.entriesForVersion(this.#expressRequest.httpVersionMajor);
-    for (const [name, value] of entries) {
-      res.setHeader(name, value);
-    }
-  }
-
-  /**
    * Writes and finishes a response that is either no-body or has already-known
    * contents.
    *

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -346,9 +346,12 @@ export class Request {
 
   /**
    * @returns {string} A reasonably-suggestive but possibly incomplete
-   * representation of the incoming request, in the form of a protocol-less URL.
-   * This is meant for logging, and specifically _not_ for any routing or other
-   * more meaningful computation (hence the name).
+   * representation of the incoming request including both the host and target,
+   * in the form of a protocol-less URL in most cases (and something vaguely
+   * URL-like when the target isn't the usual `origin` type).
+   *
+   * This value is meant for logging, and specifically _not_ for any routing or
+   * other more meaningful computation (hence the name).
    */
   get urlForLogging() {
     const { host }               = this;

--- a/src/net-util/export/HttpResponse.js
+++ b/src/net-util/export/HttpResponse.js
@@ -308,7 +308,7 @@ export class HttpResponse {
       let remaining = length;
 
       while (remaining > 0) {
-        const { bytesRead } = handle.read(buffer, { position: at });
+        const { bytesRead } = await handle.read(buffer, { position: at });
 
         if (bytesRead === 0) {
           throw new Error(`File changed length during response processing: ${path}`);

--- a/src/net-util/export/HttpResponse.js
+++ b/src/net-util/export/HttpResponse.js
@@ -1,0 +1,484 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs/promises';
+import http from 'node:http';
+
+import { ManualPromise } from '@this/async';
+import { Paths, StatsBase } from '@this/fs-util';
+import { MustBe } from '@this/typey';
+
+import { HttpHeaders } from '#x/HttpHeaders';
+import { HttpUtil } from '#x/HttpUtil';
+
+/**
+ * Responder to an HTTP request. This class holds all the information needed to
+ * perform a response, along with the functionality to produce it.
+ */
+export class HttpResponse {
+  /** @type {?string} The original request method, or `null` if not yet set. */
+  #requestMethod = null;
+
+  /** @type {?number} The response status code, or `null` if not yet set. */
+  #status = null;
+
+  /** @type {?HttpHeaders} The response headers, or `null` if not yet set. */
+  #headers = null;
+
+  /** @type {?object} Information about the body, or `null` if not yet set. */
+  #body = null;
+
+  /**
+   * Constructs an instance. It is initially empty / unset.
+   */
+  constructor() {
+    // Nothing to do here. (This method exists at all just for the doc comment.)
+  }
+
+  /**
+   * @returns {HttpHeaders} The headers to be sent with this response. The
+   * return value is shared with the internal state of this instance.
+   */
+  get headers() {
+    if (this.#headers === null) {
+      this.#headers = new HttpHeaders();
+    }
+
+    return this.#headers;
+  }
+
+  /**
+   * @param {HttpHeaders} headers The headers to set. This object becomes shared
+   * with the internal state of this instance.
+   */
+  set headers(headers) {
+    this.#headers = MustBe.instanceOf(headers, HttpHeaders);
+  }
+
+  /**
+   * @returns {string} The original HTTP(ish) request's "method" (e.g. `get`
+   * or `post`).
+   */
+  get requestMethod() {
+    return this.#requestMethod;
+  }
+
+  /**
+   * @param {string} value The original request method.
+   */
+  set requestMethod(value) {
+    this.#requestMethod = MustBe.string(value, /^[a-z]{1,15}$/);
+  }
+
+  /**
+   * @returns {number} The HTTP(ish) response status code.
+   */
+  get status() {
+    return this.#status;
+  }
+
+  /**
+   * @param {number} value The HTTP(ish) response status code.
+   */
+  set status(value) {
+    this.#status =
+      MustBe.number(value, { safeInteger: true, minInclusive: 100, maxInclusive: 599 });
+  }
+
+  /**
+   * Sets the response body to be based on a buffer.
+   *
+   * @param {Buffer} body The full body.
+   * @param {?object} [options] Options.
+   * @param {?number} [options.offset] Offset in bytes from the start of `body`
+   *   of what to actually send. Defaults to `0` (that is, the start).
+   * @param {?number} [options.length] How many bytes to actually send, or
+   *   `null` to indicate the maximum amount possible. Defaults to `null`.
+   */
+  setBodyBuffer(body, options = null) {
+    MustBe.instanceOf(body, Buffer);
+    const { offset = null, length = null } = options ?? {};
+
+    const finalOffset = HttpResponse.#adjustByteIndex(offset ?? 0, body.length);
+    const finalLength = HttpResponse.#adjustByteIndex(length, body.length - finalOffset);
+    const buffer = (finalLength === body.length)
+      ? body
+      : body.subarray(finalOffset, finalOffset + finalLength);
+
+    this.#body = { type: 'buffer', buffer };
+  }
+
+  /**
+   * Sets the response body to be based on a file. If the response length (e.g.
+   * the `length` if specified) is small enough, the response body is read from
+   * the file during this call.
+   *
+   * @param {string} absolutePath Absolute path to the file.
+   * @param {?object} [options] Options.
+   * @param {?StatsBase} [options.stats] Stats for the file, if known. If not
+   *   known, then they are retrieved during this call.
+   * @param {?number} [options.offset] Offset in bytes from the start of `body`
+   *   of what to actually send. Defaults to `0` (that is, the start).
+   * @param {?number} [options.length] How many bytes to actually send, or
+   *   `null` to indicate the maximum amount possible. Defaults to `null`.
+   */
+  async setBodyFile(absolutePath, options = null) {
+    Paths.checkAbsolutePath(absolutePath);
+    const { offset = null, length = null, stats: maybeStats = null } = options ?? {};
+
+    const stats = await HttpResponse.#adjustStats(maybeStats, absolutePath);
+
+    const fileLength  = stats.size;
+    const finalOffset = HttpResponse.#adjustByteIndex(offset ?? 0, fileLength);
+    const finalLength = HttpResponse.#adjustByteIndex(length, fileLength - finalOffset);
+
+    if (finalLength <= HttpResponse.#MAX_IMMEDIATE_READ_SIZE) {
+      const buffer =
+        await HttpResponse.#readFilePortion(absolutePath, finalOffset, finalLength);
+
+      this.#body = { type: 'buffer', buffer };
+    } else {
+      this.#body = {
+        type:   'file',
+        path:   absolutePath,
+        offset: finalOffset,
+        length: finalLength,
+      };
+    }
+  }
+
+  /**
+   * Indicates unambiguously that this instance is to have no response body.
+   */
+  setNoBody() {
+    this.#body = { type: 'none' };
+  }
+
+  /**
+   * Validates this instance for completeness and correctness. This includes:
+   *
+   * * Checking that {@link #requestMethod} is set.
+   * * Checking that {@link #status} is set.
+   * * Checking that one of the body-setup methods has been called (that is, one
+   *   of {@link #setBodyBuffer}, {@link #setBodyFile}, or {@link #setNoBody}).
+   *
+   * And, depending on the body:
+   *
+   * * If `body !== null`:
+   *   * Checking that request method was not `HEAD` if the the status is
+   *     successful (`2xx`).
+   *   * Checking that `status` allows a body.
+   *   * Checking that a `content-type` header is present.
+   *   * Checking that a `content-length` header is _not_ present (because this
+   *     class will generate it).
+   * * If `body === null`:
+   *   * Checking that no content-related headers are present.
+   *
+   * To be clear, this is far from an exhaustive list of possible error checks.
+   * It is meant to catch the most common and blatant client problems.
+   */
+  validate() {
+    const { headers, requestMethod, status } = this;
+    const body = this.#body;
+
+    if (requestMethod === null) {
+      throw new Error('`.requestMethod` not set.');
+    } else if (status === null) {
+      throw new Error('`.status` not set.');
+    } else if (body === null) {
+      throw new Error('Body (or lack thereof) not defined.');
+    }
+
+    if (body.type === 'none') {
+      if (HttpUtil.responseBodyIsRequiredFor(requestMethod, status)) {
+        throw new Error(`Non-body response is incompatible with method \`${requestMethod}\` and status ${status}.`);
+      }
+
+      for (const h of HttpResponse.#CONTENT_HEADERS) {
+        if (headers.get(h)) {
+          throw new Error(`Non-body response cannot use header \`${h}\`.`);
+        }
+      }
+    } else {
+      if (!HttpUtil.responseBodyIsAllowedFor(requestMethod, status)) {
+        throw new Error(`Body-bearing response is incompatible with method \`${requestMethod}\` and status ${status}.`);
+      } else if (headers.get('content-length')) {
+        throw new Error('Body-bearing response must not have `content-length` header pre-set.');
+      } else if (!headers.get('content-type')) {
+        throw new Error('Body-bearing response must have `content-type` header pre-set.');
+      }
+    }
+  }
+
+  /**
+   * Sends this instance as a response to the request linked to the given core
+   * {@link http.HttpResponse} object (or similar).
+   *
+   * @param {http.HttpResponse} res The response object to invoke.
+   * @returns {boolean} `true` when the response is completed.
+   */
+  async writeTo(res) {
+    this.validate();
+
+    const { headers, status } = this;
+    const body = this.#body;
+
+    res.status(status);
+
+    // We'd love to use `response.setHeaders()` here, but as of this writing
+    // (checked on Node 21.4), there are three issues which prevent its use:
+    //
+    // * It is not implemented on `Http2ServerResponse`. This is filed as Node
+    //   issue #51573 <https://github.com/nodejs/node/issues/51573>.
+    // * Calling it on a `Headers` object will cause it to fail to handle
+    //   multiple `Set-Cookies` headers correctly. This is filed as Node issue
+    //   #51599 <https://github.com/nodejs/node/issues/51599>.
+    // * When used on an HTTP1 server (that is not the HTTP2 protocol), it
+    //   forces header names to lower case. Though not against the spec, it is
+    //   atypical to send lowercased headers in HTTP1.
+
+    const entries = headers.entriesForVersion(res.req.httpVersionMajor);
+    for (const [name, value] of entries) {
+      res.setHeader(name, value);
+    }
+
+    // Note: At this point, all headers have been set on `res` _except_
+    // `content-length` (which is always set per body type as necessary).
+
+    switch (body.type) {
+      case 'buffer': {
+        return await this.#writeBodyBuffer(res);
+      }
+      case 'file':  {
+        return await this.#writeBodyFile(res);
+      }
+      case 'none': {
+        return await this.#writeNoBody(res);
+      }
+      default: {
+        // If we get here, it indicates a bug in this class.
+        throw new Error(`Shouldn't happen: Weird body type: ${body.type}.`);
+      }
+    }
+  }
+
+  /**
+   * Writes the body from a buffer, and ends the response.
+   *
+   * @param {http.HttpResponse} res The response object to use.
+   * @returns {boolean} `true` when closed without error.
+   * @throws {Error} Any error reported by `res`.
+   */
+  async #writeBodyBuffer(res) {
+    const buffer = this.#body.buffer;
+
+    res.setHeader('Content-Length', buffer.length);
+    res.end(buffer);
+
+    return HttpResponse.#whenResponseDone(res);
+  }
+
+  /**
+   * Writes the body from a file, and ends the response.
+   *
+   * @param {http.HttpResponse} res The response object to use.
+   * @returns {boolean} `true` when closed without error.
+   * @throws {Error} Any error reported by `res`.
+   */
+  async #writeBodyFile(res) {
+    const CHUNK_SIZE = HttpResponse.#READ_CHUNK_SIZE;
+    const { path, offset, length } = this.#body;
+
+    res.setHeader('Content-Length', length);
+
+    if (length <= CHUNK_SIZE) {
+      const buffer =
+        await HttpResponse.#readFilePortion(path, offset, length);
+      res.end(buffer);
+      return HttpResponse.#whenResponseDone(res);
+    }
+
+    const buffer = Buffer.alloc(CHUNK_SIZE);
+
+    let handle = null;
+    try {
+      handle = await fs.open(path);
+
+      let at        = offset;
+      let remaining = length;
+
+      while (remaining > 0) {
+        const { bytesRead } = handle.read(buffer, { position: at });
+
+        if (bytesRead === 0) {
+          throw new Error(`File changed length during response processing: ${path}`);
+        }
+
+        // TODO: Handle `drain` requests (based on return value of `write()`).
+        res.write(bytesRead === buffer.length ? buffer : buffer.subarray(0, bytesRead));
+
+        at += bytesRead;
+        remaining -= bytesRead;
+      }
+    } finally {
+      await handle.close();
+    }
+
+    res.end();
+    return HttpResponse.#whenResponseDone(res);
+  }
+
+  /**
+   * Ends a response without writing a body.
+   *
+   * @param {http.HttpResponse} res The response object to use.
+   * @returns {boolean} `true` when closed without error.
+   * @throws {Error} Any error reported by `res`.
+   */
+  async #writeNoBody(res) {
+    res.end();
+    return HttpResponse.#whenResponseDone(res);
+  }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * @type {Array<string>} Array of header names associated with non-empty
+   * bodies.
+   */
+  static #CONTENT_HEADERS = Object.freeze([
+    'content-encoding',
+    'content-language',
+    'content-length',
+    'content-location',
+    'content-range',
+    'content-security-policy',
+    'content-security-policy-report-only',
+    'content-type'
+  ]);
+
+  /**
+   * @type {number} Maximum size of a response body to immediately read from a
+   * file and keep in an instance.
+   */
+  static #MAX_IMMEDIATE_READ_SIZE = 16 * 1024; // 16k
+
+  /**
+   * @type {number} Chunk size to use when reading a file and writing it as a
+   * response.
+   */
+  static #READ_CHUNK_SIZE = 64 * 1024; // 64k
+
+  /**
+   * Adjusts an incoming index value (e.g. bytes into a buffer or file), per
+   * this class's contracts.
+   *
+   * @param {*} value Value to adjust. Must be either a number or `null`.
+   * @param {?number} maxInclusive Maximum allowed value.
+   * @returns {?number} Adjusted value, if `value` was valid.
+   */
+  static #adjustByteIndex(value, maxInclusive) {
+    return (value === null)
+      ? maxInclusive
+      : MustBe.number(value, { safeInteger: true, minInclusive: 0, maxInclusive });
+  }
+
+  /**
+   * Checks that the given value is a stats object that could possibly be
+   * allowed, or is `null`. If `null`, the stats are retrieved.
+   *
+   * @param {*} value The (alleged) stats value, or `null`.
+   * @param {string} path Absolute path of the file.
+   * @returns {StatsBase} The given `value` if it is non-`null`, or the freshly
+   *   retrieved stats for a non-directory `path`.
+   */
+  static async #adjustStats(value, path) {
+    if (value === null) {
+      value = await fs.stat(path, { bigint: true });
+    } else {
+      MustBe.instanceOf(value, StatsBase);
+    }
+
+    if (value.isDirectory()) {
+      throw new Error(`Cannot use a directory as a response body: ${path}`);
+    }
+
+    return value;
+  }
+
+  /**
+   * Reads a portion of a file, returning a fresh buffer with the contents.
+   *
+   * @param {string} path Path to the file.
+   * @param {number} offset Offset to start reading at.
+   * @param {number} length Number of bytes to read.
+   * @returns {Buffer} Buffer of the contents of the indicated file portion.
+   */
+  static async #readFilePortion(path, offset, length) {
+    const buffer = Buffer.alloc(length);
+
+    let handle = null;
+
+    try {
+      handle = await fs.open(path);
+      const result = await handle.read(buffer, { position: offset });
+      if (result.bytesRead !== length) {
+        throw new Error(`File changed length during response processing: ${path}`);
+      }
+    } finally {
+      await handle.close();
+    }
+
+    return buffer;
+  }
+
+  /**
+   * Returns when an underlying response has been closed successfully (after
+   * all of the response is believed to be sent) or has errored. Returns `true`
+   * for a normal close, or throws whatever error the response reports.
+   *
+   * @param {http.HttpResponse} res The response object in question.
+   * @returns {boolean} `true` when closed without error.
+   * @throws {Error} Any error reported by the underlying response object.
+   */
+  static async #whenResponseDone(res) {
+    function makeProperError(error) {
+      return (error instanceof Error)
+        ? error
+        : new Error(`non-error object: ${error}`);
+    }
+
+    // Note: It's not correct to also check for `.writableEnded` here (as an
+    // earlier version of this code did), because that becomes `true` _before_
+    // the outgoing data is believed to be actually made it to the networking
+    // stack to be sent out.
+    if (res.closed || res.destroyed) {
+      const error = res.errored;
+      if (error) {
+        throw makeProperError(error);
+      }
+      return true;
+    }
+
+    const resultMp = new ManualPromise();
+
+    res.once('error', (error) => {
+      if (error) {
+        resultMp.reject(makeProperError(error));
+      } else {
+        resultMp.resolve(true);
+      }
+    });
+
+    res.once('close', () => {
+      if (!resultMp.isSettled()) {
+        resultMp.resolve(true);
+      }
+    });
+
+    return resultMp.promise;
+  }
+}

--- a/src/net-util/export/HttpResponse.js
+++ b/src/net-util/export/HttpResponse.js
@@ -298,8 +298,6 @@ export class HttpResponse {
       return HttpResponse.#whenResponseDone(res);
     }
 
-    const buffer = Buffer.alloc(CHUNK_SIZE);
-
     let handle = null;
     try {
       handle = await fs.open(path);
@@ -308,6 +306,10 @@ export class HttpResponse {
       let remaining = length;
 
       while (remaining > 0) {
+        // TODO: Consider using a pool for buffers, though probably _don't_ want
+        // to use `Buffer.allocUnsafe()` so as to avoid relying on the global
+        // `poolSize` being something we'd want.
+        const buffer = Buffer.alloc(Math.min(remaining, CHUNK_SIZE));
         const { bytesRead } = await handle.read(buffer, { position: at });
 
         if (bytesRead === 0) {

--- a/src/net-util/index.js
+++ b/src/net-util/index.js
@@ -5,6 +5,7 @@ export * from '#x/Cookies';
 export * from '#x/EtagGenerator';
 export * from '#x/HostInfo';
 export * from '#x/HttpHeaders';
+export * from '#x/HttpResponse';
 export * from '#x/HttpUtil';
 export * from '#x/MimeTypes';
 export * from '#x/Uris';


### PR DESCRIPTION
This PR reworks a bunch of aspects of how our `Request` class produces responses. Highlights:

* Split a new class `net-util.HttpResponse` out of `Request`, to take care of our lowest layer of response handling.
* Added stuff to `HttpResponse` to handle sending a response using file content.
* Rewrote `Request.sendFile()` to use `HttpResponse` instead of `expressResponse.sendFile()`.