### PR TITLE
Default to `charset=utf-8`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
-* None.
+* `net-util`:
+  * `MimeTypes` methods that return MIME type strings now default have the
+    default option `charSet: 'utf-8'`, which is about the most sensible default
+    these days.
 
 Other notable changes:
 * None.

--- a/src/builtin-applications/export/SimpleResponse.js
+++ b/src/builtin-applications/export/SimpleResponse.js
@@ -158,7 +158,7 @@ export class SimpleResponse extends BaseApplication {
       } else if (filePath !== null) {
         this.#filePath    = Paths.checkAbsolutePath(filePath);
         this.#contentType = (contentType === null)
-          ? MimeTypes.typeFromPathExtension(filePath, { charSet: 'utf-8' })
+          ? MimeTypes.typeFromPathExtension(filePath)
           : MimeTypes.typeFromExtensionOrType(contentType, { charSet: 'utf-8' });
       } else {
         // It's an empty body.

--- a/src/builtin-applications/export/SimpleResponse.js
+++ b/src/builtin-applications/export/SimpleResponse.js
@@ -153,13 +153,12 @@ export class SimpleResponse extends BaseApplication {
         const isText = typeof body === 'string';
 
         this.#body        = body;
-        this.#contentType =
-          MimeTypes.typeFromExtensionOrType(contentType, { charSet: 'utf-8', isText });
+        this.#contentType = MimeTypes.typeFromExtensionOrType(contentType, { isText });
       } else if (filePath !== null) {
         this.#filePath    = Paths.checkAbsolutePath(filePath);
         this.#contentType = (contentType === null)
           ? MimeTypes.typeFromPathExtension(filePath)
-          : MimeTypes.typeFromExtensionOrType(contentType, { charSet: 'utf-8' });
+          : MimeTypes.typeFromExtensionOrType(contentType);
       } else {
         // It's an empty body.
         if (contentType !== null) {

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -83,7 +83,7 @@ export class StaticFiles extends BaseApplication {
       return await request.respond(response);
     } else if (resolved.path) {
       const contentType =
-        MimeTypes.typeFromPathExtension(resolved.path, { charSet: 'utf-8' });
+        MimeTypes.typeFromPathExtension(resolved.path);
 
       const rawResponse = new HttpResponse();
 
@@ -132,7 +132,7 @@ export class StaticFiles extends BaseApplication {
       response.cacheControl = this.#cacheControl;
 
       const body        = await fs.readFile(notFoundPath);
-      const contentType = MimeTypes.typeFromPathExtension(notFoundPath, { charSet: 'utf-8' });
+      const contentType = MimeTypes.typeFromPathExtension(notFoundPath);
 
       response.setBodyBuffer(body);
       response.headers.set('content-type', contentType);

--- a/src/net-util/export/HttpResponse.js
+++ b/src/net-util/export/HttpResponse.js
@@ -348,8 +348,7 @@ export class HttpResponse {
   setBodyString(body, contentType) {
     MustBe.string(body);
 
-    contentType =
-      MimeTypes.typeFromExtensionOrType(contentType, { charSet: 'utf-8', isText: true });
+    contentType = MimeTypes.typeFromExtensionOrType(contentType, { isText: true });
 
     const charSet = MimeTypes.charSetFromType(contentType);
 

--- a/src/net-util/export/MimeTypes.js
+++ b/src/net-util/export/MimeTypes.js
@@ -70,9 +70,9 @@ export class MimeTypes {
    * @param {?object} [options] Options.
    * @param {?string} [options.charSet] Character set to return _if_ the
    *   returned type has the prefix `text/` or is otherwise considered to be
-   *   text, and doesn't already come with a character set. Defaults to `null`,
-   *   that is, not to ever add a character set when given an extension, nor to
-   *   add a character set when given a MIME type without one.
+   *   text and doesn't already come with a character set, or `null` to _not_
+   *   add a `charset` to the result. Defaults to `'utf-8'`, that is, to include
+   *   `charset=utf-8` in the result for any textual type.
    * @param {?boolean} [options.isText] Indicates that the type is definitely
    *   text. If `true`, `options.charSet` is taken into account if present, and
    *   the default type if no other type can be ascertained is `text/plain`.
@@ -81,7 +81,7 @@ export class MimeTypes {
    */
   static typeFromExtensionOrType(extensionOrType, options = {}) {
     MustBe.string(extensionOrType);
-    const { charSet = null, isText = false } = MustBe.object(options);
+    const { charSet = 'utf-8', isText = false } = MustBe.object(options);
 
     if (/^\.[^./]{1,10}$/.test(extensionOrType)) {
       return this.#typeFromPathOrExtension(extensionOrType, charSet, isText);

--- a/src/net-util/export/MimeTypes.js
+++ b/src/net-util/export/MimeTypes.js
@@ -42,8 +42,9 @@ export class MimeTypes {
    * @param {?object} [options] Options.
    * @param {?string} [options.charSet] Character set to return _if_ the
    *   returned type has the prefix `text/` or is otherwise considered to be
-   *   text. Defaults to `null`, that is, not to ever include a character set in
-   *   the result.
+   *   text, or `null` to _not_ add a `charset` to the result. Defaults to
+   *   `'utf-8'`, that is, to include `charset=utf-8` in the result for any
+   *   textual type.
    * @param {?boolean} [options.isText] Indicates that the type is definitely
    *   text. If `true`, `options.charSet` is always used if present, and the
    *   default type if no other type can be ascertained is `text/plain`.
@@ -52,7 +53,7 @@ export class MimeTypes {
    */
   static typeFromPathExtension(absolutePath, options = {}) {
     Paths.checkAbsolutePath(absolutePath);
-    const { charSet = null, isText = false } = MustBe.object(options);
+    const { charSet = 'utf-8', isText = false } = MustBe.object(options);
 
     return this.#typeFromPathOrExtension(absolutePath, charSet, isText);
   }

--- a/src/net-util/tests/MimeTypes.test.js
+++ b/src/net-util/tests/MimeTypes.test.js
@@ -100,6 +100,26 @@ describe('typeFromPathExtension()', () => {
     test('defaults to `application/octet-stream`', () => {
       expect(MimeTypes.typeFromPathExtension('/abc.abcdefgXYZ')).toBe('application/octet-stream');
     });
+
+    test('returns a value with `charset=utf-8` given a text type', () => {
+      expect(MimeTypes.typeFromPathExtension('/a/b/c.html')).toBe('text/html; charset=utf-8');
+    });
+  });
+
+  describe('with config `{ charSet: null }`', () => {
+    const config = { charSet: null };
+
+    test('does not impact a non-text extension', () => {
+      expect(MimeTypes.typeFromPathExtension('/foo.gif', config)).toBe('image/gif');
+    });
+
+    test('does not include a `charset` in the result from a text extension', () => {
+      expect(MimeTypes.typeFromPathExtension('/bar.text', config)).toBe('text/plain');
+    });
+
+    test('defaults to `application/octet-stream`', () => {
+      expect(MimeTypes.typeFromPathExtension('/florp.abcdefgXYZ', config)).toBe('application/octet-stream');
+    });
   });
 
   describe('with config `{ charSet: \'florp\' }`', () => {
@@ -121,23 +141,23 @@ describe('typeFromPathExtension()', () => {
   describe('with config `{ isText: true }`', () => {
     const config = { isText: true };
 
-    test('does not impact a non-text extension', () => {
-      expect(MimeTypes.typeFromPathExtension('/a/b.gif', config)).toBe('image/gif');
+    test('alters an otherwise non-text extension', () => {
+      expect(MimeTypes.typeFromPathExtension('/a/b.gif', config)).toBe('image/gif; charset=utf-8');
     });
 
     test('does not impact a text extension', () => {
-      expect(MimeTypes.typeFromPathExtension('/c/d/e.text', config)).toBe('text/plain');
+      expect(MimeTypes.typeFromPathExtension('/c/d/e.text', config)).toBe('text/plain; charset=utf-8');
     });
 
     test('defaults to `text/plain`', () => {
-      expect(MimeTypes.typeFromPathExtension('/bonk/.abcdefgXYZ', config)).toBe('text/plain');
+      expect(MimeTypes.typeFromPathExtension('/bonk/.abcdefgXYZ', config)).toBe('text/plain; charset=utf-8');
     });
   });
 
   describe('with config `{ charSet: \'boop\', isText: true }`', () => {
     const config = { charSet: 'boop', isText: true };
 
-    test('alters the result from a non0text extension', () => {
+    test('alters the result from a non-text extension', () => {
       expect(MimeTypes.typeFromPathExtension('/a.png', config)).toBe('image/png; charset=boop');
     });
 

--- a/src/net-util/tests/MimeTypes.test.js
+++ b/src/net-util/tests/MimeTypes.test.js
@@ -83,8 +83,20 @@ describe('typeFromExtensionOrType()', () => {
       expect(MimeTypes.typeFromExtensionOrType(theType)).toBe(theType);
     });
 
-    test('finds the MIME type of a known extension', () => {
+    test('adds `charset=utf-8` to a text MIME type', () => {
+      const theType  = 'text/plain';
+      const expected = `${theType}; charset=utf-8`;
+      expect(MimeTypes.typeFromExtensionOrType(theType)).toBe(expected);
+    });
+
+    test('finds the MIME type of a known non-text extension', () => {
       expect(MimeTypes.typeFromExtensionOrType('.png')).toBe('image/png');
+    });
+
+    test('adds `charset=utf-8` to a text extension', () => {
+      const theType  = 'text/html';
+      const expected = `${theType}; charset=utf-8`;
+      expect(MimeTypes.typeFromExtensionOrType('.html')).toBe(expected);
     });
 
     test('defaults to `application/octet-stream` given an unknown extension', () => {
@@ -94,6 +106,38 @@ describe('typeFromExtensionOrType()', () => {
     test('preserves a charset if given', () => {
       const theType = 'text/plain; charset=utf-8';
       expect(MimeTypes.typeFromExtensionOrType(theType)).toBe(theType);
+    });
+  });
+
+  describe('with config `{ charSet: null }`', () => {
+    const config = { charSet: null };
+
+    test('does not alter a text MIME type', () => {
+      const theType  = 'text/plain';
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
+    });
+
+    test('does not alter a non-text MIME type', () => {
+      const theType = 'image/jpeg';
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
+    });
+
+    test('returns the MIME type of a known non-text extension, as-is', () => {
+      expect(MimeTypes.typeFromExtensionOrType('.png', config)).toBe('image/png');
+    });
+
+    test('returns the MIME type of a known text extension, as-is', () => {
+      const theType  = 'text/javascript';
+      expect(MimeTypes.typeFromExtensionOrType('.js', config)).toBe(theType);
+    });
+
+    test('defaults to `application/octet-stream` given an unknown extension', () => {
+      expect(MimeTypes.typeFromExtensionOrType('.abcdefgXYZ', config)).toBe('application/octet-stream');
+    });
+
+    test('preserves a charset if given', () => {
+      const theType = 'text/plain; charset=zimbo-zombo';
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
     });
   });
 
@@ -126,7 +170,7 @@ describe('typeFromExtensionOrType()', () => {
     });
 
     test('preserves a charset if given', () => {
-      const theType = 'text/plain; charset=utf-8';
+      const theType = 'text/plain; charset=zimbo-zombo';
       expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
     });
   });
@@ -134,30 +178,33 @@ describe('typeFromExtensionOrType()', () => {
   describe('with config `{ isText: true }`', () => {
     const config = { isText: true };
 
-    test('does not alter a text MIME type', () => {
-      const theType  = 'text/plain';
-      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
+    function doTest(theType, theMime = null) {
+      const expected = `${theMime ?? theType}; charset=utf-8`;
+      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(expected);
+    }
+
+    test('includes `charset=utf-8` on a text MIME type', () => {
+      doTest('text/plain');
     });
 
-    test('does not alter a non-text MIME type', () => {
-      const theType = 'image/jpeg';
-      expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
+    test('includes `charset=utf-8` on a text extension', () => {
+      doTest('.js', 'text/javascript');
     });
 
-    test('finds the MIME type of a known non-text extension, as-is', () => {
-      expect(MimeTypes.typeFromExtensionOrType('.png', config)).toBe('image/png');
+    test('includes `charset=utf-8` on a non-text MIME type', () => {
+      doTest('image/jpeg');
     });
 
-    test('finds the MIME type of a known text extension, as-is', () => {
-      expect(MimeTypes.typeFromExtensionOrType('.js', config)).toBe('text/javascript');
+    test('includes `charset=utf-8` on a non-text extension', () => {
+      doTest('.png', 'image/png');
     });
 
     test('defaults to `text/plain` given an unknown extension', () => {
-      expect(MimeTypes.typeFromExtensionOrType('.abcdefgXYZ', config)).toBe('text/plain');
+      doTest('.abcdefgXYZ', 'text/plain');
     });
 
     test('preserves a charset if given', () => {
-      const theType = 'text/plain; charset=utf-8';
+      const theType = 'text/plain; charset=zonkers-29';
       expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
     });
   });

--- a/src/net-util/tests/MimeTypes.test.js
+++ b/src/net-util/tests/MimeTypes.test.js
@@ -48,129 +48,6 @@ describe('charSetFromType()', () => {
   });
 });
 
-describe('typeFromPathExtension()', () => {
-  // Failure cases: Wrong argument type.
-  test.each`
-  arg
-  ${null}
-  ${undefined}
-  ${false}
-  ${123}
-  ${['.x']}
-  ${{ a: 10 }}
-  ${new Map()}
-  `('throws given $arg', ({ arg }) => {
-    expect(() => MimeTypes.typeFromPathExtension(arg)).toThrow();
-  });
-
-  // Failure cases: Incorrect syntax (not an absolute path).
-  test.each`
-  arg
-  ${''}
-  ${'txt'}
-  ${'.txt'}
-  ${'foo.txt'}
-  ${'foo/bar.txt'}
-  ${'//foo.txt'}
-  ${'/foo//bar.txt'}
-  ${'/foo/./bar.txt'}
-  ${'/foo/../bar.txt'}
-  ${'/foo/bar.txt/'}
-  `('throws given $arg', ({ arg }) => {
-    expect(() => MimeTypes.typeFromPathExtension(arg)).toThrow(/^Not an absolute path/);
-  });
-
-  describe('with no config argument', () => {
-    test('finds the type given a zero-directory absolute path', () => {
-      expect(MimeTypes.typeFromPathExtension('/boop.tar')).toBe('application/x-tar');
-    });
-
-    test('finds the type given a one-directory absolute path', () => {
-      expect(MimeTypes.typeFromPathExtension('/x/blonk.json')).toBe('application/json');
-    });
-
-    test('finds the type given a zero-directory absolute path with a dot-file', () => {
-      expect(MimeTypes.typeFromPathExtension('/.boop.tar')).toBe('application/x-tar');
-    });
-
-    test('finds the type given a one-directory absolute path with a dot-file', () => {
-      expect(MimeTypes.typeFromPathExtension('/x/.blonk.json')).toBe('application/json');
-    });
-
-    test('defaults to `application/octet-stream`', () => {
-      expect(MimeTypes.typeFromPathExtension('/abc.abcdefgXYZ')).toBe('application/octet-stream');
-    });
-
-    test('returns a value with `charset=utf-8` given a text type', () => {
-      expect(MimeTypes.typeFromPathExtension('/a/b/c.html')).toBe('text/html; charset=utf-8');
-    });
-  });
-
-  describe('with config `{ charSet: null }`', () => {
-    const config = { charSet: null };
-
-    test('does not impact a non-text extension', () => {
-      expect(MimeTypes.typeFromPathExtension('/foo.gif', config)).toBe('image/gif');
-    });
-
-    test('does not include a `charset` in the result from a text extension', () => {
-      expect(MimeTypes.typeFromPathExtension('/bar.text', config)).toBe('text/plain');
-    });
-
-    test('defaults to `application/octet-stream`', () => {
-      expect(MimeTypes.typeFromPathExtension('/florp.abcdefgXYZ', config)).toBe('application/octet-stream');
-    });
-  });
-
-  describe('with config `{ charSet: \'florp\' }`', () => {
-    const config = { charSet: 'florp' };
-
-    test('does not impact a non-text extension', () => {
-      expect(MimeTypes.typeFromPathExtension('/foo.gif', config)).toBe('image/gif');
-    });
-
-    test('alters the result from a text extension', () => {
-      expect(MimeTypes.typeFromPathExtension('/bar.text', config)).toBe('text/plain; charset=florp');
-    });
-
-    test('defaults to `application/octet-stream`', () => {
-      expect(MimeTypes.typeFromPathExtension('/florp.abcdefgXYZ', config)).toBe('application/octet-stream');
-    });
-  });
-
-  describe('with config `{ isText: true }`', () => {
-    const config = { isText: true };
-
-    test('alters an otherwise non-text extension', () => {
-      expect(MimeTypes.typeFromPathExtension('/a/b.gif', config)).toBe('image/gif; charset=utf-8');
-    });
-
-    test('does not impact a text extension', () => {
-      expect(MimeTypes.typeFromPathExtension('/c/d/e.text', config)).toBe('text/plain; charset=utf-8');
-    });
-
-    test('defaults to `text/plain`', () => {
-      expect(MimeTypes.typeFromPathExtension('/bonk/.abcdefgXYZ', config)).toBe('text/plain; charset=utf-8');
-    });
-  });
-
-  describe('with config `{ charSet: \'boop\', isText: true }`', () => {
-    const config = { charSet: 'boop', isText: true };
-
-    test('alters the result from a non-text extension', () => {
-      expect(MimeTypes.typeFromPathExtension('/a.png', config)).toBe('image/png; charset=boop');
-    });
-
-    test('alters the result from a text extension', () => {
-      expect(MimeTypes.typeFromPathExtension('/bb.text', config)).toBe('text/plain; charset=boop');
-    });
-
-    test('defaults to `text/plain` with the configured charset', () => {
-      expect(MimeTypes.typeFromPathExtension('/cc.abcdefgXYZ', config)).toBe('text/plain; charset=boop');
-    });
-  });
-});
-
 describe('typeFromExtensionOrType()', () => {
   // Failure cases: Wrong argument type.
   test.each`
@@ -321,6 +198,129 @@ describe('typeFromExtensionOrType()', () => {
     test('preserves a charset if given', () => {
       const theType = 'text/plain; charset=utf-8';
       expect(MimeTypes.typeFromExtensionOrType(theType, config)).toBe(theType);
+    });
+  });
+});
+
+describe('typeFromPathExtension()', () => {
+  // Failure cases: Wrong argument type.
+  test.each`
+  arg
+  ${null}
+  ${undefined}
+  ${false}
+  ${123}
+  ${['.x']}
+  ${{ a: 10 }}
+  ${new Map()}
+  `('throws given $arg', ({ arg }) => {
+    expect(() => MimeTypes.typeFromPathExtension(arg)).toThrow();
+  });
+
+  // Failure cases: Incorrect syntax (not an absolute path).
+  test.each`
+  arg
+  ${''}
+  ${'txt'}
+  ${'.txt'}
+  ${'foo.txt'}
+  ${'foo/bar.txt'}
+  ${'//foo.txt'}
+  ${'/foo//bar.txt'}
+  ${'/foo/./bar.txt'}
+  ${'/foo/../bar.txt'}
+  ${'/foo/bar.txt/'}
+  `('throws given $arg', ({ arg }) => {
+    expect(() => MimeTypes.typeFromPathExtension(arg)).toThrow(/^Not an absolute path/);
+  });
+
+  describe('with no config argument', () => {
+    test('finds the type given a zero-directory absolute path', () => {
+      expect(MimeTypes.typeFromPathExtension('/boop.tar')).toBe('application/x-tar');
+    });
+
+    test('finds the type given a one-directory absolute path', () => {
+      expect(MimeTypes.typeFromPathExtension('/x/blonk.json')).toBe('application/json');
+    });
+
+    test('finds the type given a zero-directory absolute path with a dot-file', () => {
+      expect(MimeTypes.typeFromPathExtension('/.boop.tar')).toBe('application/x-tar');
+    });
+
+    test('finds the type given a one-directory absolute path with a dot-file', () => {
+      expect(MimeTypes.typeFromPathExtension('/x/.blonk.json')).toBe('application/json');
+    });
+
+    test('defaults to `application/octet-stream`', () => {
+      expect(MimeTypes.typeFromPathExtension('/abc.abcdefgXYZ')).toBe('application/octet-stream');
+    });
+
+    test('returns a value with `charset=utf-8` given a text type', () => {
+      expect(MimeTypes.typeFromPathExtension('/a/b/c.html')).toBe('text/html; charset=utf-8');
+    });
+  });
+
+  describe('with config `{ charSet: null }`', () => {
+    const config = { charSet: null };
+
+    test('does not impact a non-text extension', () => {
+      expect(MimeTypes.typeFromPathExtension('/foo.gif', config)).toBe('image/gif');
+    });
+
+    test('does not include a `charset` in the result from a text extension', () => {
+      expect(MimeTypes.typeFromPathExtension('/bar.text', config)).toBe('text/plain');
+    });
+
+    test('defaults to `application/octet-stream`', () => {
+      expect(MimeTypes.typeFromPathExtension('/florp.abcdefgXYZ', config)).toBe('application/octet-stream');
+    });
+  });
+
+  describe('with config `{ charSet: \'florp\' }`', () => {
+    const config = { charSet: 'florp' };
+
+    test('does not impact a non-text extension', () => {
+      expect(MimeTypes.typeFromPathExtension('/foo.gif', config)).toBe('image/gif');
+    });
+
+    test('alters the result from a text extension', () => {
+      expect(MimeTypes.typeFromPathExtension('/bar.text', config)).toBe('text/plain; charset=florp');
+    });
+
+    test('defaults to `application/octet-stream`', () => {
+      expect(MimeTypes.typeFromPathExtension('/florp.abcdefgXYZ', config)).toBe('application/octet-stream');
+    });
+  });
+
+  describe('with config `{ isText: true }`', () => {
+    const config = { isText: true };
+
+    test('alters an otherwise non-text extension', () => {
+      expect(MimeTypes.typeFromPathExtension('/a/b.gif', config)).toBe('image/gif; charset=utf-8');
+    });
+
+    test('does not impact a text extension', () => {
+      expect(MimeTypes.typeFromPathExtension('/c/d/e.text', config)).toBe('text/plain; charset=utf-8');
+    });
+
+    test('defaults to `text/plain`', () => {
+      expect(MimeTypes.typeFromPathExtension('/bonk/.abcdefgXYZ', config)).toBe('text/plain; charset=utf-8');
+    });
+  });
+
+  describe('with config `{ charSet: \'boop\', isText: true }`', () => {
+    const config = { charSet: 'boop', isText: true };
+
+    test('alters the result from a non-text extension', () => {
+      expect(MimeTypes.typeFromPathExtension('/a.png', config)).toBe('image/png; charset=boop');
+    });
+
+    test('alters the result from a text extension', () => {
+      expect(MimeTypes.typeFromPathExtension('/bb.text', config)).toBe('text/plain; charset=boop');
+    });
+
+    test('defaults to `text/plain` with the configured charset', () => {
+      expect(MimeTypes.typeFromPathExtension('/cc.abcdefgXYZ', config)).toBe('text/plain; charset=boop');
     });
   });
 });


### PR DESCRIPTION
This PR makes it so that the `MimeTypes` methods that return MIME types default to reporting `charset=utf-8` unless overridden by an option. The default used to be `charSet: null` (that is, don't ever add `charset`s), which meant that, in practice, a bunch of code had to explicitly say `charSet: 'utf-8'`. It's much cleaner now.