### PR TITLE
Body strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
 * Tweaked the contract of `contentType` bindings in configurations, to help
   avoid ambiguity and confusion. Specifically, file extensions now need to start
   with a dot.
+* Significant rework of the API of `net-protocol.Request`.
 
 Other notable changes:
 * New integration test setup, along with a handful of tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,16 @@ Breaking changes:
 
 Other notable changes:
 * New integration test setup, along with a handful of tests.
-* New class `HttpConditional` to take over from the old npm module `fresh`.
-* New class `HttpResponse` to encapsulate data required to make an HTTP(ish)
-  response and to handle much of the mechanics of actually producing a response.
-* Rewrote `Request.sendFile()` to no longer use Express-specific functionality.
-* Expanded `MimeTypes` to handle character set stuff.
+* Module `net-util`:
+  * Expanded `MimeTypes` to handle character set stuff.
+  * New class `HttpConditional` to take over from the old npm module `fresh`.
+  * New class `HttpResponse` to encapsulate data required to make an HTTP(ish)
+    response and to handle much of the mechanics of actually producing a
+    response.
+* `net-protocol.Request`:
+  * Reworked it to use `HttpResponse`.
+  * Specifically, rewrote `sendFile()` to no longer use Express-specific
+    functionality.
 
 ###  v0.6.5 -- 2024-02-09
 

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -473,6 +473,22 @@ export class Request {
   }
 
   /**
+   * Sends a response to this request, by asking the given response object to
+   * write itself to this isntance's underlying `http.ServerResponse` object (or
+   * similar).
+   *
+   * @param {HttpResponse} response The response to send.
+   * @returns {boolean} `true` when the response is completed.
+   * @throws {Error} Thrown if there is any trouble sending the response.
+   */
+  respond(response) {
+    const result = response.writeTo(this.#expressResponse);
+
+    this.#responsePromise.resolve(result);
+    return result;
+  }
+
+  /**
    * Issues a successful response, with the given body contents or with an empty
    * body as appropriate. The actual reported status will be one of:
    *
@@ -629,9 +645,7 @@ export class Request {
         length: rangeInfo.bodyLength
       });
 
-      const result = response.writeTo(this.#expressResponse);
-      this.#responsePromise.resolve(result);
-      return result;
+      return this.respond(response);
     }
   }
 
@@ -679,9 +693,7 @@ export class Request {
 
     response.setBodyMessage(options);
 
-    const result = response.writeTo(this.#expressResponse);
-    this.#responsePromise.resolve(result);
-    return result;
+    return this.respond(response);
   }
 
   /**
@@ -1022,10 +1034,7 @@ export class Request {
       response.setNoBody();
     }
 
-    const result = response.writeTo(this.#expressResponse);
-
-    this.#responsePromise.resolve(result);
-    return result;
+    return this.respond(response);
   }
 
 

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -763,27 +763,6 @@ export class Request {
   }
 
   /**
-   * Issues a redirect response targeted at the original request's referrer. If
-   * there was no referrer, this redirects to `/`.
-   *
-   * Calling this method results in this request being considered complete, and
-   * as such no additional response-related methods will work.
-   *
-   * @param {?object} [options] Options to control response behavior. See class
-   *   header comment for more details.
-   * @param {?number} [options.status] The status code to report. Defaults to
-   *   `302` ("Found").
-   * @returns {boolean} `true` when the response is completed.
-   */
-  async sendRedirectBack(options = null) {
-    // Note: Express lets you ask for `referrer` (spelled properly), but the
-    // actual header that's supposed to be sent is `referer` (which is of course
-    // misspelled).
-    const target = this.getHeaderOrNull('referer') ?? '/';
-    return this.sendRedirect(target, options);
-  }
-
-  /**
    * Returns when the underlying response has been closed successfully (after
    * all of the response is believed to be sent) or has errored. Returns `true`
    * for a normal close, or throws whatever error the response reports.

--- a/src/net-util/export/HttpResponse.js
+++ b/src/net-util/export/HttpResponse.js
@@ -236,7 +236,9 @@ export class HttpResponse {
    *   * Checking that no content-related headers are present.
    * * If there is a content body:
    *   * Checking that `status` allows a body.
-   *   * Checking that a `content-type` header is present.
+   *   * Checking that a `content-type` header is present _or_ {@link
+   *     #setBodyString} was used (which includes an explicit `contentType`
+   *     argument).
    *   * Checking that a `content-length` header is _not_ present (because this
    *     class will generate it).
    * * If there is a "message" (meta-information) body:

--- a/src/net-util/export/HttpResponse.js
+++ b/src/net-util/export/HttpResponse.js
@@ -228,8 +228,7 @@ export class HttpResponse {
    *
    * * Checking that {@link #status} is set.
    * * Checking that one of the body-setup methods has been called (that is, one
-   *   of {@link #setBodyBuffer}, {@link #setBodyFile}, {@link #setBodyMessage},
-   *   or {@link #setNoBody}).
+   *   of `setBody*()` or {@link #setNoBody}).
    *
    * And, depending on the body:
    *

--- a/src/net-util/export/HttpResponse.js
+++ b/src/net-util/export/HttpResponse.js
@@ -16,7 +16,10 @@ import { MimeTypes } from '#x/MimeTypes';
 
 /**
  * Responder to an HTTP request. This class holds all the information needed to
- * perform a response, along with the functionality to produce it.
+ * perform a response, along with the functionality to produce it. This class is
+ * mostly in the "mechanism not policy" camp, except that (a) it _does_ enforce
+ * consistency / unambiguity of use, and (b) it refuses to send responses that
+ * are (reasonably believed to be) contrary to the HTTP (etc.) specification.
  *
  * **Note:** This class is designed so that clients can ignore the special
  * response behavior required by the `HEAD` request method. Specifically, even

--- a/src/net-util/export/MimeTypes.js
+++ b/src/net-util/export/MimeTypes.js
@@ -15,6 +15,25 @@ import { MustBe } from '@this/typey';
  */
 export class MimeTypes {
   /**
+   * Gets the `charset`, if any, from the given MIME type. This method assumes
+   * that the given type is syntactically valid.
+   *
+   * @param {string} mimeType The MIME type to inspect.
+   * @returns {?string} The `charset` value of `type`, or `null` if it does not
+   *   have one.
+   */
+  static charSetFromType(mimeType) {
+    MustBe.string(mimeType);
+
+    // RFC2978 says charset names have to be 40 characters or less and also
+    // specifies the allowed symbols.
+    const found =
+      mimeType.match(/; *charset=(?<charSet>[-~_'`!#$%&+^{}A-Za-z0-9]{1,40}) *(?:;|$)/);
+
+    return found?.groups.charSet ?? null;
+  }
+
+  /**
    * Gets the MIME type for the filename extension on the given absolute path.
    * This returns `'application/octet-stream'` if nothing better can be
    * determined.

--- a/src/net-util/tests/MimeTypes.test.js
+++ b/src/net-util/tests/MimeTypes.test.js
@@ -4,6 +4,50 @@
 import { MimeTypes } from '@this/net-util';
 
 
+describe('charSetFromType()', () => {
+  // Failure cases: Wrong argument type.
+  test.each`
+  arg
+  ${null}
+  ${undefined}
+  ${false}
+  ${123}
+  ${['.x']}
+  ${{ a: 10 }}
+  ${new Map()}
+  `('throws given $arg', ({ arg }) => {
+    expect(() => MimeTypes.charSetFromType(arg)).toThrow();
+  });
+
+  test.each`
+  arg                                        | expected
+  ${''}                                      | ${null}
+  ${'text/plain'}                            | ${null}
+  ${'text/plain; charset=abc'}               | ${'abc'}
+  ${'text/plain;charset=abc'}                | ${'abc'}
+  ${'application/json; charset=abc-123-xyz'} | ${'abc-123-xyz'}
+  ${'x/y'}                                   | ${null}
+  ${'x/y; a=z'}                              | ${null}
+  ${'x/y; charset=z9z'}                      | ${'z9z'}
+  ${'x/y; charset=z9z; b=c'}                 | ${'z9z'}
+  ${'x/y; charset=z9z ; b=c'}                | ${'z9z'}
+  ${'x/y; charset=z9z ;b=c'}                 | ${'z9z'}
+  ${'x/y; b=c; charset=z9z'}                 | ${'z9z'}
+  ${'x/y; b=c; charset=z9z; d=e'}            | ${'z9z'}
+  ${'x/y; xcharset=z'}                       | ${null}
+  ${'x/y; charset=boop; xcharset=z'}         | ${'boop'}
+  ${'x/y; charsetx=z'}                       | ${null}
+  ${'x/y; charsetx=z; charset=beep'}         | ${'beep'}
+  ${'w/eird; charset=-~_\'`!#$%&+^{}'}       | ${'-~_\'`!#$%&+^{}'} // All the allowed special chars.
+  ${'w/eird; charset=x@y'}                   | ${null} // Disallowed special char.
+  ${'w/eird; charset="xy"'}                  | ${null} // Ditto.
+  ${'w/eird; charset=(xy)'}                  | ${null} // Ditto.
+  ${'w/eird; charset=[xy]'}                  | ${null} // Ditto.
+  `('returns `$expected` given `$arg`', ({ arg, expected }) => {
+    expect(MimeTypes.charSetFromType(arg)).toBe(expected);
+  });
+});
+
 describe('typeFromPathExtension()', () => {
   // Failure cases: Wrong argument type.
   test.each`


### PR DESCRIPTION
This PR adds one more body-setting method to `HttpResponse`, namely `setBodyString()`. It is meant to be used to replace some bits in `Request`, though that's not done in this PR.