### PR TITLE
Response stuff, conditional requests, integration tests, and more!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Breaking changes:
 
 Other notable changes:
 * New integration test setup, along with a handful of tests.
+* New class `HttpConditional` to take over from the old npm module `fresh`.
 * New class `HttpResponse` to encapsulate data required to make an HTTP(ish)
   response and to handle much of the mechanics of actually producing a response.
 * Rewrote `Request.sendFile()` to no longer use Express-specific functionality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Breaking changes:
   with a dot.
 
 Other notable changes:
+* New integration test setup, along with a handful of tests.
 * New class `HttpResponse` to encapsulate data required to make an HTTP(ish)
   response and to handle much of the mechanics of actually producing a response.
 * Rewrote `Request.sendFile()` to no longer use Express-specific functionality.

--- a/scripts/lib/lactoserv/run-tests
+++ b/scripts/lib/lactoserv/run-tests
@@ -27,8 +27,8 @@ define-usage --with-help $'
       `build` -- Always build, even if there is something already built.
       `clean` -- Always do a clean build.
       `run` -- Build only if there is nothing yet built. This is the default.
-    --integration
-      Run integration tests. By default, runs unit tests.
+    --type=<type> :: `integration` `unit`
+      Test type to run. By default, runs unit tests.
     --out=<dir>
       Directory where built output goes. Defaults to `out` directly under the
       main product directory.
@@ -37,8 +37,8 @@ define-usage --with-help $'
 # What to do?
 opt-value --var=action --default=run --enum[]='build clean run' do
 
-# Run integration tests?
-opt-toggle --var=doIntegration integration
+# Test type.
+opt-value --var=testType --enum[]='integration unit' type
 
 # Built output directory.
 opt-value --var=outDir out
@@ -193,7 +193,7 @@ outDir="$(lib buildy out-dir --out="${outDir}")" \
 build-if-necessary "${action}" \
 || exit "$?"
 
-if (( doIntegration )); then
+if [[ ${testType} == integration ]]; then
     run-integration-tests
 else
     run-unit-tests

--- a/scripts/lib/lactoserv/run-tests
+++ b/scripts/lib/lactoserv/run-tests
@@ -27,6 +27,8 @@ define-usage --with-help $'
       `build` -- Always build, even if there is something already built.
       `clean` -- Always do a clean build.
       `run` -- Build only if there is nothing yet built. This is the default.
+    --integration
+      Run integration tests. By default, runs unit tests.
     --out=<dir>
       Directory where built output goes. Defaults to `out` directly under the
       main product directory.
@@ -34,6 +36,9 @@ define-usage --with-help $'
 
 # What to do?
 opt-value --var=action --default=run --enum[]='build clean run' do
+
+# Run integration tests?
+opt-toggle --var=doIntegration integration
 
 # Built output directory.
 opt-value --var=outDir out
@@ -103,6 +108,62 @@ function config-file-path {
     echo "${configFile[0]}"
 }
 
