### PR TITLE
Range requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Other notable changes:
 * New integration test setup, along with a handful of tests.
 * Module `net-util`:
   * Expanded `MimeTypes` to handle character set stuff.
-  * New class `HttpConditional` to take over from the old npm module `fresh`.
+  * New class `HttpConditional` to take over from the old npm module `fresh` as
+    well as hold our (already existing) range conditional implementation.
   * New class `HttpResponse` to encapsulate data required to make an HTTP(ish)
     response and to handle much of the mechanics of actually producing a
     response.

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -948,8 +948,8 @@ export class Request {
       return status200();
     }
 
-    if (!HttpConditional.isRangeFresh(this.method, this.headers, responseHeaders, stats)) {
-      // There was a range conditional which didn't match.
+    if (!HttpConditional.isRangeApplicable(this.method, this.headers, responseHeaders, stats)) {
+      // There was a range condition which didn't match.
       return status200();
     }
 

--- a/src/net-protocol/export/Request.js
+++ b/src/net-protocol/export/Request.js
@@ -691,7 +691,11 @@ export class Request {
     response.status  = status;
     response.headers = this.#makeResponseHeaders(status, options);
 
-    response.setBodyMessage(options);
+    if (options.body || options.bodyExtra) {
+      response.setBodyMessage(options);
+    } else {
+      response.setNoBody();
+    }
 
     return this.respond(response);
   }

--- a/src/net-util/export/HttpConditional.js
+++ b/src/net-util/export/HttpConditional.js
@@ -165,7 +165,7 @@ export class HttpConditional {
     switch (requestMethod) {
       case 'get': case 'head':
       case 'GET': case 'HEAD': {
-        // Possibly fresh.
+        // Possibly applicable.
         break;
       }
       default: {
@@ -176,14 +176,14 @@ export class HttpConditional {
     const ifRange = HttpHeaders.get(requestHeaders, 'if-range');
 
     if (!ifRange) {
-      // This isn't a conditional range request, so it is de facto "fresh."
+      // This isn't a conditional range request, so it is de facto applicable.
       return true;
     }
 
     if (ifRange.startsWith('"')) {
-      // It's an etag conditional. Note: It is invalid per spec to use a weak
-      // etag (form `W/"..."`) in this case, so we don't recognize that form in
-      // the `if` above.
+      // It's an etag condition. Note: It is invalid per spec to use a weak etag
+      // (form `W/"..."`) in this case, so we don't recognize them in the `if`
+      // above.
       const responseEtag = responseHeaders?.get('etag') ?? null;
 
       if (!responseEtag || (responseEtag === '')) {
@@ -192,9 +192,7 @@ export class HttpConditional {
 
       return (ifRange === responseEtag);
     } else {
-      // Try to parse it as a date. If it can be parsed, this is a date
-      // conditional which is asking the same question as an
-      // `if-unmodified-since` header would.
+      // Try to parse it as a date.
       const ifUnmodifiedSince = HttpUtil.msecFromDateString(ifRange);
 
       if (!ifUnmodifiedSince) {

--- a/src/net-util/export/HttpConditional.js
+++ b/src/net-util/export/HttpConditional.js
@@ -123,15 +123,18 @@ export class HttpConditional {
   }
 
   /**
-   * Checks to see if a response with the given headers would be considered
-   * valid to send as a `206` range response.
+   * Checks to see if a range request would be applicable in light of any
+   * conditional range request headers. This returns `true` if it is valid to
+   * send a `206` ("Partial Content") response.
    *
-   * A range request is considered to be fresh:
+   * A range request is considered to be applicable if:
    * * The request method is `HEAD` or `GET`.
-   * * Either:
+   * * One of:
    *   * The request does not have a range condition at all.
    *   * The request has an `if-range` header with a matching etag.
    *   * The request has an `if-range` header with a sufficiently-late date.
+   *     This form is akin to the `if-unmodified-since` header for non-range
+   *     requests.
    *
    * This assumes that the response would have a sans-check status code that is
    * acceptable for conversion to status `206` ("Partial Content").
@@ -149,7 +152,7 @@ export class HttpConditional {
    *   precedence over a header value.
    * @returns {boolean} `true` iff the request is to be considered "fresh."
    */
-  static isRangeFresh(requestMethod, requestHeaders, responseHeaders, stats = null) {
+  static isRangeApplicable(requestMethod, requestHeaders, responseHeaders, stats = null) {
     MustBe.string(requestMethod);
     // MustBe.instanceOf(requestHeaders, HttpHeaders); TODO: Make it true.
     if (responseHeaders !== null) {

--- a/src/net-util/export/HttpResponse.js
+++ b/src/net-util/export/HttpResponse.js
@@ -596,7 +596,7 @@ export class HttpResponse {
   static #READ_CHUNK_SIZE = 64 * 1024; // 64k
 
   /**
-   * @type {Symbol} Key to use on response objects to hold a result from
+   * @type {symbol} Key to use on response objects to hold a result from
    * {@link #whenResponseDone}. See comment at use site for more explanation.
    */
   static #RESPONSE_DONE_SYMBOL = Symbol('HttpResponseDone');

--- a/src/net-util/export/HttpResponse.js
+++ b/src/net-util/export/HttpResponse.js
@@ -114,8 +114,8 @@ export class HttpResponse {
    * @param {?object} [options] Options to control the response body.
    * @param {?string|Buffer} [options.body] Complete body content to include.
    * @param {?string} [options.bodyExtra] Extra body content to include, in
-   *   addition to the default body. Either this or `options.body` is allowed,
-   *   but not both.
+   *   addition to the default body. One of this or `options.body` is must be
+   *   passed, but not both.
    * @param {?string} [options.contentType] Content type of `options.body`.
    *   Required if `options.body` is a `Buffer`. Disallowed in all other cases.
    */
@@ -140,6 +140,8 @@ export class HttpResponse {
       }
     } else if (bodyExtra !== null) {
       this.#body = { type: 'message', messageExtra: MustBe.string(bodyExtra) };
+    } else {
+      throw new Error('Must specify either `body` or `bodyExtra`.');
     }
   }
 

--- a/src/net-util/tests/HttpConditional.test.js
+++ b/src/net-util/tests/HttpConditional.test.js
@@ -10,7 +10,7 @@ import { HttpConditional, HttpHeaders } from '@this/net-util';
 describe.each`
 methodName
 ${'isContentFresh'}
-${'isRangeFresh'}
+${'isRangeApplicable'}
 `('$methodName()', ({ methodName }) => {
   // Convenient stats objects.
   let statsNum;
@@ -213,7 +213,7 @@ describe('isContentFresh()', () => {
   });
 });
 
-describe('isRangeFresh()', () => {
+describe('isRangeApplicable()', () => {
   // Convenient stats objects.
   let statsNum;
   let statsBig;
@@ -236,7 +236,7 @@ describe('isRangeFresh()', () => {
     reqHead.set('if-range', '"xyz"');
     resHead.set('etag',     '"xyz"');
 
-    expect(HttpConditional.isRangeFresh(requestMethod, reqHead, resHead)).toBeFalse();
+    expect(HttpConditional.isRangeApplicable(requestMethod, reqHead, resHead)).toBeFalse();
   });
 
   describe.each`
@@ -253,9 +253,9 @@ describe('isRangeFresh()', () => {
       resHead.set('etag', '"xyz"');
       resHead.set('last-modified', statsNum.mtime.toUTCString());
 
-      expect(HttpConditional.isRangeFresh(requestMethod, reqHead, resHead)).toBeTrue();
-      expect(HttpConditional.isRangeFresh(requestMethod, reqHead, resHead, statsNum)).toBeTrue();
-      expect(HttpConditional.isRangeFresh(requestMethod, reqHead, resHead, statsBig)).toBeTrue();
+      expect(HttpConditional.isRangeApplicable(requestMethod, reqHead, resHead)).toBeTrue();
+      expect(HttpConditional.isRangeApplicable(requestMethod, reqHead, resHead, statsNum)).toBeTrue();
+      expect(HttpConditional.isRangeApplicable(requestMethod, reqHead, resHead, statsBig)).toBeTrue();
     });
 
     test('finds a fresh etag', () => {
@@ -265,7 +265,7 @@ describe('isRangeFresh()', () => {
       reqHead.set('if-range', '"xyz"');
       resHead.set('etag',     '"xyz"');
 
-      expect(HttpConditional.isRangeFresh(requestMethod, reqHead, resHead)).toBeTrue();
+      expect(HttpConditional.isRangeApplicable(requestMethod, reqHead, resHead)).toBeTrue();
     });
 
     test('does not consider a non-matching etag to be fresh', () => {
@@ -275,7 +275,7 @@ describe('isRangeFresh()', () => {
       reqHead.set('if-range', '"xyz"');
       resHead.set('etag',     '"abc"');
 
-      expect(HttpConditional.isRangeFresh(requestMethod, reqHead, resHead)).toBeFalse();
+      expect(HttpConditional.isRangeApplicable(requestMethod, reqHead, resHead)).toBeFalse();
     });
 
     test('finds a fresh last-modified date as a header', () => {
@@ -287,7 +287,7 @@ describe('isRangeFresh()', () => {
       reqHead.set('if-range',      modTime);
       resHead.set('last-modified', modTime);
 
-      expect(HttpConditional.isRangeFresh(requestMethod, reqHead, resHead)).toBeTrue();
+      expect(HttpConditional.isRangeApplicable(requestMethod, reqHead, resHead)).toBeTrue();
     });
 
     test('finds a fresh last-modified date via a stats', () => {
@@ -297,8 +297,8 @@ describe('isRangeFresh()', () => {
 
       reqHead.set('if-range', modTime);
 
-      expect(HttpConditional.isRangeFresh(requestMethod, reqHead, null, statsNum)).toBeTrue();
-      expect(HttpConditional.isRangeFresh(requestMethod, reqHead, null, statsBig)).toBeTrue();
+      expect(HttpConditional.isRangeApplicable(requestMethod, reqHead, null, statsNum)).toBeTrue();
+      expect(HttpConditional.isRangeApplicable(requestMethod, reqHead, null, statsBig)).toBeTrue();
     });
 
     test('understands a later last-modified date (as a header) to make things un-fresh', () => {
@@ -312,7 +312,7 @@ describe('isRangeFresh()', () => {
       reqHead.set('if-range',      modTime);
       resHead.set('last-modified', laterTime.toUTCString());
 
-      expect(HttpConditional.isRangeFresh(requestMethod, reqHead, resHead)).toBeFalse();
+      expect(HttpConditional.isRangeApplicable(requestMethod, reqHead, resHead)).toBeFalse();
     });
 
     test('understands a later last-modified date (via a stats) to make things un-fresh', async () => {
@@ -326,7 +326,7 @@ describe('isRangeFresh()', () => {
 
       reqHead.set('if-range', modTime);
 
-      expect(HttpConditional.isRangeFresh(requestMethod, reqHead, resHead, laterStats)).toBeFalse();
+      expect(HttpConditional.isRangeApplicable(requestMethod, reqHead, resHead, laterStats)).toBeFalse();
     });
   });
 });

--- a/tests/03-http2/06-range/expect.md
+++ b/tests/03-http2/06-range/expect.md
@@ -1,0 +1,19 @@
+## Start-end range
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.
+
+## Not Satisfiable 2
+
+### Metadata
+
+* No problems.
+
+### Body
+
+(no body)

--- a/tests/03-http2/06-range/expect.md
+++ b/tests/03-http2/06-range/expect.md
@@ -1,4 +1,4 @@
-## Start-end range
+## `start-end` range
 
 ### Metadata
 
@@ -7,6 +7,36 @@
 ### Body
 
 Body is as expected.
+
+## `start-` range
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.
+
+## `-suffix` range
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.
+
+## Not Satisfiable 1
+
+### Metadata
+
+* No problems.
+
+### Body
+
+(no body)
 
 ## Not Satisfiable 2
 

--- a/tests/03-http2/06-range/info.md
+++ b/tests/03-http2/06-range/info.md
@@ -1,0 +1,1 @@
+Test of `Range` headers.

--- a/tests/03-http2/06-range/run.mjs
+++ b/tests/03-http2/06-range/run.mjs
@@ -12,7 +12,7 @@ const bodyText  = await response1.text();
 
 // Get a `start-end` range.
 
-console.log('## Start-end range\n');
+console.log('## `start-end` range\n');
 
 const response2 = await fetch(theUrl,
   {
@@ -39,29 +39,99 @@ await checkResponse(response2, {
   body: bodyText.slice(5, 27 + 1)
 });
 
+// Get a `start-` range.
 
+console.log('\n## `start-` range\n');
 
+const response3 = await fetch(theUrl,
+  {
+    headers: {
+      'range': 'bytes=200-'
+    }
+  });
 
+await checkResponse(response3, {
+  status: 206,
+  statusText: 'Partial Content',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'content-length': `${bodyText.length - 200}`,
+    'content-range':  `bytes 200-${bodyText.length - 1}/${bodyText.length}`,
+    'content-type':   'text/html; charset=utf-8',
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'last-modified':  /./,
+    'server':         /./
+  },
+  body: bodyText.slice(200)
+});
 
-// TODO
+// Get a `start-` range.
 
+console.log('\n## `-suffix` range\n');
 
+const response4 = await fetch(theUrl,
+  {
+    headers: {
+      'range': 'bytes=-95'
+    }
+  });
 
-
-
+await checkResponse(response4, {
+  status: 206,
+  statusText: 'Partial Content',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'content-length': '95',
+    'content-range':  `bytes ${bodyText.length - 95}-${bodyText.length - 1}/${bodyText.length}`,
+    'content-type':   'text/html; charset=utf-8',
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'last-modified':  /./,
+    'server':         /./
+  },
+  body: bodyText.slice(bodyText.length - 95)
+});
 
 // Get a "not satisfiable" error, because the server only knows about `bytes`.
 
-console.log('\n## Not Satisfiable 2\n');
+console.log('\n## Not Satisfiable 1\n');
 
-const response_xxx = await fetch(theUrl,
+const response5 = await fetch(theUrl,
   {
     headers: {
       'range': 'florp=10-100'
     }
   });
 
-await checkResponse(response_xxx, {
+await checkResponse(response5, {
+  status: 416,
+  statusText: 'Range Not Satisfiable',
+  headers: {
+    'connection':     /./,
+    'content-length': '0', // This is getting added by Node at a lower level.
+    'content-range':  `bytes */${bodyText.length}`,
+    'date':           /./,
+    'server':         /./
+  }
+});
+
+// Get a "not satisfiable" error, because the range is inverted.
+
+console.log('\n## Not Satisfiable 2\n');
+
+const response6 = await fetch(theUrl,
+  {
+    headers: {
+      'range': 'bytes=10-1'
+    }
+  });
+
+await checkResponse(response6, {
   status: 416,
   statusText: 'Range Not Satisfiable',
   headers: {

--- a/tests/03-http2/06-range/run.mjs
+++ b/tests/03-http2/06-range/run.mjs
@@ -1,0 +1,74 @@
+// Copyright 2022-2024 the Bashy-lib Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { checkResponse } from '@this/integration-testing';
+
+const theUrl = 'https://localhost:8443/';
+
+// First, get the response without a range, and note the body.
+
+const response1 = await fetch(theUrl);
+const bodyText  = await response1.text();
+
+// Get a `start-end` range.
+
+console.log('## Start-end range\n');
+
+const response2 = await fetch(theUrl,
+  {
+    headers: {
+      'range': 'bytes=5-27'
+    }
+  });
+
+await checkResponse(response2, {
+  status: 206,
+  statusText: 'Partial Content',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'content-length': `${27 - 5 + 1}`,
+    'content-range':  `bytes 5-27/${bodyText.length}`,
+    'content-type':   'text/html; charset=utf-8',
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'last-modified':  /./,
+    'server':         /./
+  },
+  body: bodyText.slice(5, 27 + 1)
+});
+
+
+
+
+
+// TODO
+
+
+
+
+
+
+// Get a "not satisfiable" error, because the server only knows about `bytes`.
+
+console.log('\n## Not Satisfiable 2\n');
+
+const response_xxx = await fetch(theUrl,
+  {
+    headers: {
+      'range': 'florp=10-100'
+    }
+  });
+
+await checkResponse(response_xxx, {
+  status: 416,
+  statusText: 'Range Not Satisfiable',
+  headers: {
+    'connection':     /./,
+    'content-length': '0', // This is getting added by Node at a lower level.
+    'content-range':  `bytes */${bodyText.length}`,
+    'date':           /./,
+    'server':         /./
+  }
+});

--- a/tests/03-http2/07-range-conditional/expect.md
+++ b/tests/03-http2/07-range-conditional/expect.md
@@ -1,0 +1,49 @@
+## Etag matches
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.
+
+## Last-modified matches exactly
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.
+
+## Last-modified is before the range date
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.
+
+## Etag miss
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.
+
+## Date miss
+
+### Metadata
+
+* No problems.
+
+### Body
+
+Body is as expected.

--- a/tests/03-http2/07-range-conditional/info.md
+++ b/tests/03-http2/07-range-conditional/info.md
@@ -1,0 +1,1 @@
+Test of `Range` with `If-Range` headers.

--- a/tests/03-http2/07-range-conditional/run.mjs
+++ b/tests/03-http2/07-range-conditional/run.mjs
@@ -1,0 +1,170 @@
+// Copyright 2022-2024 the Bashy-lib Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { checkResponse } from '@this/integration-testing';
+
+const theUrl = 'https://localhost:8443/';
+
+// First, get the response without a range, and note the body and salient
+// headers.
+
+const response1    = await fetch(theUrl);
+const bodyText     = await response1.text();
+const etag         = response1.headers.get('etag');
+const lastModified = response1.headers.get('last-modified');
+
+// Get a range which should work because the etag matches.
+
+console.log('## Etag matches\n');
+
+const response2 = await fetch(theUrl,
+  {
+    headers: {
+      'range':    'bytes=10-25',
+      'if-range': etag
+    }
+  });
+
+await checkResponse(response2, {
+  status: 206,
+  statusText: 'Partial Content',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'content-length': `${25 - 10 + 1}`,
+    'content-range':  `bytes 10-25/${bodyText.length}`,
+    'content-type':   'text/html; charset=utf-8',
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'last-modified':  /./,
+    'server':         /./
+  },
+  body: bodyText.slice(10, 25 + 1)
+});
+
+// Get a range which should work because the last-modified date is the same as
+// the one from the original request.
+
+console.log('\n## Last-modified matches exactly\n');
+
+const response3 = await fetch(theUrl,
+  {
+    headers: {
+      'range':    'bytes=20-51',
+      'if-range': lastModified
+    }
+  });
+
+await checkResponse(response3, {
+  status: 206,
+  statusText: 'Partial Content',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'content-length': `${51 - 20 + 1}`,
+    'content-range':  `bytes 20-51/${bodyText.length}`,
+    'content-type':   'text/html; charset=utf-8',
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'last-modified':  /./,
+    'server':         /./
+  },
+  body: bodyText.slice(20, 51 + 1)
+});
+
+// Get a range which should work because the last-modified date is before the
+// one from the original request.
+
+console.log('\n## Last-modified is before the range date\n');
+
+const laterDate = new Date(lastModified);
+laterDate.setSeconds(laterDate.getSeconds() + 1);
+
+const response4 = await fetch(theUrl,
+  {
+    headers: {
+      'range':    'bytes=2-22',
+      'if-range': laterDate.toUTCString()
+    }
+  });
+
+await checkResponse(response4, {
+  status: 206,
+  statusText: 'Partial Content',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'content-length': `${22 - 2 + 1}`,
+    'content-range':  `bytes 2-22/${bodyText.length}`,
+    'content-type':   'text/html; charset=utf-8',
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'last-modified':  /./,
+    'server':         /./
+  },
+  body: bodyText.slice(2, 22 + 1)
+});
+
+
+// Try getting a range, but expect the whole document, because the etag doesn't
+// match.
+
+console.log('\n## Etag miss\n');
+
+const response5 = await fetch(theUrl,
+  {
+    headers: {
+      'range':    'bytes=1-100',
+      'if-range': "xyz-123"
+    }
+  });
+
+await checkResponse(response5, {
+  status: 200,
+  statusText: 'OK',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'content-length': /./,
+    'content-type':   'text/html; charset=utf-8',
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'last-modified':  /./,
+    'server':         /./
+  },
+  body: bodyText
+});
+
+// Try getting a range, but expect the whole document, because the last-modified
+// date is wrong.
+
+console.log('\n## Date miss\n');
+
+const response6 = await fetch(theUrl,
+  {
+    headers: {
+      'range':    'bytes=1-100',
+      'if-range': new Date(1234567890123).toUTCString()
+    }
+  });
+
+await checkResponse(response6, {
+  status: 200,
+  statusText: 'OK',
+  headers: {
+    'accept-ranges':  'bytes',
+    'cache-control':  /./,
+    'connection':     /./,
+    'content-length': /./,
+    'content-type':   'text/html; charset=utf-8',
+    'date':           /./,
+    'etag':           /^"[-0-9a-zA-Z]+"$/,
+    'last-modified':  /./,
+    'server':         /./
+  },
+  body: bodyText
+});


### PR DESCRIPTION
This PR fixes up the code related to range requests, which had gotten partially broken for at least two reasons. Relatedly, I took the opportunity to extract the `if-range` code out of `Request` and into `HttpConditional`.