+# Runs integration tests.
+function run-integration-tests {
+    "$(base-dir)/tests/run-all" "${args[@]}"
+}
+
+# Runs unit tests.
+function run-unit-tests {
+    local configFile
+    configFile="$(config-file-path)" \
+    || exit "$?"
+
+    local toolPath
+    toolPath="$(tester-path)" \
+    || exit "$?"
+
+    # Find the tests, and generally set up the testing directory.
+
+    local testsDir="${outDir}/tests"
+
+    rm -rf "${testsDir}"
+    mkdir -p "${testsDir}"
+    cd "${testsDir}"
+    rm -rf node_modules
+    ln -s ../lactoserv/lib/code/node_modules .
+    echo >package.json '{ "type": "module" }'
+
+    # TODO: Try this to see if Pulsar and/or Zed still mess up syntax highlighting.
+    #cat >package.json <<< '{ "type": "module" }'
+
+    local dirsWithTests
+    dirsWithTests="$(
+        lib ls-files --output=array --cd="${srcDir}" --dirs --full-paths \
+            --include='/tests$')" \
+    || exit "$?"
+
+    while IFS='' read -r -d $'\0' dir; do
+        [[ ${dir} =~ /([^/]+)/tests$ ]] || {
+            error-msg "Weird directory name: ${dir}"
+            exit 1
+        }
+
+        local moduleName="${BASH_REMATCH[1]}"
+        cp -r "${dir}" "${testsDir}/${moduleName}"
+    done < <(jget --output=raw0 "${dirsWithTests}" '.[]')
+
+    # Copy the config file into place, where it will be found when the test
+    # harness is run.
+    cp "${configFile}" "${testsDir}"
+    configFile="${testsDir}/$(basename "${configFile}")"
+
+    # Run the tool!
+
+    "${toolPath}" --config="${configFile}" "${args[@]}" \
+    || return "$?"
+}
+
 # Builds the tester if necessary, and then prints the path to it main binary.
 function tester-path {
     local toolModule=tester
@@ -129,46 +190,15 @@ srcDir="$(base-dir)/src"
 outDir="$(lib buildy out-dir --out="${outDir}")" \
 || exit "$?"
 
-configFile="$(config-file-path)" \
-|| exit "$?"
-
-toolPath="$(tester-path)" \
-|| exit "$?"
-
 build-if-necessary "${action}" \
 || exit "$?"
 
-# Find the tests, and generally set up the testing directory.
+if (( doIntegration )); then
+    run-integration-tests
+else
+    run-unit-tests
+fi
 
-testsDir="${outDir}/tests"
-rm -rf "${testsDir}"
-mkdir -p "${testsDir}"
-cd "${testsDir}"
-rm -rf node_modules
-ln -s ../lactoserv/lib/code/node_modules .
-cat >package.json <<< '{ "type": "module" }'
-
-dirsWithTests="$(
-    lib ls-files --output=array --cd="${srcDir}" --dirs --full-paths \
-        --include='/tests$')" \
-|| exit "$?"
-while IFS='' read -r -d $'\0' dir; do
-    [[ ${dir} =~ /([^/]+)/tests$ ]] || {
-        error-msg "Weird directory name: ${dir}"
-        exit 1
-    }
-    moduleName="${BASH_REMATCH[1]}"
-    cp -r "${dir}" "${testsDir}/${moduleName}"
-done < <(jget --output=raw0 "${dirsWithTests}" '.[]')
-
-# Copy the config file into place, where it will be found when the test harness
-# is run.
-cp "${configFile}" "${testsDir}"
-configFile="${testsDir}/$(basename "${configFile}")"
-
-# Run the tool!
-
-"${toolPath}" --config="${configFile}" "${args[@]}"
 status="$?"
 
 info-msg

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -69,16 +69,12 @@ export class StaticFiles extends BaseApplication {
 
       return request.sendRedirect(redirectTo, { status: 301 });
     } else if (resolved.path) {
-      const options = {
-        ...StaticFiles.#SEND_OPTIONS,
-        headers: {
-          'last-modified': HttpUtil.dateStringFromMsec(resolved.stats.mtimeMs)
-        }
-      };
+      const options = { ...StaticFiles.#SEND_OPTIONS };
 
       if (this.#etagGenerator) {
-        options.headers['etag'] =
-          await this.#etagGenerator.etagFromFile(resolved.path);
+        options.headers = {
+          'etag': await this.#etagGenerator.etagFromFile(resolved.path)
+        };
       }
 
       return await request.sendFile(resolved.path, options);

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -6,7 +6,7 @@ import fs from 'node:fs/promises';
 import { Paths, Statter } from '@this/fs-util';
 import { IntfLogger } from '@this/loggy';
 import { DispatchInfo } from '@this/net-protocol';
-import { EtagGenerator, HttpUtil, MimeTypes } from '@this/net-util';
+import { EtagGenerator, MimeTypes } from '@this/net-util';
 import { ApplicationConfig } from '@this/sys-config';
 import { BaseApplication } from '@this/sys-framework';
 

--- a/src/main-lactoserv/package-lock.json
+++ b/src/main-lactoserv/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "express": "^4.18.2",
-        "fresh": "^0.5.2",
         "http2-express-bridge": "^1.0.7",
         "lodash": "^4.17.21",
         "mime": "^4.0.1",

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -120,9 +120,9 @@ export class Request {
   #parsedTargetObject = null;
 
   /**
-   * @type {Promise<boolean>} Promise which resolves to `true` when the response
-   * to this request is complete, or is rejected with whatever error caused it
-   * to fail.
+   * @type {ManualPromise<boolean>} Manual promise whose actual-promise resolves
+   * to `true` when the response to this request is complete, or is rejected
+   * with whatever error caused it to fail.
    */
   #responsePromise = new ManualPromise();
 

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -578,9 +578,6 @@ export class Request {
       return this.sendMetaResponse(rangeInfo.status, errOptions);
     }
 
-    // Note: `#rangeInfo()` notices if this is a HEAD request, and returns a
-    // `bodyBuffer === null` if so.
-
     headers.setAll(rangeInfo.headers);
     return this.#writeCompleteResponse(rangeInfo.status, headers, rangeInfo.bodyBuffer);
   }
@@ -654,9 +651,8 @@ export class Request {
     } else {
       const response = new HttpResponse();
 
-      response.requestMethod = this.method;
-      response.status        = rangeInfo.status;
-      response.headers       = headers;
+      response.status  = rangeInfo.status;
+      response.headers = headers;
 
       await response.setBodyFile(path, {
         stats,
@@ -680,8 +676,6 @@ export class Request {
    *
    * If the status code is allowed to be cached (per HTTP spec), the response
    * will always have a standard `Cache-Control` header.
-   *
-   * The response _never_ includes an `Etag` header.
    *
    * If a body is not supplied and _is_ appropriate to send, this method
    * constructs a `text/plain` body in a standard form which includes the
@@ -1037,10 +1031,8 @@ export class Request {
     }
 
     const { start, end } = ranges[0];
-    const finalLength = (end - start) + 1; // Note: `end` is inclusive.
-    const finalBuffer = (bodyBuffer && (this.#requestMethod !== 'head'))
-      ? bodyBuffer.subarray(start, end + 1)
-      : null;
+    const finalLength    = (end - start) + 1; // Note: `end` is inclusive.
+    const finalBuffer    = bodyBuffer?.subarray(start, end + 1) ?? null;
 
     return {
       status:     206,
@@ -1066,9 +1058,8 @@ export class Request {
   async #writeCompleteResponse(status, headers, body = null) {
     const response = new HttpResponse();
 
-    response.requestMethod = this.method;
-    response.status        = status;
-    response.headers       = headers;
+    response.status  = status;
+    response.headers = headers;
 
     if (body) {
       response.setBodyBuffer(body);

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -559,6 +559,7 @@ export class Request {
     if (this.isFreshWithRespectTo(headers)) {
       // For basic range-support headers.
       headers.setAll(this.#rangeInfo().headers);
+      headers.deleteContent();
       return this.#writeCompleteResponse(304, headers);
     }
 
@@ -626,6 +627,7 @@ export class Request {
     if (this.isFreshWithRespectTo(headers)) {
       // For basic range-support headers.
       headers.setAll(this.#rangeInfo().headers);
+      headers.deleteContent();
       return this.#writeCompleteResponse(304, headers);
     }
 

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -620,8 +620,7 @@ export class Request {
     }
 
     const headers = this.#makeResponseHeaders('cacheable', options, {
-      'content-type':   contentType,
-      'last-modified':  HttpUtil.dateStringFromStatsMtime(stats)
+      'content-type': contentType
     });
 
     if (this.isFreshWithRespectTo(headers)) {

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -826,7 +826,7 @@ export class Request {
    * @throws {Error} Any error reported by the underlying response object.
    */
   async whenResponseDone() {
-    return this.#responsePromise;
+    return this.#responsePromise.promise;
   }
 
   /**

--- a/src/net-protocol/package.json
+++ b/src/net-protocol/package.json
@@ -20,7 +20,6 @@
     "@this/net-util": "*",
     "@this/typey": "*",
     "express": "^4.18.2",
-    "fresh": "^0.5.2",
     "http2-express-bridge": "^1.0.7",
     "lodash": "^4.17.21",
     "range-parser": "^1.2.1",

--- a/src/net-util/export/HttpConditional.js
+++ b/src/net-util/export/HttpConditional.js
@@ -104,9 +104,9 @@ export class HttpConditional {
         return false;
       }
 
-      const lastModified = this.#msecTimeFrom(requestHeaders, stats);
+      const lastModified = this.#msecTimeFrom(responseHeaders, stats);
 
-      if (!lastModified || isNaN(lastModified)) {
+      if (!lastModified) {
         return false;
       }
 

--- a/src/net-util/export/HttpConditional.js
+++ b/src/net-util/export/HttpConditional.js
@@ -1,0 +1,119 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { StatsBase } from '@this/fs-util';
+import { MustBe } from '@this/typey';
+
+import { HttpHeaders } from '#x/HttpHeaders';
+import { HttpUtil } from '#x/HttpUtil';
+
+
+/**
+ * Utility class for various HTTP conditional tests.
+ */
+export class HttpConditional {
+  /**
+   * @type {RegExp} Regex which matches a `cache-control` header that specifies
+   * `no-cache` somewhere in it.
+   */
+  static #NO_CACHE_REGEX = /(?:^|,) *no-cache *(?:,|$)/;
+
+  /**
+   * Checks to see if a response with the given headers would be considered
+   * "fresh" such that a not-modified (status `304`) response could be issued to
+   * either a `GET` or `HEAD` request.
+   *
+   * A request is considered fresh if all of the following are true:
+   * * The request method is `HEAD` or `GET`.
+   * * The request doesn't ask for caching to be off.
+   * * The request has at least one condition which checks for freshness, and
+   *   all such conditions pass.
+   *
+   * This assumes that the response would have a sans-check status code that is
+   * acceptable for conversion to the not-modified status (`304`).
+   *
+   * **Note:** This is akin to Express's `request.fresh` getter.
+   *
+   * @param {string} requestMethod The request method (e.g., `get`), in either
+   *   lowercase or all-caps.
+   * @param {HttpHeaders|object} requestHeaders Request headers which possibly
+   *   contain content conditionals. The headers that matter in this regard are
+   *   `cache-control`, `if-none-match`, and `if-modified-since`.
+   * @param {?HttpHeaders} responseHeaders Would-be response headers for a
+   *   content-bearing response, or `null` to _just_ use `stats`. The headers
+   *   that matter in this regard are `etag` and `last-modified`.
+   * @param {?StatsBase} [stats] File stats from which to derive a last-modified
+   *   date, or `null` if no stats are available. If non-`null`, this takes
+   *   precedence over a header value.
+   * @returns {boolean} `true` iff the request is to be considered "fresh."
+   */
+  static isContentFresh(requestMethod, requestHeaders, responseHeaders, stats = null) {
+    MustBe.string(requestMethod);
+    // MustBe.instanceOf(requestHeaders, HttpHeaders); TODO: Make it true.
+    MustBe.instanceOf(responseHeaders, HttpHeaders);
+    if (stats !== null) {
+      MustBe.instanceOf(stats, StatsBase);
+    }
+
+    switch (requestMethod) {
+      case 'get': case 'head':
+      case 'GET': case 'HEAD': {
+        // Possibly fresh.
+        break;
+      }
+      default: {
+        return false;
+      }
+    }
+
+    const cacheControl = HttpHeaders.get(requestHeaders, 'cache-control');
+
+    if (cacheControl && this.#NO_CACHE_REGEX.test(cacheControl)) {
+      return false;
+    }
+
+    const ifNoneMatch = HttpHeaders.get(requestHeaders, 'if-none-match');
+
+    if (ifNoneMatch) {
+      const responseEtag = responseHeaders.get('etag');
+
+      if (!responseEtag || (responseEtag === '')) {
+        return false;
+      }
+
+      const tagsToMatch = ifNoneMatch.split(/^ *| *, */);
+
+      if (tagsToMatch.indexOf(responseEtag) < 0) {
+        return false;
+      }
+
+      // We don't check `if-modified-since` at this point, because we have a
+      // matching etag, and per spec a matching etag takes precedence over any
+      // date checks.
+      return true;
+    }
+
+    const ifModifiedSince = HttpHeaders.get(requestHeaders, 'if-modified-since');
+
+    if (ifModifiedSince) {
+      const modifiedSince = HttpUtil.msecFromDateString(ifModifiedSince);
+
+      if (isNaN(modifiedSince)) {
+        return false;
+      }
+
+      const lastModified = stats?.mtime.getTime()
+        ?? HttpUtil.msecFromDateString(responseHeaders.get('last-modified') ?? null);
+
+      if (!lastModified || isNaN(lastModified)) {
+        return false;
+      }
+
+      if (lastModified > modifiedSince) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/src/net-util/export/HttpHeaders.js
+++ b/src/net-util/export/HttpHeaders.js
@@ -1,6 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { MustBe } from '@this/typey';
+
 import { Cookies } from '#x/Cookies';
 import { HttpUtil } from '#x/HttpUtil';
 
@@ -296,6 +298,8 @@ export class HttpHeaders extends Headers {
    * @returns {?string} The value of the header, or `null` if not found.
    */
   static get(headers, name) {
+    MustBe.string(name);
+
     if (headers instanceof Headers) {
       return headers.get(name);
     } else if (headers[name] !== undefined) {

--- a/src/net-util/export/HttpHeaders.js
+++ b/src/net-util/export/HttpHeaders.js
@@ -280,4 +280,39 @@ export class HttpHeaders extends Headers {
       yield* doOne(name, value);
     }
   }
+
+
+  //
+  // Static methods
+  //
+
+  /**
+   * Like {@link #get}, except will operate on either an instance of `Headers`
+   * (including this class) _or_ on a plain object. This is meant to make things
+   * easier during transition away from use of plain objects.
+   *
+   * @param {Headers|object} headers A `Headers`-ish thing to query.
+   * @param {string} name A header name.
+   * @returns {?string} The value of the header, or `null` if not found.
+   */
+  static get(headers, name) {
+    if (headers instanceof Headers) {
+      return headers.get(name);
+    } else if (headers[name] !== undefined) {
+      return headers[name];
+    }
+
+    // The hard part: The case of `name` and the keys of `headers` might not
+    // match, so we need to do a more manual search.
+
+    const lowerName = name.toLowercase();
+
+    for (const [k, v] of Object.entries(headers)) {
+      if (k.toLowercase() === lowerName) {
+        return v;
+      }
+    }
+
+    return null;
+  }
 }

--- a/src/net-util/export/HttpHeaders.js
+++ b/src/net-util/export/HttpHeaders.js
@@ -69,6 +69,26 @@ export class HttpHeaders extends Headers {
   }
 
   /**
+   * Deletes all content-related headers. These are (unsurprisingly) the ones
+   * whose names begin with `content-`.
+   */
+  deleteContent() {
+    // Note: Can't safely delete in the middle of an iteration. Arguably a bug
+    // in `Headers`.
+    const toDelete = [];
+
+    for (const [name] of this) {
+      if (name.startsWith('content-')) {
+        toDelete.push(name);
+      }
+    }
+
+    for (const name of toDelete) {
+      this.delete(name);
+    }
+  }
+
+  /**
    * Like the default `entries()` method, except alters names to be cased
    * appropriately for the indicated HTTP version. In addition, most values
    * returned are strings, but `Set-Cookie` values are always arrays of strings.

--- a/src/net-util/export/HttpHeaders.js
+++ b/src/net-util/export/HttpHeaders.js
@@ -305,10 +305,10 @@ export class HttpHeaders extends Headers {
     // The hard part: The case of `name` and the keys of `headers` might not
     // match, so we need to do a more manual search.
 
-    const lowerName = name.toLowercase();
+    const lowerName = name.toLowerCase();
 
     for (const [k, v] of Object.entries(headers)) {
-      if (k.toLowercase() === lowerName) {
+      if (k.toLowerCase() === lowerName) {
         return v;
       }
     }

--- a/src/net-util/export/HttpResponse.js
+++ b/src/net-util/export/HttpResponse.js
@@ -126,9 +126,7 @@ export class HttpResponse {
   }
 
   /**
-   * Sets the response body to be based on a file. If the response length (e.g.
-   * the `length` if specified) is small enough, the response body is read from
-   * the file during this call.
+   * Sets the response body to be based on a file.
    *
    * Unless directed not to (by an option), this method will cause a
    * `last-modified` header to be added to the response, based on the stats of
@@ -160,20 +158,13 @@ export class HttpResponse {
     const finalOffset = HttpResponse.#adjustByteIndex(offset ?? 0, fileLength);
     const finalLength = HttpResponse.#adjustByteIndex(length, fileLength - finalOffset);
 
-    if (finalLength <= HttpResponse.#MAX_IMMEDIATE_READ_SIZE) {
-      const buffer =
-        await HttpResponse.#readFilePortion(absolutePath, finalOffset, finalLength);
-
-      this.#body = { type: 'buffer', buffer };
-    } else {
-      this.#body = {
-        type:   'file',
-        path:   absolutePath,
-        offset: finalOffset,
-        length: finalLength,
-        lastModified
-      };
-    }
+    this.#body = {
+      type:   'file',
+      path:   absolutePath,
+      offset: finalOffset,
+      length: finalLength,
+      lastModified
+    };
   }
 
   /**
@@ -496,12 +487,6 @@ export class HttpResponse {
     'content-security-policy-report-only',
     'content-type'
   ]);
-
-  /**
-   * @type {number} Maximum size of a response body to immediately read from a
-   * file and keep in an instance.
-   */
-  static #MAX_IMMEDIATE_READ_SIZE = 16 * 1024; // 16k
 
   /**
    * @type {number} Chunk size to use when reading a file and writing it as a

--- a/src/net-util/index.js
+++ b/src/net-util/index.js
@@ -4,6 +4,7 @@
 export * from '#x/Cookies';
 export * from '#x/EtagGenerator';
 export * from '#x/HostInfo';
+export * from '#x/HttpConditional';
 export * from '#x/HttpHeaders';
 export * from '#x/HttpResponse';
 export * from '#x/HttpUtil';

--- a/src/net-util/tests/HttpConditional.test.js
+++ b/src/net-util/tests/HttpConditional.test.js
@@ -1,0 +1,47 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs/promises';
+
+import { HttpConditional, HttpHeaders } from '@this/net-util';
+
+
+describe('isContentFresh()', () => {
+  // Convenient stats objects.
+  let statsNum;
+  let statsBig;
+
+  beforeAll(async () => {
+    statsNum = await fs.stat('/');
+    statsBig = await fs.stat('/', { bigint: true });
+  });
+
+  test('rejects non-string `requestMethod`', () => {
+    expect(() => HttpConditional.isContentFresh(123, new HttpHeaders(), new HttpHeaders(), statsNum)).toThrow();
+  });
+
+  // TODO: Check `requestHeaders` once its type has been tightened.
+
+  test('rejects incorrect `responseHeaders`', () => {
+    expect(() => HttpConditional.isContentFresh('x', new HttpHeaders(), null, statsNum)).toThrow();
+    expect(() => HttpConditional.isContentFresh('x', new HttpHeaders(), new Headers(), statsNum)).toThrow();
+  });
+
+  test('rejects incorrect `stats`', () => {
+    expect(() => HttpConditional.isContentFresh('x', new HttpHeaders(), new HttpHeaders(), 123)).toThrow();
+  });
+
+  test('accepts `stats === null`', () => {
+    expect(() => HttpConditional.isContentFresh('x', new HttpHeaders(), new HttpHeaders(), null)).not.toThrow();
+  });
+
+  test('accepts old-style `stats`', () => {
+    expect(() => HttpConditional.isContentFresh('x', new HttpHeaders(), new HttpHeaders(), statsNum)).not.toThrow();
+  });
+
+  test('accepts bigint `stats`', () => {
+    expect(() => HttpConditional.isContentFresh('x', new HttpHeaders(), new HttpHeaders(), statsBig)).not.toThrow();
+  });
+
+  // TODO
+});

--- a/src/net-util/tests/HttpConditional.test.js
+++ b/src/net-util/tests/HttpConditional.test.js
@@ -22,8 +22,12 @@ describe('isContentFresh()', () => {
 
   // TODO: Check `requestHeaders` once its type has been tightened.
 
+  test('accepts `responseHeaders === null`', () => {
+    expect(() => HttpConditional.isContentFresh('x', new HttpHeaders(), null, statsNum)).not.toThrow();
+  });
+
   test('rejects incorrect `responseHeaders`', () => {
-    expect(() => HttpConditional.isContentFresh('x', new HttpHeaders(), null, statsNum)).toThrow();
+    expect(() => HttpConditional.isContentFresh('x', new HttpHeaders(), 1234, statsNum)).toThrow();
     expect(() => HttpConditional.isContentFresh('x', new HttpHeaders(), new Headers(), statsNum)).toThrow();
   });
 
@@ -43,5 +47,150 @@ describe('isContentFresh()', () => {
     expect(() => HttpConditional.isContentFresh('x', new HttpHeaders(), new HttpHeaders(), statsBig)).not.toThrow();
   });
 
-  // TODO
+  test.each`
+  requestMethod
+  ${'post'}
+  ${'POST'}
+  ${'put'}
+  ${'PUT'}
+  `('never treats request method $requestMethod as fresh', ({ requestMethod }) => {
+    const reqHead = new HttpHeaders();
+    const resHead = new HttpHeaders();
+
+    reqHead.set('if-none-match', '"xyz"');
+    resHead.set('etag',          '"xyz"');
+
+    expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead)).toBeFalse();
+  });
+
+  describe.each`
+  requestMethod
+  ${'get'}
+  ${'GET'}
+  ${'head'}
+  ${'HEAD'}
+  `('for request method $requestMethod', ({ requestMethod }) => {
+    test('returns `false` for an unconditional request', () => {
+      const reqHead = new HttpHeaders();
+      const resHead = new HttpHeaders();
+
+      resHead.set('etag', '"xyz"');
+      resHead.set('last-modified', statsNum.mtime.toUTCString());
+
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead)).toBeFalse();
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead, statsNum)).toBeFalse();
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead, statsBig)).toBeFalse();
+    });
+
+    test('returns `false` for a `no-cache` request that would otherwise match', () => {
+      const reqHead = new HttpHeaders();
+      const resHead = new HttpHeaders();
+
+      reqHead.set('cache-control', 'no-cache');
+      reqHead.set('if-none-match', '"xyz"');
+      resHead.set('etag',          '"xyz"');
+
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead)).toBeFalse();
+    });
+
+    test('finds a fresh etag', () => {
+      const reqHead = new HttpHeaders();
+      const resHead = new HttpHeaders();
+
+      reqHead.set('if-none-match', '"xyz"');
+      resHead.set('etag',          '"xyz"');
+
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead)).toBeTrue();
+    });
+
+    test('finds a fresh etag in multiple matches', () => {
+      const reqHead = new HttpHeaders();
+      const resHead = new HttpHeaders();
+
+      reqHead.set('if-none-match', '"abc", "xyz", "pdq"');
+      resHead.set('etag',          '"xyz"');
+
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead)).toBeTrue();
+    });
+
+    test('does not consider a non-matching etag to be fresh', () => {
+      const reqHead = new HttpHeaders();
+      const resHead = new HttpHeaders();
+
+      reqHead.set('if-none-match', '"xyz"');
+      resHead.set('etag',          '"abc"');
+
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead)).toBeFalse();
+    });
+
+    test('finds a fresh last-modified date as a header', () => {
+      const reqHead = new HttpHeaders();
+      const resHead = new HttpHeaders();
+
+      const modTime = statsNum.mtime.toUTCString();
+
+      reqHead.set('if-modified-since', modTime);
+      resHead.set('last-modified',     modTime);
+
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead)).toBeTrue();
+    });
+
+    test('finds a fresh last-modified date via a stats', () => {
+      const reqHead = new HttpHeaders();
+
+      const modTime = statsNum.mtime.toUTCString();
+
+      reqHead.set('if-modified-since', modTime);
+
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, null, statsNum)).toBeTrue();
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, null, statsBig)).toBeTrue();
+    });
+
+    test('understands a later last-modification date (as a header) to make things un-fresh', () => {
+      const reqHead = new HttpHeaders();
+      const resHead = new HttpHeaders();
+
+      const modTime   = statsNum.mtime.toUTCString();
+      const laterTime = new Date(statsNum.mtime);
+      laterTime.setSeconds(laterTime.seconds + 2);
+
+      reqHead.set('if-modified-since', modTime);
+      resHead.set('last-modified',     laterTime.toUTCString());
+
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead)).toBeFalse();
+    });
+
+    test('understands a later last-modification date (via a stats) to make things un-fresh', async () => {
+      const reqHead = new HttpHeaders();
+      const resHead = new HttpHeaders();
+
+      const modTime    = statsNum.mtime.toUTCString();
+      const laterStats = await fs.stat('/');
+      laterStats.mtime.setSeconds(laterStats.mtime.getSeconds() + 1);
+      laterStats.mtimeMs = laterStats.mtime.getTime();
+
+      reqHead.set('if-modified-since', modTime);
+
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead, laterStats)).toBeFalse();
+    });
+
+    test('considers only an etag when `if-none-match` is specified, even if `is-modified-since` is present', () => {
+      const reqHead = new HttpHeaders();
+      const resHead = new HttpHeaders();
+
+      const modTime   = statsNum.mtime.toUTCString();
+      const laterTime = new Date(statsNum.mtime);
+      laterTime.setSeconds(laterTime.seconds + 2);
+
+      reqHead.set('if-modified-since', modTime);
+      resHead.set('last-modified',     laterTime.toUTCString());
+
+      reqHead.set('if-none-match', '"xyz"');
+      resHead.set('etag',          '"xyz"');
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead)).toBeTrue();
+
+      reqHead.set('if-none-match', '"abc"');
+      expect(HttpConditional.isContentFresh(requestMethod, reqHead, resHead)).toBeFalse();
+    });
+  });
 });

--- a/src/net-util/tests/HttpHeaders.test.js
+++ b/src/net-util/tests/HttpHeaders.test.js
@@ -323,6 +323,35 @@ describe('extract()', () => {
   });
 });
 
+describe('deleteContent()', () => {
+  test('deletes all `content-*` headers', () => {
+    const hh = new HttpHeaders({
+      'a': 'aa',
+      'content-type': 'florp',
+      'content-length': 'floop',
+      'content-zorch': 'flongle',
+      'z': 'zz'
+    });
+
+    hh.deleteContent();
+    expect(hh.get('content-type')).toBeNull();
+    expect(hh.get('content-length')).toBeNull();
+    expect(hh.get('content-zorch')).toBeNull();
+  });
+
+  test('does not delete non-`content-*` headers', () => {
+    const hh = new HttpHeaders({
+      'a': 'aa',
+      'content-type': 'florp',
+      'z': 'zz'
+    });
+
+    hh.deleteContent();
+    expect(hh.get('a')).toBe('aa');
+    expect(hh.get('z')).toBe('zz');
+  });
+});
+
 describe.each`
 methodName
 ${'hasAll'}

--- a/src/net-util/tests/HttpHeaders.test.js
+++ b/src/net-util/tests/HttpHeaders.test.js
@@ -495,5 +495,75 @@ describe('setAll()', () => {
 });
 
 describe('static get()', () => {
-  // TODO
+  test('rejects non-string name', () => {
+    expect(() => HttpHeaders.get({}, 123)).toThrow();
+  });
+
+  test('finds a name in a regular `Headers`', () => {
+    const name    = 'beep';
+    const value   = 'boop';
+    const headers = new Headers();
+
+    headers.set(name, value);
+    expect(HttpHeaders.get(headers, name)).toBe(value);
+  });
+
+  test('correctly fails to find a name in a regular `Headers`', () => {
+    const name    = 'beep';
+    const value   = 'boop';
+    const headers = new Headers();
+
+    headers.set(name, value);
+    expect(HttpHeaders.get(headers, `x${name}x`)).toBeNull();
+  });
+
+  test('finds a name in an `HttpHeaders`', () => {
+    const name    = 'beep';
+    const value   = 'boop';
+    const headers = new HttpHeaders();
+
+    headers.set(name, value);
+    expect(HttpHeaders.get(headers, name)).toBe(value);
+  });
+
+  test('correctly fails to find a name an `HttpHeaders`', () => {
+    const name    = 'beep';
+    const value   = 'boop';
+    const headers = new HttpHeaders();
+
+    headers.set(name, value);
+    expect(HttpHeaders.get(headers, `x${name}x`)).toBeNull();
+  });
+
+  test('finds a name in a plain object', () => {
+    const name    = 'beep';
+    const value   = 'boop';
+    const headers = { [name]: value };
+
+    expect(HttpHeaders.get(headers, name)).toBe(value);
+  });
+
+  test('correctly fails to find a name a plain object', () => {
+    const name    = 'beep';
+    const value   = 'boop';
+    const headers = { [name]: value };
+
+    expect(HttpHeaders.get(headers, `x${name}x`)).toBeNull();
+  });
+
+  test('correctly finds a name in a plain object, where the object name is not all lowercase', () => {
+    const name    = 'beep';
+    const value   = 'boop';
+    const headers = { [name.toUpperCase()]: value };
+
+    expect(HttpHeaders.get(headers, name)).toBe(value);
+  });
+
+  test('correctly finds a name in a plain object, where the given name is not all lowercase', () => {
+    const name    = 'beep';
+    const value   = 'boop';
+    const headers = { [name]: value };
+
+    expect(HttpHeaders.get(headers, name.toUpperCase())).toBe(value);
+  });
 });

--- a/src/net-util/tests/HttpHeaders.test.js
+++ b/src/net-util/tests/HttpHeaders.test.js
@@ -493,3 +493,7 @@ describe('setAll()', () => {
     ]);
   });
 });
+
+describe('static get()', () => {
+  // TODO
+});

--- a/tests/01-test-harness/01-call-and-log/expect.md
+++ b/tests/01-test-harness/01-call-and-log/expect.md
@@ -1,0 +1,149 @@
+## no output; success
+
+### exit: 0
+
+- - - - - - - - - -
+
+## no output; error
+
+### exit: 1
+
+- - - - - - - - - -
+
+## stdout without nl; success
+
+### stdout
+```
+hello
+```
+(no newline at end)
+
+### exit: 0
+
+- - - - - - - - - -
+
+## stdout; success
+
+### stdout
+```
+hello
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## stderr without nl; fail
+
+### stderr
+```
+eek
+```
+(no newline at end)
+
+### exit: 127
+
+- - - - - - - - - -
+
+## stderr; fail
+
+### stderr
+```
+eek
+```
+
+### exit: 255
+
+- - - - - - - - - -
+
+## stdout and stderr
+
+### stdout
+```
+hello
+```
+
+### stderr
+```
+eek
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## stdout and stderr, two lines without final nl
+
+### stdout
+```
+hello
+hi
+```
+(no newline at end)
+
+### stderr
+```
+eek
+oy
+```
+(no newline at end)
+
+### exit: 0
+
+- - - - - - - - - -
+
+## stdout and stderr, two lines
+
+### stdout
+```
+hello
+hi
+```
+
+### stderr
+```
+eek
+oy
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## stdout and stderr, two lines and extra nl at end
+
+### stdout
+```
+hello
+hi
+
+```
+
+### stderr
+```
+eek
+oy
+
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## stdout and stderr, two lines and extra nl at start
+
+### stdout
+```
+
+hello
+hi
+```
+
+### stderr
+```
+
+eek
+oy
+```
+
+### exit: 0

--- a/tests/01-test-harness/01-call-and-log/info.md
+++ b/tests/01-test-harness/01-call-and-log/info.md
@@ -1,0 +1,1 @@
+Test for proper operation of call-and-log-as-test.

--- a/tests/01-test-harness/01-call-and-log/run
+++ b/tests/01-test-harness/01-call-and-log/run
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2022-2024 the Bashy-lib Authors (Dan Bornstein et alia).
+# SPDX-License-Identifier: Apache-2.0
+
+[[ "$(readlink -f "$0")" =~ ^(.*/tests/) ]] && . "${BASH_REMATCH[1]}_test-init.sh" || exit 1
+
+cmd="$(this-cmd-dir)/the-cmd"
+
+call-and-log-as-test 'no output; success' \
+    "${cmd}" '' '' 0
+
+call-and-log-as-test 'no output; error' \
+    "${cmd}" '' '' 1
+
+call-and-log-as-test 'stdout without nl; success' \
+    "${cmd}" 'hello' '' 0
+
+call-and-log-as-test 'stdout; success' \
+    "${cmd}" $'hello\n' '' 0
+
+call-and-log-as-test 'stderr without nl; fail' \
+    "${cmd}" '' 'eek' 127
+
+call-and-log-as-test 'stderr; fail' \
+    "${cmd}" '' $'eek\n' 255
+
+call-and-log-as-test 'stdout and stderr' \
+    "${cmd}" $'hello\n' $'eek\n' 0
+
+call-and-log-as-test 'stdout and stderr, two lines without final nl' \
+    "${cmd}" $'hello\nhi' $'eek\noy' 0
+
+call-and-log-as-test 'stdout and stderr, two lines' \
+    "${cmd}" $'hello\nhi\n' $'eek\noy\n' 0
+
+call-and-log-as-test 'stdout and stderr, two lines and extra nl at end' \
+    "${cmd}" $'hello\nhi\n\n' $'eek\noy\n\n' 0
+
+call-and-log-as-test 'stdout and stderr, two lines and extra nl at start' \
+    "${cmd}" $'\nhello\nhi\n' $'\neek\noy\n' 0

--- a/tests/01-test-harness/01-call-and-log/the-cmd
+++ b/tests/01-test-harness/01-call-and-log/the-cmd
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+# SPDX-License-Identifier: Apache-2.0
+
+toStdout="$1"
+toStderr="$2"
+exitCode="$3"
+
+if [[ ${toStdout} != '' ]]; then
+    printf '%s' "${toStdout}"
+fi
+
+if [[ ${toStderr} != '' ]]; then
+    printf 1>&2 '%s' "${toStderr}"
+fi
+
+exit "${exitCode}"

--- a/tests/02-http/01-basic/expect.md
+++ b/tests/02-http/01-basic/expect.md
@@ -1,4 +1,5 @@
 ### Metadata
+
 * No problems.
 
 ### Body

--- a/tests/02-http/01-basic/expect.md
+++ b/tests/02-http/01-basic/expect.md
@@ -1,0 +1,10 @@
+### Metadata
+* No problems.
+
+### Body
+
+```
+308 Permanent Redirect:
+
+https://localhost:8443/resp/
+```

--- a/tests/02-http/01-basic/info.md
+++ b/tests/02-http/01-basic/info.md
@@ -1,0 +1,1 @@
+Test of HTTP request basics.

--- a/tests/02-http/01-basic/run.mjs
+++ b/tests/02-http/01-basic/run.mjs
@@ -1,0 +1,79 @@
+// Copyright 2022-2024 the Bashy-lib Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { checkResponse } from '@this/integration-testing';
+
+async function xcheckResponse(responsePromise, config) {
+  const response = await responsePromise;
+
+  console.log('### Metadata');
+
+  let anyErrors = false;
+
+  if (response.status !== config.status) {
+    console.log('* Status: got %s, expected %s', response.status, config.status);
+    anyErrors = true;
+  }
+
+  if (response.statusText !== config.statusText) {
+    console.log('* Status text: got %s, expected %s', response.statusText, config.statusText);
+    anyErrors = true;
+  }
+
+  const gotHeaders = new Map(response.headers.entries());
+  for (const [name, value] of Object.entries(config.headers)) {
+    const got = gotHeaders.get(name);
+    gotHeaders.delete(name);
+
+    if (got === null) {
+      console.log('* Header %s: missing', name);
+      anyErrors = true;
+    } else if (typeof value === 'string') {
+      if (got !== value) {
+        console.log('* Header %s: got %o, expected `%o`', name, got, value);
+        anyErrors = true;
+      }
+    } else {
+      if (!new RegExp(value).test(got)) {
+        console.log('* Header %s: got `%o`, expected match of `/%o/`', name, got, value);
+        anyErrors = true;
+      }
+    }
+  }
+
+  for (const [name, value] of Object.entries(gotHeaders)) {
+    console.log('* Header %s: unexpected, value `%o`', name, value);
+    anyErrors = true;
+  }
+
+  if (!anyErrors) {
+    console.log('* No problems.');
+  }
+
+  console.log('');
+  console.log('### Body');
+  console.log('');
+
+  if (!response.body) {
+    console.log('(no body)');
+  } else {
+    console.log('```\n%s```', await response.text());
+  }
+}
+
+const response = await fetch('http://localhost:8080/', { redirect: 'manual' });
+
+await checkResponse(response, {
+  status: 308,
+  statusText: 'Permanent Redirect',
+  headers: {
+    'cache-control':  'public, max-age=0',
+    'connection':     'keep-alive',
+    'content-length': '54',
+    'content-type':   'text/plain; charset=utf-8',
+    'date':           /^[,: a-zA-Z0-9]+ GMT$/,
+    'keep-alive':     'timeout=5',
+    'location':       'https://localhost:8443/resp/',
+    'server':         /^lactoserv-[.0-9]+ [0-9a-f]+$/
+  }
+});

--- a/tests/02-http/01-basic/run.mjs
+++ b/tests/02-http/01-basic/run.mjs
@@ -3,64 +3,6 @@
 
 import { checkResponse } from '@this/integration-testing';
 
-async function xcheckResponse(responsePromise, config) {
-  const response = await responsePromise;
-
-  console.log('### Metadata');
-
-  let anyErrors = false;
-
-  if (response.status !== config.status) {
-    console.log('* Status: got %s, expected %s', response.status, config.status);
-    anyErrors = true;
-  }
-
-  if (response.statusText !== config.statusText) {
-    console.log('* Status text: got %s, expected %s', response.statusText, config.statusText);
-    anyErrors = true;
-  }
-
-  const gotHeaders = new Map(response.headers.entries());
-  for (const [name, value] of Object.entries(config.headers)) {
-    const got = gotHeaders.get(name);
-    gotHeaders.delete(name);
-
-    if (got === null) {
-      console.log('* Header %s: missing', name);
-      anyErrors = true;
-    } else if (typeof value === 'string') {
-      if (got !== value) {
-        console.log('* Header %s: got %o, expected `%o`', name, got, value);
-        anyErrors = true;
-      }
-    } else {
-      if (!new RegExp(value).test(got)) {
-        console.log('* Header %s: got `%o`, expected match of `/%o/`', name, got, value);
-        anyErrors = true;
-      }
-    }
-  }
-
-  for (const [name, value] of Object.entries(gotHeaders)) {
-    console.log('* Header %s: unexpected, value `%o`', name, value);
-    anyErrors = true;
-  }
-
-  if (!anyErrors) {
-    console.log('* No problems.');
-  }
-
-  console.log('');
-  console.log('### Body');
-  console.log('');
-
-  if (!response.body) {
-    console.log('(no body)');
-  } else {
-    console.log('```\n%s```', await response.text());
-  }
-}
-
 const response = await fetch('http://localhost:8080/', { redirect: 'manual' });
 
 await checkResponse(response, {

--- a/tests/03-http2/01-basic/expect.md
+++ b/tests/03-http2/01-basic/expect.md
@@ -1,4 +1,5 @@
 ### Metadata
+
 * No problems.
 
 ### Body

--- a/tests/03-http2/01-basic/expect.md
+++ b/tests/03-http2/01-basic/expect.md
@@ -1,0 +1,40 @@
+### Metadata
+* No problems.
+
+### Body
+
+```
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hello!</title>
+</head>
+<body>
+    <h1>Hello!</h1>
+</body>
+
+<ul>
+  <li><a href="avec-index">avec-index/</a></li>
+  <li>florp/
+    <ul>
+      <li><a href="florp/boop.html">boop.html</a></li>
+    </ul>
+  </li>
+  <li>resp/
+    <ul>
+      <li><a href="resp/empty-body">empty-body</a></li>
+      <li><a href="resp/no-body">no-body</a></li>
+      <li><a href="resp/one">one</a></li>
+      <li><a href="resp/two">two</a></li>
+    </ul>
+  </li>
+  <li>subdir/
+    <ul>
+      <li><a href="subdir/one.txt">one.txt</a></li>
+      <li><a href="subdir/two.txt">two.txt</a></li>
+    </ul>
+  </li>
+</ul>
+
+</html>
+```

--- a/tests/03-http2/01-basic/info.md
+++ b/tests/03-http2/01-basic/info.md
@@ -1,1 +1,1 @@
-Test of HTTP request basics.
+Test of HTTP2 request basics.

--- a/tests/03-http2/01-basic/info.md
+++ b/tests/03-http2/01-basic/info.md
@@ -1,0 +1,1 @@
+Test of HTTP request basics.

--- a/tests/03-http2/01-basic/run.mjs
+++ b/tests/03-http2/01-basic/run.mjs
@@ -16,6 +16,7 @@ await checkResponse(response, {
     'content-type':   'text/html; charset=utf-8',
     'date':           /^[,: a-zA-Z0-9]+ GMT$/,
     'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'last-modified':  /^[,: a-zA-Z0-9]+ GMT$/,
     'server':         /^lactoserv-[.0-9]+ [0-9a-f]+$/
   }
 });

--- a/tests/03-http2/01-basic/run.mjs
+++ b/tests/03-http2/01-basic/run.mjs
@@ -9,11 +9,13 @@ await checkResponse(response, {
   status: 200,
   statusText: 'OK',
   headers: {
+    'accept-ranges':  'bytes',
     'cache-control':  'public, max-age=300',
     'connection':     'keep-alive',
     'content-length': '637',
     'content-type':   'text/html; charset=utf-8',
     'date':           /^[,: a-zA-Z0-9]+ GMT$/,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
     'server':         /^lactoserv-[.0-9]+ [0-9a-f]+$/
   }
 });

--- a/tests/03-http2/01-basic/run.mjs
+++ b/tests/03-http2/01-basic/run.mjs
@@ -1,0 +1,19 @@
+// Copyright 2022-2024 the Bashy-lib Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { checkResponse } from '@this/integration-testing';
+
+const response = await fetch('https://localhost:8443/');
+
+await checkResponse(response, {
+  status: 200,
+  statusText: 'OK',
+  headers: {
+    'cache-control':  'public, max-age=300',
+    'connection':     'keep-alive',
+    'content-length': '637',
+    'content-type':   'text/html; charset=utf-8',
+    'date':           /^[,: a-zA-Z0-9]+ GMT$/,
+    'server':         /^lactoserv-[.0-9]+ [0-9a-f]+$/
+  }
+});

--- a/tests/03-http2/02-if-none-match/expect.md
+++ b/tests/03-http2/02-if-none-match/expect.md
@@ -1,0 +1,29 @@
+## Match 1
+
+### Metadata
+
+* No problems.
+
+### Body
+
+(no body)
+
+## Match 2
+
+### Metadata
+
+* No problems.
+
+### Body
+
+(no body)
+
+## Miss
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.

--- a/tests/03-http2/02-if-none-match/expect.md
+++ b/tests/03-http2/02-if-none-match/expect.md
@@ -18,7 +18,17 @@
 
 (no body)
 
-## Miss
+## Miss 1
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.
+
+## Miss 2
 
 ### Metadata
 

--- a/tests/03-http2/02-if-none-match/info.md
+++ b/tests/03-http2/02-if-none-match/info.md
@@ -1,0 +1,1 @@
+Test of `If-None-Match` headers.

--- a/tests/03-http2/02-if-none-match/run.mjs
+++ b/tests/03-http2/02-if-none-match/run.mjs
@@ -1,0 +1,94 @@
+// Copyright 2022-2024 the Bashy-lib Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { checkResponse } from '@this/integration-testing';
+
+const theUrl = 'https://localhost:8443/';
+
+// First, get the response without a conditional check, and note the etag.
+
+const response1 = await fetch(theUrl);
+const etag      = response1.headers.get('etag');
+
+// Try to get a match.
+
+const response2 = await fetch(theUrl,
+  {
+    // Note: Node's `fetch()` puts in a conditional-busting `cache-control:
+    // no-cache` header unless we put our own in.
+    headers: {
+      'cache-control': 'max-age=0',
+      'if-none-match': etag
+    }
+  });
+
+console.log('## Match 1\n');
+
+await checkResponse(response2, {
+  status: 304,
+  statusText: 'Not Modified',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'server':         /./
+  }
+});
+
+console.log('\n## Match 2\n');
+
+// Try to get a match with one of N etags.
+
+const response3 = await fetch(theUrl,
+  {
+    // Note: Node's `fetch()` puts in a conditional-busting `cache-control:
+    // no-cache` header unless we put our own in.
+    headers: {
+      'cache-control': 'max-age=0',
+      'if-none-match': `"XYZ", ${etag}, "PDQ"`
+    }
+  });
+
+await checkResponse(response3, {
+  status: 304,
+  statusText: 'Not Modified',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'server':         /./
+  }
+});
+
+console.log('\n## Miss\n');
+
+// Try to get a miss, even though there is an etag (but it doesn't match).
+
+const response4 = await fetch(theUrl,
+  {
+    headers: {
+      'cache-control': 'max-age=0',
+      'if-none-match': `"XYZ-${etag.slice(1, etag.length - 1)}"`
+    }
+  });
+
+await checkResponse(response4, {
+  status: 200,
+  statusText: 'OK',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'content-length': response1.headers.get('content-length'),
+    'content-type':   response1.headers.get('content-type'),
+    'date':           /./,
+    'last-modified':  response1.headers.get('last-modified'),
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'server':         /./
+  },
+  body: await response1.text()
+});

--- a/tests/03-http2/02-if-none-match/run.mjs
+++ b/tests/03-http2/02-if-none-match/run.mjs
@@ -64,9 +64,9 @@ await checkResponse(response3, {
   }
 });
 
-console.log('\n## Miss\n');
-
 // Try to get a miss, even though there is an etag header (it doesn't match).
+
+console.log('\n## Miss 1\n');
 
 const response4 = await fetch(theUrl,
   {

--- a/tests/03-http2/02-if-none-match/run.mjs
+++ b/tests/03-http2/02-if-none-match/run.mjs
@@ -12,6 +12,8 @@ const etag      = response1.headers.get('etag');
 
 // Try to get a match.
 
+console.log('## Match 1\n');
+
 const response2 = await fetch(theUrl,
   {
     // Note: Node's `fetch()` puts in a conditional-busting `cache-control:
@@ -21,8 +23,6 @@ const response2 = await fetch(theUrl,
       'if-none-match': etag
     }
   });
-
-console.log('## Match 1\n');
 
 await checkResponse(response2, {
   status: 304,
@@ -37,9 +37,9 @@ await checkResponse(response2, {
   }
 });
 
-console.log('\n## Match 2\n');
-
 // Try to get a match with one of N etags.
+
+console.log('\n## Match 2\n');
 
 const response3 = await fetch(theUrl,
   {

--- a/tests/03-http2/02-if-none-match/run.mjs
+++ b/tests/03-http2/02-if-none-match/run.mjs
@@ -5,10 +5,12 @@ import { checkResponse } from '@this/integration-testing';
 
 const theUrl = 'https://localhost:8443/';
 
-// First, get the response without a conditional check, and note the etag.
+// First, get the response without a conditional check, and note the etag and
+// body.
 
 const response1 = await fetch(theUrl);
 const etag      = response1.headers.get('etag');
+const bodyText  = await response1.text();
 
 // Try to get a match.
 
@@ -90,5 +92,35 @@ await checkResponse(response4, {
     'etag':           /^"[-0-9a-zA-Z]+"$/,
     'server':         /./
   },
-  body: await response1.text()
+  body: bodyText
+});
+
+// Try to get a miss, by virtue of specifying `no-cache`, even though there is
+// a matching etag.
+
+console.log('\n## Miss 2\n');
+
+const response5 = await fetch(theUrl,
+  {
+    headers: {
+      'cache-control': 'no-cache',
+      'if-none-match': etag
+    }
+  });
+
+await checkResponse(response5, {
+  status: 200,
+  statusText: 'OK',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'content-length': response1.headers.get('content-length'),
+    'content-type':   response1.headers.get('content-type'),
+    'date':           /./,
+    'last-modified':  response1.headers.get('last-modified'),
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'server':         /./
+  },
+  body: bodyText
 });

--- a/tests/03-http2/02-if-none-match/run.mjs
+++ b/tests/03-http2/02-if-none-match/run.mjs
@@ -66,7 +66,7 @@ await checkResponse(response3, {
 
 console.log('\n## Miss\n');
 
-// Try to get a miss, even though there is an etag (but it doesn't match).
+// Try to get a miss, even though there is an etag header (it doesn't match).
 
 const response4 = await fetch(theUrl,
   {

--- a/tests/03-http2/03-if-modified-since/expect.md
+++ b/tests/03-http2/03-if-modified-since/expect.md
@@ -1,0 +1,29 @@
+## Match 1
+
+### Metadata
+
+* No problems.
+
+### Body
+
+(no body)
+
+## Match 2
+
+### Metadata
+
+* No problems.
+
+### Body
+
+(no body)
+
+## Miss
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.

--- a/tests/03-http2/03-if-modified-since/expect.md
+++ b/tests/03-http2/03-if-modified-since/expect.md
@@ -18,7 +18,17 @@
 
 (no body)
 
-## Miss
+## Miss 1
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.
+
+## Miss 2
 
 ### Metadata
 

--- a/tests/03-http2/03-if-modified-since/info.md
+++ b/tests/03-http2/03-if-modified-since/info.md
@@ -1,0 +1,1 @@
+Test of `If-Modified-Since` headers.

--- a/tests/03-http2/03-if-modified-since/run.mjs
+++ b/tests/03-http2/03-if-modified-since/run.mjs
@@ -74,13 +74,13 @@ console.log('\n## Miss\n');
 // Try to get a miss.
 
 const earlierDate = new Date(lastMod);
-laterDate.setSeconds(-1);
+earlierDate.setSeconds(-1);
 
 const response4 = await fetch(theUrl,
   {
     headers: {
       'cache-control': 'max-age=0',
-      'if-modified-since': laterDate.toUTCString()
+      'if-modified-since': earlierDate.toUTCString()
     }
   });
 

--- a/tests/03-http2/03-if-modified-since/run.mjs
+++ b/tests/03-http2/03-if-modified-since/run.mjs
@@ -1,0 +1,102 @@
+// Copyright 2022-2024 the Bashy-lib Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { checkResponse } from '@this/integration-testing';
+
+const theUrl = 'https://localhost:8443/';
+
+// First, get the response without a conditional check, and note the
+// last-modfied date.
+
+const response1 = await fetch(theUrl);
+const lastMod   = new Date(Date.parse(response1.headers.get('last-modified')));
+
+
+// Try to get a match.
+
+console.log('## Match 1\n');
+
+const response2 = await fetch(theUrl,
+  {
+    // Note: Node's `fetch()` puts in a conditional-busting `cache-control:
+    // no-cache` header unless we put our own in.
+    headers: {
+      'cache-control': 'max-age=0',
+      'if-modified-since': lastMod.toUTCString()
+    }
+  });
+
+await checkResponse(response2, {
+  status: 304,
+  statusText: 'Not Modified',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'server':         /./
+  }
+});
+
+// Try to get a match with a later date.
+
+console.log('\n## Match 2\n');
+
+const laterDate = new Date(lastMod);
+laterDate.setSeconds(laterDate.getSeconds() + 1);
+
+const response3 = await fetch(theUrl,
+  {
+    // Note: Node's `fetch()` puts in a conditional-busting `cache-control:
+    // no-cache` header unless we put our own in.
+    headers: {
+      'cache-control': 'max-age=0',
+      'if-modified-since': laterDate.toUTCString()
+    }
+  });
+
+await checkResponse(response3, {
+  status: 304,
+  statusText: 'Not Modified',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'server':         /./
+  }
+});
+
+console.log('\n## Miss\n');
+
+// Try to get a miss.
+
+const earlierDate = new Date(lastMod);
+laterDate.setSeconds(-1);
+
+const response4 = await fetch(theUrl,
+  {
+    headers: {
+      'cache-control': 'max-age=0',
+      'if-modified-since': laterDate.toUTCString()
+    }
+  });
+
+await checkResponse(response4, {
+  status: 200,
+  statusText: 'OK',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'content-length': response1.headers.get('content-length'),
+    'content-type':   response1.headers.get('content-type'),
+    'date':           /./,
+    'last-modified':  response1.headers.get('last-modified'),
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'server':         /./
+  },
+  body: await response1.text()
+});

--- a/tests/03-http2/03-if-modified-since/run.mjs
+++ b/tests/03-http2/03-if-modified-since/run.mjs
@@ -69,9 +69,9 @@ await checkResponse(response3, {
   }
 });
 
-console.log('\n## Miss\n');
-
 // Try to get a miss.
+
+console.log('\n## Miss\n');
 
 const earlierDate = new Date(lastMod);
 earlierDate.setSeconds(-1);

--- a/tests/03-http2/04-combo-conditional/expect.md
+++ b/tests/03-http2/04-combo-conditional/expect.md
@@ -2,52 +2,8 @@
 
 ### Metadata
 
-* Status: got 200, expected 304
-* Status text: got OK, expected Not Modified
-* Header content-length
-  * got '637'
-  * unexpected
-* Header content-type
-  * got 'text/html; charset=utf-8'
-  * unexpected
-* Header last-modified
-  * got 'Mon, 12 Feb 2024 22:35:02 GMT'
-  * unexpected
+* No problems.
 
 ### Body
 
-```
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Hello!</title>
-</head>
-<body>
-    <h1>Hello!</h1>
-</body>
-
-<ul>
-  <li><a href="avec-index">avec-index/</a></li>
-  <li>florp/
-    <ul>
-      <li><a href="florp/boop.html">boop.html</a></li>
-    </ul>
-  </li>
-  <li>resp/
-    <ul>
-      <li><a href="resp/empty-body">empty-body</a></li>
-      <li><a href="resp/no-body">no-body</a></li>
-      <li><a href="resp/one">one</a></li>
-      <li><a href="resp/two">two</a></li>
-    </ul>
-  </li>
-  <li>subdir/
-    <ul>
-      <li><a href="subdir/one.txt">one.txt</a></li>
-      <li><a href="subdir/two.txt">two.txt</a></li>
-    </ul>
-  </li>
-</ul>
-
-</html>
-```
+(no body)

--- a/tests/03-http2/04-combo-conditional/expect.md
+++ b/tests/03-http2/04-combo-conditional/expect.md
@@ -1,0 +1,53 @@
+## Match
+
+### Metadata
+
+* Status: got 200, expected 304
+* Status text: got OK, expected Not Modified
+* Header content-length
+  * got '637'
+  * unexpected
+* Header content-type
+  * got 'text/html; charset=utf-8'
+  * unexpected
+* Header last-modified
+  * got 'Mon, 12 Feb 2024 22:35:02 GMT'
+  * unexpected
+
+### Body
+
+```
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hello!</title>
+</head>
+<body>
+    <h1>Hello!</h1>
+</body>
+
+<ul>
+  <li><a href="avec-index">avec-index/</a></li>
+  <li>florp/
+    <ul>
+      <li><a href="florp/boop.html">boop.html</a></li>
+    </ul>
+  </li>
+  <li>resp/
+    <ul>
+      <li><a href="resp/empty-body">empty-body</a></li>
+      <li><a href="resp/no-body">no-body</a></li>
+      <li><a href="resp/one">one</a></li>
+      <li><a href="resp/two">two</a></li>
+    </ul>
+  </li>
+  <li>subdir/
+    <ul>
+      <li><a href="subdir/one.txt">one.txt</a></li>
+      <li><a href="subdir/two.txt">two.txt</a></li>
+    </ul>
+  </li>
+</ul>
+
+</html>
+```

--- a/tests/03-http2/04-combo-conditional/info.md
+++ b/tests/03-http2/04-combo-conditional/info.md
@@ -1,0 +1,2 @@
+Test of interaction of `If-Modified-Since` headers and `If-None-Match`
+headers.

--- a/tests/03-http2/04-combo-conditional/run.mjs
+++ b/tests/03-http2/04-combo-conditional/run.mjs
@@ -1,0 +1,47 @@
+// Copyright 2022-2024 the Bashy-lib Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { checkResponse } from '@this/integration-testing';
+
+const theUrl = 'https://localhost:8443/';
+
+// First, get the response without a conditional check, and note the salient
+// headers.
+
+const response1 = await fetch(theUrl);
+const lastMod   = new Date(Date.parse(response1.headers.get('last-modified')));
+const etag      = response1.headers.get('etag');
+
+
+// Try to get a match: The etag will match, but the last-modified date will
+// _not_. The HTTP spec says that in this case the etag match should be the only
+// thing that matters.
+
+console.log('## Match\n');
+
+const earlierDate = new Date(lastMod);
+earlierDate.setSeconds(-1);
+
+const response2 = await fetch(theUrl,
+  {
+    // Note: Node's `fetch()` puts in a conditional-busting `cache-control:
+    // no-cache` header unless we put our own in.
+    headers: {
+      'cache-control': 'max-age=0',
+      'if-modified-since': earlierDate.toUTCString(),
+      'if-none-match': etag
+    }
+  });
+
+await checkResponse(response2, {
+  status: 304,
+  statusText: 'Not Modified',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'server':         /./
+  }
+});

--- a/tests/04-https/01-basic/expect.md
+++ b/tests/04-https/01-basic/expect.md
@@ -1,4 +1,5 @@
 ### Metadata
+
 * No problems.
 
 ### Body

--- a/tests/04-https/01-basic/expect.md
+++ b/tests/04-https/01-basic/expect.md
@@ -1,0 +1,40 @@
+### Metadata
+* No problems.
+
+### Body
+
+```
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hello!</title>
+</head>
+<body>
+    <h1>Hello!</h1>
+</body>
+
+<ul>
+  <li><a href="avec-index">avec-index/</a></li>
+  <li>florp/
+    <ul>
+      <li><a href="florp/boop.html">boop.html</a></li>
+    </ul>
+  </li>
+  <li>resp/
+    <ul>
+      <li><a href="resp/empty-body">empty-body</a></li>
+      <li><a href="resp/no-body">no-body</a></li>
+      <li><a href="resp/one">one</a></li>
+      <li><a href="resp/two">two</a></li>
+    </ul>
+  </li>
+  <li>subdir/
+    <ul>
+      <li><a href="subdir/one.txt">one.txt</a></li>
+      <li><a href="subdir/two.txt">two.txt</a></li>
+    </ul>
+  </li>
+</ul>
+
+</html>
+```

--- a/tests/04-https/01-basic/info.md
+++ b/tests/04-https/01-basic/info.md
@@ -1,0 +1,1 @@
+Test of HTTPS (HTTP 1.1 over TLS) request basics.

--- a/tests/04-https/01-basic/run.mjs
+++ b/tests/04-https/01-basic/run.mjs
@@ -3,17 +3,19 @@
 
 import { checkResponse } from '@this/integration-testing';
 
-const response = await fetch('https://localhost:8444/');
+const response = await fetch('https://localhost:8443/');
 
 await checkResponse(response, {
   status: 200,
   statusText: 'OK',
   headers: {
+    'accept-ranges':  'bytes',
     'cache-control':  'public, max-age=300',
     'connection':     'keep-alive',
     'content-length': '637',
     'content-type':   'text/html; charset=utf-8',
     'date':           /^[,: a-zA-Z0-9]+ GMT$/,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
     'server':         /^lactoserv-[.0-9]+ [0-9a-f]+$/
   }
 });

--- a/tests/04-https/01-basic/run.mjs
+++ b/tests/04-https/01-basic/run.mjs
@@ -16,6 +16,7 @@ await checkResponse(response, {
     'content-type':   'text/html; charset=utf-8',
     'date':           /^[,: a-zA-Z0-9]+ GMT$/,
     'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'last-modified':  /^[,: a-zA-Z0-9]+ GMT$/,
     'server':         /^lactoserv-[.0-9]+ [0-9a-f]+$/
   }
 });

--- a/tests/04-https/01-basic/run.mjs
+++ b/tests/04-https/01-basic/run.mjs
@@ -1,0 +1,19 @@
+// Copyright 2022-2024 the Bashy-lib Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { checkResponse } from '@this/integration-testing';
+
+const response = await fetch('https://localhost:8444/');
+
+await checkResponse(response, {
+  status: 200,
+  statusText: 'OK',
+  headers: {
+    'cache-control':  'public, max-age=300',
+    'connection':     'keep-alive',
+    'content-length': '637',
+    'content-type':   'text/html; charset=utf-8',
+    'date':           /^[,: a-zA-Z0-9]+ GMT$/,
+    'server':         /^lactoserv-[.0-9]+ [0-9a-f]+$/
+  }
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,11 @@ Integration Tests
 =================
 
 This directory is for integration tests. As of this writing, things here are a
-bit ad-hoc.
+bit ad-hoc and not 100% automated.
+
+To run these tests, first build and run the system, and _then_ run the script
+`run-all` in this directory. You can also run it as `ubik run-tests
+--type=integration`.
 
 - - - - - - - - - -
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+Integration Tests
+=================
+
+This directory is for integration tests. As of this writing, things here are a
+bit ad-hoc.
+
+- - - - - - - - - -
+```
+Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+SPDX-License-Identifier: Apache-2.0
+```

--- a/tests/_init.sh
+++ b/tests/_init.sh
@@ -1,0 +1,1 @@
+. "${BASH_SOURCE[0]%/*}/../scripts/_init.sh" || return "$?"

--- a/tests/_test-init.sh
+++ b/tests/_test-init.sh
@@ -1,0 +1,140 @@
+# Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+# SPDX-License-Identifier: Apache-2.0
+
+. "${BASH_SOURCE[0]%/*}/_init.sh" || return "$?"
+
+
+#
+# Global variables
+#
+
+# Have there been any calls to log test results?
+_test_anyLoggedResults=0
+
+
+#
+# Library functions
+#
+
+# Calls a function, wrapping its output in a standard form, writing it all
+# (including stderr) to stdout.
+function call-and-log-as-test {
+    local label="$1"
+    shift
+    local cmd=("$@")
+
+    if (( !_test_anyLoggedResults )); then
+        _test_anyLoggedResults=1
+    else
+        echo ''
+        echo '- - - - - - - - - -'
+        echo ''
+    fi
+
+    echo "## ${label}"
+    echo ''
+
+    # What's going on here: We capture both stdout and stderr of the call to
+    # log, and then emit them to stdout in a specific order and with
+    # standardized markings.
+
+    local output
+    output="$(
+        (
+            # Print the PID of the subshell we are currently in.
+            sh 1>&2 -c 'echo "${PPID}"'
+
+            "${cmd[@]}" > >(_test_do-stream-marking stdout)
+        ) 2> >(_test_do-stream-marking --wait stderr)
+    )"
+    local exitCode="$?"
+
+    awk <<<"${output}" '
+    BEGIN {
+        finishSection();
+    }
+
+    /^[a-z]+:$/ {
+        finishSection();
+        label = substr($0, 1, length($0) - 1);
+    }
+
+    /^[a-z]+- / {
+        finalNl = 0;
+    }
+
+    /^[a-z]+-? / {
+        if (!any) {
+            any = 1;
+            print "###", label;
+            print "```";
+        }
+        sub(/^[^ ]+ /, "");
+        print;
+    }
+
+    END {
+        finishSection();
+    }
+
+    function finishSection() {
+        if (any) {
+            print "```";
+            if (!finalNl) {
+                print "(no newline at end)";
+            }
+            print "";
+        }
+
+        any = 0;
+        finalNl = 1;
+        label = "";
+    }
+    '
+
+    echo "### exit: ${exitCode}"
+}
+
+
+#
+# Internal functions
+#
+
+# Helper for `call-and-log-as-test`, which re-emits its input with each line
+# prefixed, optionally waiting for a particular PID to exit first.
+function _test_do-stream-marking {
+    local pid=''
+    if [[ $1 == '--wait' ]]; then
+        shift
+        IFS='' read -r pid
+    fi
+
+    local mark="$1"
+
+    if [[ ${pid} != '' ]]; then
+        while kill 2>/dev/null -0 "${pid}"; do
+            sleep 0.1
+        done
+    fi
+
+    local any=0
+
+    local str
+    while IFS='' read -r str; do
+        if (( !any )); then
+            any=1
+            printf '%s:\n' "${mark}"
+        fi
+        printf '%s %s\n' "${mark}" "${str}"
+    done
+
+    # If we hit EOF on the read, that is, if the final line of output read
+    # didn't end with a newline, then `str` will be non-empty.
+    if [[ ${str} != '' ]]; then
+        if (( !any )); then
+            any=1
+            printf '%s:\n' "${mark}"
+        fi
+        printf '%s- %s\n' "${mark}" "${str}"
+    fi
+}

--- a/tests/node_modules/@this/integration-testing/index.js
+++ b/tests/node_modules/@this/integration-testing/index.js
@@ -62,9 +62,9 @@ export async function checkResponse(responsePromise, config) {
   const gotBody = response.body ? await response.text() : null;
   const bodyCheck = config.body ?? null;
 
-  const printBody = async () => {
+  const printBody = () => {
     if (gotBody) {
-      console.log('```\n%s```', await response.text());
+      console.log('```\n%s```', gotBody);
     } else {
       console.log('(no body)');
     }
@@ -78,14 +78,14 @@ export async function checkResponse(responsePromise, config) {
     } else if (typeof bodyCheck === 'string') {
       if (gotBody !== bodyCheck) {
         console.log('Non-matching body.\n');
-        await printBody();
+        printBody();
       } else {
         console.log('Body is as expected.');
       }
     } else {
       if (!new RegExp(bodyCheck).test(gotBody)) {
         console.log('Non-matching body.\n');
-        await printBody();
+        printBody();
       } else {
         console.log('Body is as expected.');
       }

--- a/tests/node_modules/@this/integration-testing/index.js
+++ b/tests/node_modules/@this/integration-testing/index.js
@@ -28,19 +28,25 @@ export async function checkResponse(responsePromise, config) {
       anyErrors = true;
     } else if (typeof value === 'string') {
       if (got !== value) {
-        console.log('* Header %s: got %o, expected `%o`', name, got, value);
+        console.log('* Header %s', name);
+        console.log('  * got %o', got);
+        console.log('  * expected %o', value);
         anyErrors = true;
       }
     } else {
       if (!new RegExp(value).test(got)) {
-        console.log('* Header %s: got `%o`, expected match of `%s`', name, got, value.toString());
+        console.log('* Header %s', name);
+        console.log('  * got %o', got);
+        console.log('  * expected match %s', value.toString());
         anyErrors = true;
       }
     }
   }
 
-  for (const [name, value] of gotHeaders) {
-    console.log('* Header %s: unexpected, value `%o`', name, value);
+  for (const [name, value] of gotHeaders.entries()) {
+    console.log('* Header %s', name);
+    console.log('  * got %o', value);
+    console.log('  * unexpected');
     anyErrors = true;
   }
 

--- a/tests/node_modules/@this/integration-testing/index.js
+++ b/tests/node_modules/@this/integration-testing/index.js
@@ -23,7 +23,7 @@ export async function checkResponse(responsePromise, config) {
     const got = gotHeaders.get(name);
     gotHeaders.delete(name);
 
-    if (got === null) {
+    if (got === undefined) {
       console.log('* Header %s: missing', name);
       anyErrors = true;
     } else if (typeof value === 'string') {

--- a/tests/node_modules/@this/integration-testing/index.js
+++ b/tests/node_modules/@this/integration-testing/index.js
@@ -5,6 +5,7 @@ export async function checkResponse(responsePromise, config) {
   const response = await responsePromise;
 
   console.log('### Metadata');
+  console.log('');
 
   let anyErrors = false;
 
@@ -58,9 +59,36 @@ export async function checkResponse(responsePromise, config) {
   console.log('### Body');
   console.log('');
 
-  if (!response.body) {
-    console.log('(no body)');
+  const gotBody = response.body ? await response.text() : null;
+  const bodyCheck = config.body ?? null;
+
+  const printBody = async () => {
+    if (gotBody) {
+      console.log('```\n%s```', await response.text());
+    } else {
+      console.log('(no body)');
+    }
+  };
+
+  if (bodyCheck === null) {
+    printBody();
   } else {
-    console.log('```\n%s```', await response.text());
+    if (!gotBody) {
+      console.log('Missing body.');
+    } else if (typeof bodyCheck === 'string') {
+      if (gotBody !== bodyCheck) {
+        console.log('Non-matching body.\n');
+        await printBody();
+      } else {
+        console.log('Body is as expected.');
+      }
+    } else {
+      if (!new RegExp(bodyCheck).test(gotBody)) {
+        console.log('Non-matching body.\n');
+        await printBody();
+      } else {
+        console.log('Body is as expected.');
+      }
+    }
   }
 }

--- a/tests/node_modules/@this/integration-testing/index.js
+++ b/tests/node_modules/@this/integration-testing/index.js
@@ -33,7 +33,7 @@ export async function checkResponse(responsePromise, config) {
       }
     } else {
       if (!new RegExp(value).test(got)) {
-        console.log('* Header %s: got `%o`, expected match of `/%o/`', name, got, value);
+        console.log('* Header %s: got `%o`, expected match of `%s`', name, got, value.toString());
         anyErrors = true;
       }
     }

--- a/tests/node_modules/@this/integration-testing/index.js
+++ b/tests/node_modules/@this/integration-testing/index.js
@@ -38,7 +38,7 @@ export async function checkResponse(responsePromise, config) {
       if (!new RegExp(value).test(got)) {
         console.log('* Header %s', name);
         console.log('  * got %o', got);
-        console.log('  * expected match %s', value.toString());
+        console.log('  * expected match /%s/', value);
         anyErrors = true;
       }
     }

--- a/tests/node_modules/@this/integration-testing/index.js
+++ b/tests/node_modules/@this/integration-testing/index.js
@@ -39,7 +39,7 @@ export async function checkResponse(responsePromise, config) {
     }
   }
 
-  for (const [name, value] of Object.entries(gotHeaders)) {
+  for (const [name, value] of gotHeaders) {
     console.log('* Header %s: unexpected, value `%o`', name, value);
     anyErrors = true;
   }

--- a/tests/node_modules/@this/integration-testing/index.js
+++ b/tests/node_modules/@this/integration-testing/index.js
@@ -1,0 +1,60 @@
+// Copyright 2022-2024 the Bashy-lib Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+export async function checkResponse(responsePromise, config) {
+  const response = await responsePromise;
+
+  console.log('### Metadata');
+
+  let anyErrors = false;
+
+  if (response.status !== config.status) {
+    console.log('* Status: got %s, expected %s', response.status, config.status);
+    anyErrors = true;
+  }
+
+  if (response.statusText !== config.statusText) {
+    console.log('* Status text: got %s, expected %s', response.statusText, config.statusText);
+    anyErrors = true;
+  }
+
+  const gotHeaders = new Map(response.headers.entries());
+  for (const [name, value] of Object.entries(config.headers)) {
+    const got = gotHeaders.get(name);
+    gotHeaders.delete(name);
+
+    if (got === null) {
+      console.log('* Header %s: missing', name);
+      anyErrors = true;
+    } else if (typeof value === 'string') {
+      if (got !== value) {
+        console.log('* Header %s: got %o, expected `%o`', name, got, value);
+        anyErrors = true;
+      }
+    } else {
+      if (!new RegExp(value).test(got)) {
+        console.log('* Header %s: got `%o`, expected match of `/%o/`', name, got, value);
+        anyErrors = true;
+      }
+    }
+  }
+
+  for (const [name, value] of Object.entries(gotHeaders)) {
+    console.log('* Header %s: unexpected, value `%o`', name, value);
+    anyErrors = true;
+  }
+
+  if (!anyErrors) {
+    console.log('* No problems.');
+  }
+
+  console.log('');
+  console.log('### Body');
+  console.log('');
+
+  if (!response.body) {
+    console.log('(no body)');
+  } else {
+    console.log('```\n%s```', await response.text());
+  }
+}

--- a/tests/node_modules/@this/integration-testing/package.json
+++ b/tests/node_modules/@this/integration-testing/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@this/integration-testing",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "license": "Apache-2.0",
+
+  "exports": "./index.js",
+  "imports": {
+    "#x/*": "./export/*.js",
+    "#p/*": "./private/*.js"
+  }
+}

--- a/tests/run-all
+++ b/tests/run-all
@@ -26,10 +26,10 @@ process-args "$@" || exit "$?"
 testsDir="$(this-cmd-dir)"
 
 # Test directories are identified as directories that have a file called `run`
-# in them.
+# or `run.*` in them.
 jset-array --raw allRunScripts "$(
     lib ls-files --output=array --sort \
-        --cd="${testsDir}" --include='^[0-9][-/a-z0-9]+/run' \
+        --cd="${testsDir}" --include='^[0-9][-/a-z0-9]+/run(\.[a-z]+)?$' \
     || echo '["error"]'
 )" \
 || exit "$?"
@@ -40,7 +40,7 @@ fi
 
 errors=()
 for run in "${allRunScripts[@]}"; do
-    testName="${run%/run}"
+    testName="${run%/run*}"
     "${testsDir}/run-one" "${testName}" \
     || errors+=("${testName}")
 done

--- a/tests/run-all
+++ b/tests/run-all
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+# SPDX-License-Identifier: Apache-2.0
+
+. "$(dirname "$(readlink -f "$0")")/_init.sh" || exit "$?"
+
+
+#
+# Argument parsing
+#
+
+define-usage --with-help $'
+    ${name} [<opt> ...] [--]
+
+    Runs all the tests.
+'
+
+process-args "$@" || exit "$?"
+
+
+#
+# Main script
+#
+
+testsDir="$(this-cmd-dir)"
+
+# Test directories are identified as directories that have a file called `run`
+# in them.
+jset-array --raw allRunScripts "$(
+    lib ls-files --output=array --sort \
+        --cd="${testsDir}" --include='^[0-9][-/a-z0-9]+/run' \
+    || echo '["error"]'
+)" \
+|| exit "$?"
+
+if [[ ${allRunScripts[0]} == 'error' ]]; then
+    exit 1
+fi
+
+errors=()
+for run in "${allRunScripts[@]}"; do
+    testName="${run%/run}"
+    "${testsDir}/run-one" "${testName}" \
+    || errors+=("${testName}")
+done
+
+errorCount="${#errors[@]}"
+
+echo ''
+
+if (( errorCount == 0 )); then
+    echo 'All passed. Yay!'
+else
+    echo 'Problems with:'
+
+    for e in "${errors[@]}"; do
+        echo "  ${e}"
+    done
+
+    (( errorCount == 1 )) && noun=error || noun=errors
+    echo ''
+    echo "${errorCount} ${noun}. Alas."
+
+    exit 1
+fi

--- a/tests/run-one
+++ b/tests/run-one
@@ -1,0 +1,251 @@
+#!/bin/bash
+#
+# Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+# SPDX-License-Identifier: Apache-2.0
+
+. "$(dirname "$(readlink -f "$0")")/_init.sh" || exit "$?"
+
+
+#
+# Argument parsing
+#
+
+define-usage --with-help $'
+    ${name} [<opt> ...] [--] <test-name>
+
+    Runs a single named test. The name of the test is fundamentally the partial
+    path from the `tests` directory to the directory of the test, but as a
+    commandline convenience:
+
+    * Any prefix on the test which looks like a path to the `tests` directory is
+      ignored.
+    * If the name consists only of digits and slashes, then it is expanded to
+      include the names of the test directories in question. E.g. `01/05` might
+      expand into `01-smoke-tests/05-dry-ice`.
+    * If the name has no slashes and starts with a digit, then it is expanded to
+      be the unique test directory (leaf in the hierarchy) with that name as a
+      prefix. E.g. `05-dry` might expand into `01-smoke-tests/05-dry-ice`.
+
+    Note that all test directories are expected to be named with a sequential
+    numeric prefix followed by a dash.
+
+    --print
+      Print the test run output to stdout, instead of doing a diff with the
+      expected output.
+    --update
+      Update the expected output to match the actual output.
+'
+
+# Print the test run output?
+opt-toggle --var=doPrint print
+
+# Update the expected output?
+opt-toggle --var=doUpdate update
+
+# The test to run.
+positional-arg --required --var=testName --filter='/[0-9][-/a-z0-9]*$/' test-name
+
+process-args "$@" || exit "$?"
+
+
+#
+# Helper functions
+#
+
+# Any errors yet?
+anyErrors=0
+
+# Emits an error. This is only used once the test name has been successfully
+# found to be an existing test directory.
+function emit-error {
+    if (( !anyErrors )); then
+        error-msg 'Trouble running test:'
+        error-msg "  ${testName}"
+        error-msg ''
+        anyErrors=1
+    fi
+
+    error-msg "$@"
+}
+
+# Expands from just numbers and slashes, to a full test path.
+function expand-numbers {
+    local numbersName="$1"
+
+    local part partExpanded
+    local newName='/'
+    while [[ ${numbersName} =~ ^/*([0-9]+)(.*)$ ]]; do
+        part="${BASH_REMATCH[1]}"
+        numbersName="${BASH_REMATCH[2]}"
+        partExpanded=($(
+            lib ls-files --output=lines --cd="${testsDir}${newName}" --dirs \
+                --depth=1 --include="^${part}-"
+        ))
+
+        case "${#partExpanded[@]}" in
+            0)
+                error-msg 'Test not found:'
+                error-msg "  ${newName#/}${part}"
+                return 1
+                ;;
+            1)
+                : # It's good
+                ;;
+            *)
+                error-msg 'Ambiguous test name:'
+                error-msg "  ${newName#/}${part}"
+                error-msg --exec printf '    %s\n' "${partExpanded[@]}"
+                return 1
+                ;;
+        esac
+
+        newName+="${partExpanded[0]}/"
+    done
+
+    echo "tests${newName}"
+}
+
+# Expands from a simple name (no slashes) taken to be a prefix, to a full test
+# path.
+function expand-prefix {
+    local prefix="$1"
+
+    local found
+    found="$(
+        lib ls-files --output=array \
+            --cd="${testsDir}" --dirs --include="/${prefix}[^/]*$" \
+            :: --output=raw '
+            if length == 0 then
+                "err: Could not find test directory with given prefix."
+            elif length == 1 then
+                .[0]
+            else
+                [
+                    "err: Ambiguous prefix matches all of:",
+                    (.[] | "  \(.)")
+                ]
+                | join("\n")
+            end'
+    )" \
+    || return "$?"
+
+    if [[ ${found} =~ ^err:\ (.*)$ ]]; then
+        error-msg "${BASH_REMATCH[1]}"
+        return 1
+    fi
+
+    echo "${found}"
+}
+
+
+#
+# Main script
+#
+
+testsDir="$(this-cmd-dir)"
+
+# Expand (if necessary) and validate the given test name.
+
+if [[ ${testName} =~ ^[/0-9]+$ ]]; then
+    # The name appears to be a shorthand that omits the non-numeric portion of
+    # the directories. Try to expand it.
+    testName="$(expand-numbers "${testName}")" \
+    || exit "$?"
+elif [[ ${testName} =~ ^[0-9][-0-9a-z]+$ ]]; then
+    # The name appears to be a shorthand prefix for a specific leaf test
+    # directory. Try to expand it.
+    testName="$(expand-prefix "${testName}")" \
+    || exit "$?"
+fi
+
+# Drop initial `.../tests/` and/or final `/` on name, if present.
+[[ ${testName} =~ ^((.*/)?tests/)?([0-9][-/a-z0-9]*[a-z0-9])/?$ ]] || {
+    error-msg 'Cannot parse test name:'
+    error-msg "  ${testName}"
+    usage --short
+    exit 1
+}
+testName="${BASH_REMATCH[3]}"
+
+testDir="${testsDir}/${testName}"
+runScript="${testDir}/run"
+infoFile="${testDir}/info.md"
+expectMd="${testDir}/expect.md"
+
+if [[ !(-d "${testDir}" && -r "${testDir}") ]]; then
+    emit-error "Test not found: ${testName}"
+    exit 1
+fi
+
+# Check the test directory for validity.
+
+if [[ !(-f "${runScript}" && -r "${runScript}") ]]; then
+    emit-error 'Run script not found.'
+elif [[ ! -x "${runScript}" ]]; then
+    emit-error 'Run script not executable. Do this:'
+    emit-error "  chmod 755 ${runScript}"
+    emit-error ''
+fi
+
+if [[ !(-f "${expectMd}" && -r "${expectMd}") ]] && (( !doUpdate )); then
+    emit-error 'Expected output not found.'
+fi
+
+if [[ !(-f "${infoFile}" && -r "${infoFile}") ]]; then
+    emit-error 'Info file not found.'
+fi
+
+if (( anyErrors )); then
+    exit 1
+fi
+
+# Run the test!
+
+echo "# ${testName}"
+
+testOutput="$("${runScript}")" \
+|| {
+    echo "${testOutput}"
+    echo "Run script exited with code: $?"
+    exit 1
+}
+
+if (( doPrint )); then
+    echo "${testOutput}"
+fi
+
+if (( doUpdate )); then
+    echo >"${expectMd}" "${testOutput}" \
+    || exit "$?"
+fi
+
+if (( doPrint || doUpdate )); then
+    exit
+fi
+
+expectedOutput="$(cat "${expectMd}")" \
+|| exit "$?"
+
+if cmp >/dev/null "${expectMd}" <(echo "${testOutput}"); then
+    echo "## passed"
+else
+    echo "## failed"
+    echo ''
+    diff -u "${expectMd}" <(echo "${testOutput}") \
+    | awk '
+        # Fix up the diff labels
+        !done && /^---/ {
+            print "--- expected";
+            print "+++ got";
+            next;
+        }
+        !done && /^+++/ {
+            done = 1;
+            next;
+        }
+        {
+            print;
+        }
+    '
+    exit 1
+fi

--- a/tests/run-one
+++ b/tests/run-one
@@ -179,12 +179,27 @@ fi
 
 # Check the test directory for validity.
 
-if [[ !(-f "${runScript}" && -r "${runScript}") ]]; then
+runSh="${runScript}"
+runMjs="${runScript}.mjs"
+
+if [[ -f "${runSh}" && -r "${runSh}" ]]; then
+    if [[ ! -x "${runSh}" ]]; then
+        emit-error 'Run script not executable. Do this:'
+        emit-error "  chmod 755 ${runSh}"
+        emit-error ''
+    fi
+else
+    runSh=''
+fi
+
+if [[ !(-f "${runMjs}" && -r "${runMjs}") ]]; then
+    runMjs=''
+fi
+
+if [[ ("${runSh}" == '') && ("${runMjs}" == '') ]]; then
     emit-error 'Run script not found.'
-elif [[ ! -x "${runScript}" ]]; then
-    emit-error 'Run script not executable. Do this:'
-    emit-error "  chmod 755 ${runScript}"
-    emit-error ''
+elif [[ ("${runSh}" != '') && ("${runMjs}" != '') ]]; then
+    emit-error 'Multiple run scripts found. Pick one type!'
 fi
 
 if [[ !(-f "${expectMd}" && -r "${expectMd}") ]] && (( !doUpdate )); then
@@ -201,9 +216,22 @@ fi
 
 # Run the test!
 
+runScript="${runSh}${runMjs}" # Only one will be non-empty
+
 echo "# ${testName}"
 
-testOutput="$("${runScript}")" \
+testOutput="$(
+    if [[ ${runSh} != '' ]]; then
+        "${runSh}"
+    else
+        # We run with a self-signed certificate, and there's no other way as of
+        # this writing to convince Node's version of `fetch()` to accept that
+        # other than to disable TLS cert checking altogether. And then we also
+        # need to squelch the warning that that setting elicits. Whee!
+        NODE_TLS_REJECT_UNAUTHORIZED=0 \
+            node --no-warnings "${runMjs}"
+    fi
+)" \
 || {
     echo "${testOutput}"
     echo "Run script exited with code: $?"


### PR DESCRIPTION
This PR ended up rolling together a bunch of work which turned out to be pretty interrelated:

* Added an integration test framework along with a bunch of integration tests which consist of making requests of a running system and sniffing at the results. TLDR: I got tired of doing these manually all the time, and of course my manual work was error prone.
* `HttpResponse`: Made it able to send "message" replies. This is meant to replace the "meta" reply functionality in `Request`, though that latter part isn't done yet.
* Added `HttpConditional` as a replacement for the npm module `fresh`. Used it to replace the freshness-testing code in `Request`.
* Added a couple helper methods here and there.