### PR TITLE
Yet more time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ versioning principles. Unstable releases do not.
 
 Breaking changes:
 * Configuration:
-  * Most configurations that used to accept plain numbers as durations in
-    seconds now instead take either duration strings that include a unit name
-    _or_ instances of the class `data-values.Duration`.
+  * Configurations that used to accept plain numbers as durations in seconds now
+    instead take either duration strings that include a unit name (e.g.,
+    `5 min`) _or_ instances of the class `data-values.Duration`.
+  * Likewise, the `flowRate` for `RateLimiter` is now expected to be either a
+    frequency string (e.g., `100 per hr` or `12/minute`) _or_ an instance of the
+    class `data-values.Frequency`.
 * `net-util`:
   * `MimeTypes` methods that return MIME type strings now default have the
     default option `charSet: 'utf-8'`, which is about the most sensible default

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -359,16 +359,15 @@ period to allow momentary usage spikes. It accepts the following configuration
 bindings:
 
 * `checkPeriod` &mdash; How often to check for memory usage being over the
-  defined limit, specified as a duration value as described in [Specifying
-  durations](#specifying-durations). Optional. Minimum `1` (which is frankly way
-  too often). Default `5 min` (that is, once every five minutes).
+  defined limit, specified as a duration value as described in
+  [Durations](#durations). Optional. Minimum `1` (which is frankly way too
+  often). Default `5 min` (that is, once every five minutes).
 * `gracePeriod` &mdash; Once a memory limit has been reached, how long it is
   allowed to remain at or beyond the maximum before this service takes action,
-  specified as a duration value as described in [Specifying
-  durations](#specifying-durations). `0` (or `null`) to not have a grace period
-  at all. Default `0`. **Note:**: When in the middle of a grace period, the
-  service will check memory usage more often than `checkPeriod` so as not to
-  miss a significant dip.
+  specified as a duration value as described in [Durations](#durations). `0` (or
+  `null`) to not have a grace period at all. Default `0`. **Note:**: When in the
+  middle of a grace period, the service will check memory usage more often than
+  `checkPeriod` so as not to miss a significant dip.
 * `maxHeapBytes` &mdash; How many bytes of heap is considered "over limit," or
   `null` for no limit on this. The amount counted is `heapTotal + external` from
   `process.memoryUsage()`. Defaults to `null`. **Note:** In order to catch
@@ -406,11 +405,10 @@ optionally on a periodic basis. It accepts the following configuration bindings:
   is read first and any process IDs found in it are kept if they are in fact
   still running.
 * `updatePeriod` &mdash; How long to wait between each file update, specified as
-  a duration value as described in [Specifying
-  durations](#specifying-durations), or `null` to indicate "never." Optional and
-  defaults to `null`. If specified, the value must be at least one second (so as
-  to prevent excessive churn). This value is only meaningfully used when
-  `multiprocess` is `true`.
+  a duration value as described in [Durations](#durations), or `null` to
+  indicate "never." Optional and defaults to `null`. If specified, the value
+  must be at least one second (so as to prevent excessive churn). This value is
+  only meaningfully used when `multiprocess` is `true`.
 
 ```js
 const services = [
@@ -435,10 +433,10 @@ configuration bindings:
 * `path` &mdash; Path to the file, with the final path component modified by
   infixing the process ID.
 * `updatePeriod` &mdash; How long to wait between each file update while the
-  system is running, specified as a duration value as described in [Specifying
-  durations](#specifying-durations), or `null` to indicate "never." Optional and
-  defaults to `null`. If specified, the value must be at least one second (so as
-  to prevent excessive churn).
+  system is running, specified as a duration value as described in
+  [Durations](#durations), or `null` to indicate "never." Optional and defaults
+  to `null`. If specified, the value must be at least one second (so as to
+  prevent excessive churn).
 * `save` &mdash; Optional file preservation configuration. If not specified, no
   file preservation is done.
 
@@ -470,10 +468,8 @@ a request), and `data` (token unit, a byte). Each of these is configured as an
 object with the following bindings:
 
 * `flowRate` &mdash; The rate of token flow once any burst capacity is
-  exhausted.
-* `timeUnit` &mdash; The time unit of `flowRate`. This can be any of the
-  following: `day` (defined here as 24 hours), `hour`, `minute`, `second`, or
-  `msec` (millisecond).
+  exhausted, specified as a frequency value as described in
+  [Frequencies](#frequencies).
 * `maxBurstSize` &mdash; The maximum allowed "burst" of tokens before
   rate-limiting takes effect.
 * `maxQueueSize` &mdash; Optional maximum possible size of the wait queue, in
@@ -493,8 +489,7 @@ const services = [
     class: 'RateLimiter',
     connections: {
       maxBurstSize: 5,
-      flowRate:     1,
-      timeUnit:     'second',
+      flowRate:     '1 per second',
       maxQueueSize: 15
     },
     requests: { /* ... */ },
@@ -563,10 +558,10 @@ const services = [
 This section documents the configuration objects that are used within top-level
 configurations.
 
-### Specifying durations and rates/frequencies
+### Specifying durations and frequencies/rates
 
 Several configurations are specified as either time durations or
-rates/frequencies. These can be specified as instances of the utility classes
+frequencies/rates. These can be specified as instances of the utility classes
 `data-values.Duration` and `data-values.Frequency` (respectively), or they can
 be specified as unit quantity strings, which include a number and a unit name,
 e.g. durations `1 day` or `1_000ms`, or frequencies `123 per sec` or `5/day`.
@@ -578,24 +573,29 @@ underscore, or they can just be directly next to each other. The frequency units
 can be indicated either with a leading slash (e.g., `5 / min`) or with the word
 `per` (e.g. `72 per hr`).
 
-The available units are:
+#### Durations
 
-* Durations
-  * `nsec` or `ns` &mdash; Nanoseconds.
-  * `usec` or `us` &mdash; Microseconds.
-  * `msec` or `ms` &mdash; Milliseconds.
-  * `sec` or `s` &mdash; Seconds.
-  * `min` or `m` &mdash; Minutes.
-  * `hr` or `h` &mdash; Hours.
-  * `day` or `d` &mdash; Days, where a "day" is defined to be exactly 24 hours.
-* Frequencies
-  * `/nsec` or `/ns` &mdash; Per nanosecond.
-  * `/usec` or `/us` &mdash; Per microsecond.
-  * `/msec` or `/ms` &mdash; Per millisecond.
-  * `/sec` or `/s` &mdash; Per second.
-  * `/min` or `/m` &mdash; Per minute.
-  * `/hr` or `/h` &mdash; Per hour.
-  * `/day` or `/d` &mdash; Per (24-hour) day.
+The available units for durations are:
+
+* `nsec` or `ns` &mdash; Nanoseconds.
+* `usec` or `us` &mdash; Microseconds.
+* `msec` or `ms` &mdash; Milliseconds.
+* `sec` or `s` &mdash; Seconds.
+* `min` or `m` &mdash; Minutes.
+* `hr` or `h` &mdash; Hours.
+* `day` or `d` &mdash; Days, where a "day" is defined to be exactly 24 hours.
+
+#### Frequencies
+
+The available units for frequencies are:
+
+* `/nsec` or `/ns` &mdash; Per nanosecond.
+* `/usec` or `/us` &mdash; Per microsecond.
+* `/msec` or `/ms` &mdash; Per millisecond.
+* `/sec` or `/s` &mdash; Per second.
+* `/min` or `/m` &mdash; Per minute.
+* `/hr` or `/h` &mdash; Per hour.
+* `/day` or `/d` &mdash; Per (24-hour) day.
 
 ### Cache control configuration: `cacheControl`
 
@@ -615,7 +615,7 @@ names (e.g. `noStore` for `no-store`). Values can be:
 * For present-vs-absent header values, such as `public` and `no-cache`:
   * A `boolean`, in which case `true` includes the value and `false` omits it.
 * For duration values:
-  * A duration as described in [Specifying durations](#specifying-durations).
+  * A duration as described in [Durations](#durations).
 
 ### ETag Configuration: `etag`
 
@@ -656,11 +656,10 @@ following bindings:
   greater. Optional, and if not specified (or if `null`), does not rotate based
   on size.
 * `checkPeriod` &mdash; How often to check for a rotation condition, specified
-  as a duration value as described in [Specifying
-  durations](#specifying-durations), or `null` to indicate "never check."
-  Optional and defaults to `5 min`. If specified, the value must be at least one
-  second (so as to prevent excessive churn). This is only meaningful if `atSize`
-  is also specified.
+  as a duration value as described in [Durations](#durations), or `null` to
+  indicate "never check." Optional and defaults to `5 min`. If specified, the
+  value must be at least one second (so as to prevent excessive churn). This is
+  only meaningful if `atSize` is also specified.
 * `maxOldBytes` &mdash; How many bytes' worth of old (post-rotation) files
   should be allowed, or `null` not to have a limit. The oldest files over the
   limit get deleted after a rotation.Optional, and defaults to `null`.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -563,26 +563,39 @@ const services = [
 This section documents the configuration objects that are used within top-level
 configurations.
 
-### Specifying durations
+### Specifying durations and rates/frequencies
 
-Several configurations are specified as time durations. These can either be an
-instance of the utility class `data-values.Duration` or a string in a format
-that includes a number followed by a unit name., e.g. `1 day`, `1_000ms`, or
-`1200.5_min`.
+Several configurations are specified as either time durations or
+rates/frequencies. These can be specified as instances of the utility classes
+`data-values.Duration` and `data-values.Frequency` (respectively), or they can
+be specified as unit quantity strings, which include a number and a unit name,
+e.g. durations `1 day` or `1_000ms`, or frequencies `123 per sec` or `5/day`.
 
 For the string form, the numeric portion is allowed to be any usual-format
 floating point number, including exponents, and including internal underscores
 for readability. The number and unit can be separated with either a space or an
-underscore, or they can just be directly next to each other. The available units
-are:
+underscore, or they can just be directly next to each other. The frequency units
+can be indicated either with a leading slash (e.g., `5 / min`) or with the word
+`per` (e.g. `72 per hr`).
 
-* `nsec` or `ns` &mdash; Nanoseconds.
-* `usec` or `us` &mdash; Microseconds.
-* `msec` or `ms` &mdash; Milliseconds.
-* `sec` or `s` &mdash; Seconds.
-* `min` or `m` &mdash; Minutes.
-* `hr` or `h` &mdash; Hours.
-* `day` or `d` &mdash; Days, where a "day" is defined to be exactly 24 hours.
+The available units are:
+
+* Durations
+  * `nsec` or `ns` &mdash; Nanoseconds.
+  * `usec` or `us` &mdash; Microseconds.
+  * `msec` or `ms` &mdash; Milliseconds.
+  * `sec` or `s` &mdash; Seconds.
+  * `min` or `m` &mdash; Minutes.
+  * `hr` or `h` &mdash; Hours.
+  * `day` or `d` &mdash; Days, where a "day" is defined to be exactly 24 hours.
+* Frequencies
+  * `/nsec` or `/ns` &mdash; Per nanosecond.
+  * `/usec` or `/us` &mdash; Per microsecond.
+  * `/msec` or `/ms` &mdash; Per millisecond.
+  * `/sec` or `/s` &mdash; Per second.
+  * `/min` or `/m` &mdash; Per minute.
+  * `/hr` or `/h` &mdash; Per hour.
+  * `/day` or `/d` &mdash; Per (24-hour) day.
 
 ### Cache control configuration: `cacheControl`
 

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -108,8 +108,8 @@ const services = [
       maxQueueSize: 100
     },
     data: {
-      maxBurstSize:      1024 * 1024,      // 1MB.
-      flowRate:          100 * 1024,       // 100kB.
+      maxBurstSize:      1024 * 1024,     // 1MB.
+      flowRate:          100 * 1024,      // 100kB.
       timeUnit:          'second',
       maxQueueGrantSize: 50 * 1024,       // 50kB.
       maxQueueSize:      2 * 1024 * 1024  // 2MB.

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -97,22 +97,19 @@ const services = [
     class:       'RateLimiter',
     connections: {
       maxBurstSize: 10,
-      flowRate:     3,
-      timeUnit:     'second',
+      flowRate:     '3 per sec',
       maxQueueSize: 25
     },
     requests: {
       maxBurstSize: 20,
-      flowRate:     10,
-      timeUnit:     'second',
+      flowRate:     '600 per min',
       maxQueueSize: 100
     },
     data: {
-      maxBurstSize:      1024 * 1024,     // 1MB.
-      flowRate:          100 * 1024,      // 100kB.
-      timeUnit:          'second',
-      maxQueueGrantSize: 50 * 1024,       // 50kB.
-      maxQueueSize:      2 * 1024 * 1024  // 2MB.
+      maxBurstSize:      1024 * 1024,           // 1MB.
+      flowRate:          `${100 * 1024} / sec`, // 100kB.
+      maxQueueGrantSize: 50 * 1024,             // 50kB.
+      maxQueueSize:      2 * 1024 * 1024        // 2MB.
     }
   }
 ];

--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -88,36 +88,34 @@ export class TokenBucket {
    *   rate), that is, how quickly the bucket gets filled, in tokens per second.
    *   This defines the steady state "flow rate" allowed by the instance. Must
    *   be a finite positive number. This is a required "option."
-   * @param {number} [options.initialBurstSize] The
-   *   instantaneously available burst size, in tokens, at the moment of
-   *   construction. Defaults to `maxBurstSize` (that is, able to be maximally
-   *   "bursted" from the get-go).
+   * @param {number} [options.initialBurstSize] The instantaneously available
+   *   burst size, in tokens, at the moment of construction. Defaults to
+   *   `maxBurstSize` (that is, able to be maximally "bursted" from the get-go).
    * @param {number} options.maxBurstSize Maximum possible instantaneous burst
    *   size (that is, the total bucket capacity in the "leaky bucket as meter"
    *   metaphor), in tokens (arbitrary volume units). This defines the
    *   "burstiness" allowed by the instance. Must be a finite positive number.
    *   This is a required "option."
-   * @param {number} [options.maxQueueGrantSize] Maximum
-   *   grant size when granting requests from the waiter queue, in tokens. No
-   *   queued grant requests will ever return a larger grant, even if there is
-   *   available "burst volume" to accommodate it. Must be a finite non-negative
-   *   number less than or equal to both `maxBurstSize` and `maxQueueSize`, or
-   *   `null` to indicate the default. If `partialTokens === false`, then the
-   *   value is rounded down to an integer by `Math.floor()`. If `0`, then this
-   *   instance will only ever synchronously grant tokens. Defaults to the
-   *   smaller of `maxBurstSize` or `maxQueueSize`.
-   * @param {?number} [options.maxQueueSize] The maximum allowed waiter
-   *   queue size, in tokens. Must be a finite non-negative number or `null`.
-   *   If `null`, then there is no limit on the queue size. If `0`, then this
+   * @param {number} [options.maxQueueGrantSize] Maximum grant size when
+   *   granting requests from the waiter queue, in tokens. No queued grant
+   *   requests will ever return a larger grant, even if there is available
+   *   "burst volume" to accommodate it. Must be a finite non-negative number
+   *   less than or equal to both `maxBurstSize` and `maxQueueSize`, or `null`
+   *   to indicate the default. If `partialTokens === false`, then the value is
+   *   rounded down to an integer by `Math.floor()`. If `0`, then this instance
+   *   will only ever synchronously grant tokens. Defaults to the smaller of
+   *   `maxBurstSize` or `maxQueueSize`.
+   * @param {?number} [options.maxQueueSize] The maximum allowed waiter queue
+   *   size, in tokens. Must be a finite non-negative number or `null`. If
+   *   `null`, then there is no limit on the queue size. If `0`, then this
    *   instance will only ever synchronously grant tokens.
-   * @param {boolean} [options.partialTokens] If `true`, allows the
-   *   instance to provide partial tokens (e.g. give a client `1.25` tokens). If
-   *   `false`, all token handoffs from the instance are quantized to integer
-   *   values.
-   * @param {IntfTimeSource} options.timeSource What to use to
-   *   determine the passage of time. If not specified, the instance will use a
-   *   standard implementation which measures time in seconds (_not_ msec) and
-   *   bottoms out at the usual JavaScript / Node wall time interface (e.g.
+   * @param {boolean} [options.partialTokens] If `true`, allows the instance to
+   *   provide partial tokens (e.g. give a client `1.25` tokens). If `false`,
+   *   all token handoffs from the instance are quantized to integer values.
+   * @param {IntfTimeSource} options.timeSource What to use to determine the
+   *   passage of time. If not specified, the instance will use a standard
+   *   implementation which measures time in seconds (_not_ msec) and bottoms
+   *   out at the usual JavaScript / Node wall time interface (e.g.
    *   `Date.now()`, `timers.setTimeout()`).
    */
   constructor(options) {

--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -101,11 +101,11 @@ export class TokenBucket {
    *   grant size when granting requests from the waiter queue, in tokens. No
    *   queued grant requests will ever return a larger grant, even if there is
    *   available "burst volume" to accommodate it. Must be a finite non-negative
-   *   number less than or equal to both `maxBurstSize` and `maxQueueSize`. If
-   *   `partialTokens === false`, then this is rounded down to an integer by
-   *   `Math.floor()`. If `0`, then this instance will only ever synchronously
-   *   grant tokens. Defaults to the smaller of `maxBurstSize` or
-   *   `maxQueueSize`.
+   *   number less than or equal to both `maxBurstSize` and `maxQueueSize`, or
+   *   `null` to indicate the default. If `partialTokens === false`, then the
+   *   value is rounded down to an integer by `Math.floor()`. If `0`, then this
+   *   instance will only ever synchronously grant tokens. Defaults to the
+   *   smaller of `maxBurstSize` or `maxQueueSize`.
    * @param {?number} [options.maxQueueSize] The maximum allowed waiter
    *   queue size, in tokens. Must be a finite non-negative number or `null`.
    *   If `null`, then there is no limit on the queue size. If `0`, then this
@@ -125,7 +125,7 @@ export class TokenBucket {
       flowRatePerSec,
       initialBurstSize  = options.maxBurstSize,
       maxBurstSize,
-      maxQueueGrantSize,
+      maxQueueGrantSize = null,
       maxQueueSize      = null,
       partialTokens     = false,
       timeSource        = TokenBucket.#DEFAULT_TIME_SOURCE
@@ -141,7 +141,7 @@ export class TokenBucket {
       : MustBe.number(maxQueueSize, { finite: true, minInclusive: 0 });
 
     const queueGrantLimit = Math.min(this.#maxBurstSize, this.#maxQueueSize);
-    if (maxQueueGrantSize === undefined) {
+    if (maxQueueGrantSize === null) {
       this.#maxQueueGrantSize = queueGrantLimit;
     } else {
       this.#maxQueueGrantSize = MustBe.number(maxQueueGrantSize,

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -322,7 +322,6 @@ describe('constructor(<invalid>)', () => {
 
   test.each`
     maxQueueGrantSize
-    ${null}
     ${true}
     ${'123'}
     ${[123]}

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -4,9 +4,26 @@
 import * as timers from 'node:timers/promises';
 
 import { ManualPromise, PromiseState, TokenBucket } from '@this/async';
-import { Duration, Moment } from '@this/data-values';
+import { Duration, Frequency, Moment } from '@this/data-values';
 import { IntfTimeSource, StdTimeSource } from '@this/metacomp';
 
+/** @type {Frequency} One per second, used as a `flowRate`. */
+const FLOW_1 = new Frequency(1);
+
+/** @type {Frequency} Five per second, used as a `flowRate`. */
+const FLOW_5 = new Frequency(5);
+
+/** @type {Frequency} Ten per second, used as a `flowRate`. */
+const FLOW_10 = new Frequency(10);
+
+/** @type {Frequency} 13 per second, used as a `flowRate`. */
+const FLOW_13 = new Frequency(13);
+
+/** @type {Frequency} Tiny value, used as a `flowRate`. */
+const FLOW_TINY = new Frequency(0.00001);
+
+/** @type {Frequency} Big value, used as a `flowRate`. */
+const FLOW_BIG = new Frequency(321 * 1024 * 1024);
 
 /**
  * Helper to check grant return values from `requestGrant()`.
@@ -118,42 +135,42 @@ class MockTimeSource extends IntfTimeSource {
 describe('constructor()', () => {
   test.each`
     opts
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1 }}
-    ${{ flowRatePerSec: 0.0001, maxBurstSize: 0.01 }}
-    ${{ flowRatePerSec: 109,    maxBurstSize: 200000 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     initialBurstSize: 0 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     initialBurstSize: 1 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 10,    initialBurstSize: 10 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 10,    initialBurstSize: 9 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueGrantSize: 0 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueGrantSize: 0.1 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueGrantSize: 1 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 100,   maxQueueGrantSize: 1 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 100,   maxQueueGrantSize: 50 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 100,   maxQueueGrantSize: 99 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueSize: 1000 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueSize: 0 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueSize: 1 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     maxQueueSize: 12.34 }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     partialTokens: false }}
-    ${{ flowRatePerSec: 12.3,   maxBurstSize: 123.4, partialTokens: false }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     partialTokens: true }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     timeSource: new StdTimeSource() }}
-    ${{ flowRatePerSec: 1,      maxBurstSize: 1,     timeSource: new MockTimeSource() }}
-    ${{ flowRatePerSec: 1, maxBurstSize: 1, initialBurstSize: 0.5, maxQueueGrantSize: 0.5,
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1 }}
+    ${{ flowRate: FLOW_TINY, maxBurstSize: 0.01 }}
+    ${{ flowRate: FLOW_BIG,  maxBurstSize: 200000 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     initialBurstSize: 0 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     initialBurstSize: 1 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 10,    initialBurstSize: 10 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 10,    initialBurstSize: 9 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     maxQueueGrantSize: 0 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     maxQueueGrantSize: 0.1 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     maxQueueGrantSize: 1 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 100,   maxQueueGrantSize: 1 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 100,   maxQueueGrantSize: 50 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 100,   maxQueueGrantSize: 99 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     maxQueueSize: 1000 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     maxQueueSize: 0 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     maxQueueSize: 1 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     maxQueueSize: 12.34 }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     partialTokens: false }}
+    ${{ flowRate: FLOW_BIG,  maxBurstSize: 123.4, partialTokens: false }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     partialTokens: true }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     timeSource: new StdTimeSource() }}
+    ${{ flowRate: FLOW_1,    maxBurstSize: 1,     timeSource: new MockTimeSource() }}
+    ${{ flowRate: FLOW_1, maxBurstSize: 1, initialBurstSize: 0.5, maxQueueGrantSize: 0.5,
         maxQueueSize: 10, partialTokens: true, timeSource: new MockTimeSource() }}
   `('trivially accepts valid options: $opts', ({ opts }) => {
     expect(() => new TokenBucket(opts)).not.toThrow();
   });
 
   test('produces an instance with the `maxBurstSize` that was passed', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 123 });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 123 });
     expect(bucket.config.maxBurstSize).toBe(123);
   });
 
-  test('produces an instance with the `flowRatePerSec` that was passed', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1234, maxBurstSize: 100000 });
-    expect(bucket.config.flowRatePerSec).toBe(1234);
+  test('produces an instance with the `flowRate` that was passed', () => {
+    const bucket = new TokenBucket({ flowRate: FLOW_BIG, maxBurstSize: 100000 });
+    expect(bucket.config.flowRate.hertz).toBe(FLOW_BIG.hertz);
   });
 
   test.each`
@@ -163,18 +180,18 @@ describe('constructor()', () => {
     ${1}              | ${false}
     ${200}            | ${false}
   `('produces an instance with the `maxQueueGrantSize` that was passed: $maxQueueGrantSize', ({ maxQueueGrantSize, partialTokens }) => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1000, maxQueueGrantSize, partialTokens });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1000, maxQueueGrantSize, partialTokens });
     expect(bucket.config.maxQueueGrantSize).toBe(maxQueueGrantSize);
   });
 
   test('rounds down a fractional `maxQueueGrantSize` if `partialTokens === false`', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1000,
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1000,
       maxQueueGrantSize: 12.9, partialTokens: false });
     expect(bucket.config.maxQueueGrantSize).toBe(12);
   });
 
   test('has `maxQueueGrantSize === maxBurstSize` if not passed `maxQueueGrantSize`', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 10203 });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 10203 });
     expect(bucket.config.maxQueueGrantSize).toBe(10203);
   });
 
@@ -185,12 +202,12 @@ describe('constructor()', () => {
     ${1.5}
     ${10}
   `('produces an instance with the `maxQueueSize` that was passed: $maxQueueSize', ({ maxQueueSize }) => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, maxQueueSize });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1, maxQueueSize });
     expect(bucket.config.maxQueueSize).toBe(maxQueueSize);
   });
 
   test('has `maxQueueSize === null` if not passed', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1 });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1 });
     expect(bucket.config.maxQueueSize).toBeNull();
   });
 
@@ -199,54 +216,54 @@ describe('constructor()', () => {
     ${false}
     ${true}
   `('produces an instance with the `partialTokens` that was passed: $partialTokens', ({ partialTokens }) => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, partialTokens });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1, partialTokens });
     expect(bucket.config.partialTokens).toBe(partialTokens);
   });
 
   test('has `partialTokens === false` if not passed', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1 });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1 });
     expect(bucket.config.partialTokens).toBeFalse();
   });
 
   test('produces an instance which uses the `timeSource` that was passed', () => {
     const ts = new MockTimeSource(321);
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, timeSource: ts });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1, timeSource: ts });
     expect(bucket.config.timeSource).toBe(ts);
     expect(bucket.latestState().now.atSec).toBe(321);
   });
 
   test('produces an instance which (apparently) uses the default time source if not passed `timeSource`', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1 });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1 });
     expect(bucket.config.timeSource).toBeNull();
   });
 
   test('produces an instance with `availableBurstSize` equal to the passed `initialBurstSize`', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 100, initialBurstSize: 23 });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 100, initialBurstSize: 23 });
     expect(bucket.latestState().availableBurstSize).toBe(23);
   });
 
   test('has `availableBurstSize === maxBurstSize` if not passed `initialBurstSize`', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 123 });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 123 });
     expect(bucket.latestState().availableBurstSize).toBe(123);
   });
 
   test('produces an instance with `availableQueueSize === infinity` if passed `maxQueueSize === null`', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 100, maxQueueSize: null });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 100, maxQueueSize: null });
     expect(bucket.latestState().availableQueueSize).toBe(Number.POSITIVE_INFINITY);
   });
 
   test('produces an instance with `availableQueueSize === infinity` if not passed `maxQueueSize`', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 100 });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 100 });
     expect(bucket.latestState().availableQueueSize).toBe(Number.POSITIVE_INFINITY);
   });
 
   test('produces an instance with `availableQueueSize === maxQueueSize` for finite `maxQueueSize`', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 100, maxQueueSize: 9876 });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 100, maxQueueSize: 9876 });
     expect(bucket.latestState().availableQueueSize).toBe(9876);
   });
 
   test('produces an instance with no waiters', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 100 });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 100 });
     expect(bucket.latestState().waiterCount).toBe(0);
   });
 });
@@ -264,10 +281,10 @@ describe('constructor(<invalid>)', () => {
   });
 
   test('rejects missing `maxBurstSize`', () => {
-    expect(() => new TokenBucket({ flowRatePerSec: 1 })).toThrow();
+    expect(() => new TokenBucket({ flowRate: FLOW_1 })).toThrow();
   });
 
-  test('rejects missing `flowRatePerSec`', () => {
+  test('rejects missing `flowRate`', () => {
     expect(() => new TokenBucket({ maxBurstSize: 1 })).toThrow();
   });
 
@@ -284,11 +301,11 @@ describe('constructor(<invalid>)', () => {
     ${NaN}
     ${Number.POSITIVE_INFINITY}
   `('rejects invalid `maxBurstSize`: $maxBurstSize', ({ maxBurstSize }) => {
-    expect(() => new TokenBucket({ maxBurstSize, flowRatePerSec: 1 })).toThrow();
+    expect(() => new TokenBucket({ maxBurstSize, flowRate: FLOW_1 })).toThrow();
   });
 
   test.each`
-    flowRatePerSec
+    flowRate
     ${undefined}
     ${null}
     ${true}
@@ -299,8 +316,8 @@ describe('constructor(<invalid>)', () => {
     ${0}
     ${NaN}
     ${Number.POSITIVE_INFINITY}
-  `('rejects invalid `flowRatePerSec`: $flowRatePerSec', ({ flowRatePerSec }) => {
-    expect(() => new TokenBucket({ flowRatePerSec, maxBurstSize: 1 })).toThrow();
+  `('rejects invalid `flowRate`: $flowRate', ({ flowRate }) => {
+    expect(() => new TokenBucket({ flowRate, maxBurstSize: 1 })).toThrow();
   });
 
   test.each`
@@ -312,12 +329,12 @@ describe('constructor(<invalid>)', () => {
     ${-1}
     ${-0.1}
   `('rejects invalid `initialBurstSize`: $initialBurstSize', ({ initialBurstSize }) => {
-    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, initialBurstSize })).toThrow();
+    expect(() => new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1, initialBurstSize })).toThrow();
   });
 
   test('rejects invalid `initialBurstSize` (`> maxBurstSize`)', () => {
-    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, initialBurstSize: 1.01 })).toThrow();
-    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, initialBurstSize: 2 })).toThrow();
+    expect(() => new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1, initialBurstSize: 1.01 })).toThrow();
+    expect(() => new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1, initialBurstSize: 2 })).toThrow();
   });
 
   test.each`
@@ -328,18 +345,18 @@ describe('constructor(<invalid>)', () => {
     ${-1}
     ${-0.1}
   `('rejects invalid `maxQueueGrantSize`: $maxQueueGrantSize', ({ maxQueueGrantSize }) => {
-    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1000, maxQueueGrantSize })).toThrow();
+    expect(() => new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1000, maxQueueGrantSize })).toThrow();
   });
 
   test('rejects invalid `maxQueueGrantSize` (`> maxQueueSize`)', () => {
     expect(() => new TokenBucket(
-      { flowRatePerSec: 1, maxBurstSize: 10, maxQueueSize: 5, maxQueueGrantSize: 6 }
+      { flowRate: FLOW_1, maxBurstSize: 10, maxQueueSize: 5, maxQueueGrantSize: 6 }
     )).toThrow();
   });
 
   test('rejects invalid `maxQueueGrantSize` (`> maxBurstSize`)', () => {
-    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, maxQueueGrantSize: 1.01 })).toThrow();
-    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, maxQueueGrantSize: 2 })).toThrow();
+    expect(() => new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1, maxQueueGrantSize: 1.01 })).toThrow();
+    expect(() => new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1, maxQueueGrantSize: 2 })).toThrow();
   });
 
   test.each`
@@ -350,7 +367,7 @@ describe('constructor(<invalid>)', () => {
     ${-1}
     ${Number.POSITIVE_INFINITY}
   `('rejects invalid `maxQueueSize`: $maxQueueSize', ({ maxQueueSize }) => {
-    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, maxQueueSize })).toThrow();
+    expect(() => new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1, maxQueueSize })).toThrow();
   });
 
   test.each`
@@ -360,7 +377,7 @@ describe('constructor(<invalid>)', () => {
     ${[false]}
     ${0}
   `('rejects invalid `partialTokens`: $partialTokens', ({ partialTokens }) => {
-    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, partialTokens })).toThrow();
+    expect(() => new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1, partialTokens })).toThrow();
   });
 
   test.each`
@@ -371,15 +388,15 @@ describe('constructor(<invalid>)', () => {
     ${IntfTimeSource /* supposed to be an instance, not a class */}
     ${MockTimeSource /* ditto */}
   `('rejects invalid `timeSource`: $timeSource', ({ timeSource }) => {
-    expect(() => new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 1, timeSource })).toThrow();
+    expect(() => new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 1, timeSource })).toThrow();
   });
 });
 
 describe('.config', () => {
   test('has exactly the expected properties', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 123, maxBurstSize: 100000 });
+    const bucket = new TokenBucket({ flowRate: FLOW_TINY, maxBurstSize: 100000 });
     expect(bucket.config).toContainAllKeys([
-      'flowRatePerSec', 'maxBurstSize', 'maxQueueGrantSize', 'maxQueueSize',
+      'flowRate', 'maxBurstSize', 'maxQueueGrantSize', 'maxQueueSize',
       'partialTokens', 'timeSource'
     ]);
   });
@@ -389,7 +406,7 @@ describe('denyAllRequests()', () => {
   test('causes pending grant requests to in fact be denied', async () => {
     const time   = new MockTimeSource(10000);
     const bucket = new TokenBucket({
-      flowRatePerSec: 1, maxBurstSize: 1000, initialBurstSize: 0, timeSource: time });
+      flowRate: FLOW_1, maxBurstSize: 1000, initialBurstSize: 0, timeSource: time });
 
     // Setup / baseline assumptions.
     const result1 = bucket.requestGrant(1);
@@ -425,7 +442,7 @@ describe('requestGrant()', () => {
     test('synchronously grants a request that can be satisfied', async () => {
       const time   = new MockTimeSource(9001);
       const bucket = new TokenBucket({
-        flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 123, timeSource: time });
+        flowRate: FLOW_1, maxBurstSize: 10000, initialBurstSize: 123, timeSource: time });
 
       const result = bucket.requestGrant(123);
       expect(bucket.latestState().availableBurstSize).toBe(0);
@@ -438,7 +455,7 @@ describe('requestGrant()', () => {
     test('synchronously grants a request that can be satisfied, with `grant > maxQueueGrantSize`', async () => {
       const time   = new MockTimeSource(9002);
       const bucket = new TokenBucket({
-        flowRatePerSec: 1, maxBurstSize: 10000, maxGrantQueueSize: 10,
+        flowRate: FLOW_1, maxBurstSize: 10000, maxGrantQueueSize: 10,
         initialBurstSize: 321, timeSource: time });
 
       const result = bucket.requestGrant(300);
@@ -451,7 +468,7 @@ describe('requestGrant()', () => {
 
     test('synchronously grants `0` tokens with `minInclusive === 0` and no available burst', async () => {
       const time   = new MockTimeSource(9003);
-      const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 10000,
+      const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 10000,
         initialBurstSize: 0, timeSource: time });
 
       const result = bucket.requestGrant({ minInclusive: 0, maxInclusive: 25 });
@@ -464,7 +481,7 @@ describe('requestGrant()', () => {
 
     test('synchronously grants non-zero tokens with `minInclusive === 0` and non-zero `maxInclusive`', async () => {
       const time   = new MockTimeSource(9004);
-      const bucket = new TokenBucket({ flowRatePerSec: 1, maxBurstSize: 10000,
+      const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 10000,
         initialBurstSize: 96, timeSource: time });
 
       const result = bucket.requestGrant({ minInclusive: 0, maxInclusive: 100 });
@@ -481,7 +498,7 @@ describe('requestGrant()', () => {
       const nowSec = 12300;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
+        flowRate: FLOW_1, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
 
       // Setup / basic assumptions.
       const request1 = bucket.requestGrant(10);
@@ -507,7 +524,7 @@ describe('requestGrant()', () => {
       const nowSec = 99000;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 1, maxBurstSize: 10000, maxQueueSize: 100,
+        flowRate: FLOW_1, maxBurstSize: 10000, maxQueueSize: 100,
         initialBurstSize: 0, timeSource: time });
 
       // Setup / basic assumptions.
@@ -532,7 +549,7 @@ describe('requestGrant()', () => {
       const nowSec = 89100;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 1, maxBurstSize: 10000, maxQueueSize: 100,
+        flowRate: FLOW_1, maxBurstSize: 10000, maxQueueSize: 100,
         initialBurstSize: 0, timeSource: time });
 
       // Setup / basic assumptions.
@@ -557,7 +574,7 @@ describe('requestGrant()', () => {
       const nowSec = 777000;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 1, maxBurstSize: 10000, maxQueueGrantSize: 100,
+        flowRate: FLOW_1, maxBurstSize: 10000, maxQueueGrantSize: 100,
         initialBurstSize: 0, timeSource: time });
 
       const request = bucket.requestGrant({ minInclusive: 25, maxInclusive: 50 });
@@ -574,7 +591,7 @@ describe('requestGrant()', () => {
       const nowSec = 888000;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 1, maxBurstSize: 10000, maxQueueGrantSize: 100,
+        flowRate: FLOW_1, maxBurstSize: 10000, maxQueueGrantSize: 100,
         initialBurstSize: 0, timeSource: time });
 
       const request = bucket.requestGrant({ minInclusive: 50, maxInclusive: 150 });
@@ -591,7 +608,7 @@ describe('requestGrant()', () => {
       const nowSec = 182100;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 1, maxBurstSize: 10000, maxQueueGrantSize: 100,
+        flowRate: FLOW_1, maxBurstSize: 10000, maxQueueGrantSize: 100,
         initialBurstSize: 0, timeSource: time });
 
       const request1 = bucket.requestGrant(10);
@@ -633,7 +650,7 @@ describe('requestGrant()', () => {
       const available = 12.34;
       const time   = new MockTimeSource(12312);
       const bucket = new TokenBucket({
-        partialTokens: false, flowRatePerSec: 1, maxBurstSize: 100,
+        partialTokens: false, flowRate: FLOW_1, maxBurstSize: 100,
         initialBurstSize: available, timeSource: time });
 
       const resultPromise = bucket.requestGrant({ minInclusive: 10, maxInclusive: 20 });
@@ -647,7 +664,7 @@ describe('requestGrant()', () => {
       const nowSec = 900;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        partialTokens: false, flowRatePerSec: 1, maxBurstSize: 100,
+        partialTokens: false, flowRate: FLOW_1, maxBurstSize: 100,
         maxQueueGrantSize: 10, initialBurstSize: 0, timeSource: time });
 
       const resultPromise = bucket.requestGrant({ minInclusive: 1.5, maxInclusive: 2.5 });
@@ -667,7 +684,7 @@ describe('requestGrant()', () => {
       const available = 12.34;
       const time   = new MockTimeSource(12312);
       const bucket = new TokenBucket({
-        partialTokens: true, flowRatePerSec: 1, maxBurstSize: 100,
+        partialTokens: true, flowRate: FLOW_1, maxBurstSize: 100,
         initialBurstSize: available, timeSource: time });
 
       const resultPromise = bucket.requestGrant({ minInclusive: 10, maxInclusive: 20 });
@@ -682,7 +699,7 @@ describe('requestGrant()', () => {
       const nowSec = 900;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        partialTokens: true, flowRatePerSec: 1, maxBurstSize: 100,
+        partialTokens: true, flowRate: FLOW_1, maxBurstSize: 100,
         maxQueueGrantSize: grant, initialBurstSize: 0, timeSource: time });
 
       const resultPromise = bucket.requestGrant({ minInclusive: 1, maxInclusive: 10 });
@@ -700,7 +717,7 @@ describe('requestGrant()', () => {
 
 describe('latestState()', () => {
   test('has exactly the expected properties', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 123, maxBurstSize: 100000 });
+    const bucket = new TokenBucket({ flowRate: FLOW_BIG, maxBurstSize: 100000 });
     expect(bucket.latestState()).toContainAllKeys([
       'availableBurstSize', 'availableQueueSize', 'now', 'waiterCount'
     ]);
@@ -709,7 +726,7 @@ describe('latestState()', () => {
   test('does not use the time source', () => {
     const time   = new MockTimeSource(900);
     const bucket = new TokenBucket({
-      flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 100, timeSource: time });
+      flowRate: FLOW_1, maxBurstSize: 10000, initialBurstSize: 100, timeSource: time });
 
     const baseResult = bucket.latestState();
     expect(baseResult.now.atSec).toBe(900);
@@ -725,14 +742,14 @@ describe('latestState()', () => {
   });
 
   test('indicates a lack of waiters, before any waiting has ever happened', () => {
-    const bucket = new TokenBucket({ flowRatePerSec: 123, maxBurstSize: 100000 });
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 100000 });
     expect(bucket.latestState().waiterCount).toBe(0);
   });
 
   test('indicates the number of waiters and available queue size as the waiters wax and wane', async () => {
     const time   = new MockTimeSource(1000);
     const bucket = new TokenBucket({
-      flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 0, maxQueueSize: 1000,
+      flowRate: FLOW_1, maxBurstSize: 10000, initialBurstSize: 0, maxQueueSize: 1000,
       timeSource: time
     });
 
@@ -774,7 +791,7 @@ describe('takeNow()', () => {
       const nowSec = 98000;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 123, timeSource: time });
+        flowRate: FLOW_1, maxBurstSize: 10000, initialBurstSize: 123, timeSource: time });
 
       const result = bucket.takeNow(123);
       checkTakeNow(result, { done: true, grant: 123, waitUntil: nowSec });
@@ -788,7 +805,7 @@ describe('takeNow()', () => {
       const nowSec = 43210;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 5, maxBurstSize: 10000, initialBurstSize: 100, timeSource: time });
+        flowRate: FLOW_5, maxBurstSize: 10000, initialBurstSize: 100, timeSource: time });
 
       const result = bucket.takeNow({ minInclusive: 10, maxInclusive: 110 });
       checkTakeNow(result, { done: true, grant: 100, waitUntil: nowSec + 0 });
@@ -802,7 +819,7 @@ describe('takeNow()', () => {
       const nowSec = 91400;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 5, maxBurstSize: 10000, initialBurstSize: 75,
+        flowRate: FLOW_5, maxBurstSize: 10000, initialBurstSize: 75,
         maxQueueGrantSize: 50, timeSource: time
       });
 
@@ -821,7 +838,7 @@ describe('takeNow()', () => {
       const nowSec = 1000;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 5, maxBurstSize: 100, initialBurstSize: 0, timeSource: time });
+        flowRate: FLOW_5, maxBurstSize: 100, initialBurstSize: 0, timeSource: time });
 
       const now1 = nowSec + 1; // Enough for 5 tokens to become available.
       time._setTime(now1);
@@ -839,7 +856,7 @@ describe('takeNow()', () => {
       const nowSec = 1000;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 5, maxBurstSize: 100, initialBurstSize: 0,
+        flowRate: FLOW_5, maxBurstSize: 100, initialBurstSize: 0,
         maxQueueGrantSize: 10, timeSource: time
       });
 
@@ -856,7 +873,7 @@ describe('takeNow()', () => {
       const nowSec = 1000;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 10, maxBurstSize: 100, initialBurstSize: 5,
+        flowRate: FLOW_10, maxBurstSize: 100, initialBurstSize: 5,
         maxQueueGrantSize: 20, timeSource: time
       });
 
@@ -879,7 +896,7 @@ describe('takeNow()', () => {
           const nowSec = 10;
           const time   = new MockTimeSource(nowSec);
           const bucket = new TokenBucket({
-            partialTokens: false, flowRatePerSec: 1, maxBurstSize: 100,
+            partialTokens: false, flowRate: FLOW_1, maxBurstSize: 100,
             initialBurstSize: available, timeSource: time
           });
 
@@ -900,7 +917,7 @@ describe('takeNow()', () => {
           const nowSec = 226000;
           const time   = new MockTimeSource(nowSec);
           const bucket = new TokenBucket({
-            partialTokens: true, flowRatePerSec: 1, maxBurstSize: 100, initialBurstSize: available,
+            partialTokens: true, flowRate: FLOW_1, maxBurstSize: 100, initialBurstSize: available,
             timeSource: time
           });
 
@@ -915,7 +932,7 @@ describe('takeNow()', () => {
       const nowSec = 226000;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 13, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
+        flowRate: FLOW_13, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
 
       // Setup / baseline assumptions.
       const requestResult = bucket.requestGrant(1300);
@@ -937,7 +954,7 @@ describe('takeNow()', () => {
       const nowSec = 50015;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 10, maxBurstSize: 10000, initialBurstSize: 0,
+        flowRate: FLOW_10, maxBurstSize: 10000, initialBurstSize: 0,
         maxQueueGrantSize: 1000, timeSource: time
       });
 
@@ -961,7 +978,7 @@ describe('takeNow()', () => {
       const nowSec = 60015;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 10, maxBurstSize: 10000, initialBurstSize: 200,
+        flowRate: FLOW_10, maxBurstSize: 10000, initialBurstSize: 200,
         maxQueueGrantSize: 1000, timeSource: time
       });
 
@@ -987,7 +1004,7 @@ describe('takeNow()', () => {
       const nowSec = 1000;
       const time   = new MockTimeSource(nowSec);
       const bucket = new TokenBucket({
-        flowRatePerSec: 1, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
+        flowRate: FLOW_1, maxBurstSize: 10000, initialBurstSize: 0, timeSource: time });
 
       // Setup / baseline expectations.
       const requestResult = bucket.requestGrant(1);

--- a/src/builtin-services/export/RateLimiter.js
+++ b/src/builtin-services/export/RateLimiter.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TokenBucket } from '@this/async';
+import { Frequency } from '@this/data-values';
 import { IntfLogger } from '@this/loggy';
 import { IntfRateLimiter } from '@this/net-protocol';
 import { ServiceConfig } from '@this/sys-config';
@@ -169,26 +170,6 @@ export class RateLimiter extends BaseService {
     }
 
     /**
-     * Converts a specified-unit flow rate to one that is per-second.
-     *
-     * @param {number} flowRate The flow rate.
-     * @param {string} timeUnit The time unit for the given `flowRate`.
-     * @returns {number} `flowRate` converted to tokens per second.
-     */
-    static #flowRatePerSecFrom(flowRate, timeUnit) {
-      switch (timeUnit) {
-        case 'day':    return flowRate * (1 / (60 * 60 * 24));
-        case 'hour':   return flowRate * (1 / (60 * 60));
-        case 'minute': return flowRate * (1 / 60);
-        case 'second': return flowRate;               // No conversion needed.
-        case 'msec':   return flowRate * 1000;
-        default: {
-          throw new Error(`Unknown time unit: ${timeUnit}`);
-        }
-      }
-    }
-
-    /**
      * Parses the bucket configuration for a specific rate-limited entity.
      * Returns `null` if passed `null`.
      *
@@ -205,12 +186,9 @@ export class RateLimiter extends BaseService {
         maxBurstSize,
         maxQueueGrantSize = null,
         maxQueueSize      = null,
-        timeUnit
       } = config;
 
-      MustBe.number(origFlowRate, { minExclusive: 0, maxInclusive: 1e100 });
       MustBe.number(maxBurstSize, { minExclusive: 0, maxInclusive: 1e100 });
-      MustBe.string(timeUnit,     /^(day|hour|minute|second|msec)$/);
 
       if (maxQueueGrantSize !== null) {
         MustBe.number(maxQueueGrantSize, { minInclusive: 0, maxInclusive: 1e100 });
@@ -220,14 +198,17 @@ export class RateLimiter extends BaseService {
         MustBe.number(maxQueueSize, { minInclusive: 0, maxInclusive: 1e100 });
       }
 
-      const flowRatePerSec = Config.#flowRatePerSecFrom(origFlowRate, timeUnit);
-      const result   = { flowRatePerSec, maxBurstSize, maxQueueSize };
+      const flowRate = Frequency.parse(origFlowRate);
 
-      if (maxQueueGrantSize !== null) {
-        result.maxQueueGrantSize = maxQueueGrantSize;
+      if (flowRate === null) {
+        throw new Error(`Could not parse \`flowRate\`: ${origFlowRate}`);
       }
 
-      return Object.freeze(result);
+      const flowRatePerSec = flowRate.hertz;
+
+      return Object.freeze({
+        flowRatePerSec, maxBurstSize, maxQueueSize, maxQueueGrantSize
+      });
     }
   };
 }

--- a/src/builtin-services/export/RateLimiter.js
+++ b/src/builtin-services/export/RateLimiter.js
@@ -202,12 +202,12 @@ export class RateLimiter extends BaseService {
 
       if (flowRate === null) {
         throw new Error(`Could not parse \`flowRate\`: ${origFlowRate}`);
+      } else if (flowRate.hertz === 0) {
+        throw new Error('`flowRate` must be positive');
       }
 
-      const flowRatePerSec = flowRate.hertz;
-
       return Object.freeze({
-        flowRatePerSec, maxBurstSize, maxQueueSize, maxQueueGrantSize
+        flowRate, maxBurstSize, maxQueueSize, maxQueueGrantSize
       });
     }
   };

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BaseConverter } from '#x/BaseConverter';
+import { Frequency } from '#x/Frequency';
 import { Struct } from '#x/Struct';
 import { UnitQuantity } from '#x/UnitQuantity';
 
@@ -21,6 +22,11 @@ export class Duration extends UnitQuantity {
    */
   constructor(sec) {
     super(sec, 'sec', null);
+  }
+
+  /** @override */
+  get [UnitQuantity.INVERSE]() {
+    return Frequency;
   }
 
   /** @returns {number} The number of milliseconds being represented. */

--- a/src/data-values/export/Frequency.js
+++ b/src/data-values/export/Frequency.js
@@ -3,6 +3,7 @@
 
 import { MustBe } from '@this/typey';
 
+import { Duration } from '#x/Duration';
 import { UnitQuantity } from '#x/UnitQuantity';
 
 
@@ -21,6 +22,11 @@ export class Frequency extends UnitQuantity {
   constructor(hertz) {
     MustBe.number(hertz, { finite: true, minInclusive: 0 });
     super(hertz, null, 'sec');
+  }
+
+  /** @override */
+  get [UnitQuantity.INVERSE]() {
+    return Duration;
   }
 
   /**

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -296,8 +296,8 @@ export class UnitQuantity {
       return null;
     }
 
-    const finalNumer = ((numer === '') || (numer == denom)) ? null : numer;
-    const finalDenom = ((denom === '') || (numer == denom)) ? null : denom;
+    const finalNumer = ((numer === '') || (numer === denom)) ? null : numer;
+    const finalDenom = ((denom === '') || (numer === denom)) ? null : denom;
 
     return new UnitQuantity(num, finalNumer, finalDenom);
   }

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -187,11 +187,13 @@ export class UnitQuantity {
    * This method _also_ optionally accepts `value` as an instance of this class,
    * (to make use of the method when parsing configurations a bit easier).
    *
-   * **Note:** The unit name `per` is not allowed, as it is reserved as the
-   * word-equivalent of `/`.
-   *
-   * **Note:** The range restriction options are only useful if the caller
-   * ends up requiring particular units.
+   * **Notes:**
+   * * If the numerator and denominator units are identical, the result is a
+   *   unitless instance.
+   * * The unit name `per` is not allowed, as it is reserved as the
+   *   word-equivalent of `/`.
+   * * The range restriction options are only useful if the caller ends up
+   *   requiring particular units.
    *
    * @param {string|UnitQuantity} value The value to parse, or the value itself.
    * @param {object} [options] Options to control the allowed range of values.
@@ -294,9 +296,9 @@ export class UnitQuantity {
       return null;
     }
 
-    return new UnitQuantity(
-      num,
-      (numer === '') ? null : numer,
-      (denom === '') ? null : denom);
+    const finalNumer = ((numer === '') || (numer == denom)) ? null : numer;
+    const finalDenom = ((denom === '') || (numer == denom)) ? null : denom;
+
+    return new UnitQuantity(num, finalNumer, finalDenom);
   }
 }

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -7,6 +7,9 @@ import { BaseConverter } from '#x/BaseConverter';
 import { Struct } from '#x/Struct';
 
 
+/** @type {symbol} Value for the exposed {@link UnitQuantity#INVERSE}. */
+const INVERSE_SYMBOL = Symbol('UnitQuantity.INVERSE');
+
 /**
  * Representation of a numeric quantity with an associated named unit. The unit
  * is allowed to be either a numerator or a denominator or a combination of the
@@ -50,6 +53,15 @@ export class UnitQuantity {
     }
 
     Object.freeze(this);
+  }
+
+  /**
+   * @returns {function(new:UnitQuantity)} Class to use when constructing a new
+   * instance via {@link #inverse}. Defaults to this class. Subclasses can
+   * override this as necessary.
+   */
+  get [INVERSE_SYMBOL]() {
+    return UnitQuantity;
   }
 
   /** @returns {?string} The denominator unit, or `null` if none. */
@@ -118,7 +130,9 @@ export class UnitQuantity {
    * @returns {UnitQuantity} The inverse.
    */
   inverse() {
-    return new UnitQuantity(1 / this.#value, this.#denominatorUnit, this.#numeratorUnit);
+    const resultClass = this[INVERSE_SYMBOL];
+
+    return new resultClass(1 / this.#value, this.#denominatorUnit, this.#numeratorUnit);
   }
 
   /**
@@ -146,6 +160,15 @@ export class UnitQuantity {
   //
   // Static members
   //
+
+  /**
+   * @returns {symbol} Symbol used for a getter on subclass instances, whose
+   * value indicates the preferred class for the result of calls to {@link
+   * #inverse}.
+   */
+  static get INVERSE() {
+    return INVERSE_SYMBOL;
+  }
 
   /**
    * Parses a string representing a unit quantity, returning an instance of this

--- a/src/data-values/tests/Duration.test.js
+++ b/src/data-values/tests/Duration.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { Duration, Moment, UnitQuantity } from '@this/data-values';
+import { Duration, Frequency, Moment, UnitQuantity } from '@this/data-values';
 
 
 describe('constructor()', () => {
@@ -32,6 +32,13 @@ describe('constructor()', () => {
   });
 });
 
+describe('[UnitQuantity.INVERSE]', () => {
+  test('is `Frequency`', () => {
+    const dur = new Duration(123);
+    expect(dur[UnitQuantity.INVERSE]).toBe(Frequency);
+  });
+});
+
 describe('.sec', () => {
   test('returns the value from the constructor', () => {
     expect(new Duration(0).sec).toBe(0);
@@ -45,6 +52,14 @@ describe('.msec', () => {
     expect(new Duration(0).msec).toBe(0);
     expect(new Duration(123).msec).toBe(123000);
     expect(new Duration(456.789).msec).toBe(456789);
+  });
+});
+
+describe('inverse()', () => {
+  test('returns an instance of `Frequency`', () => {
+    const result = new Duration(123).inverse();
+    expect(result).toBeInstanceOf(Frequency);
+    expect(result.hertz).toBe(1/123);
   });
 });
 

--- a/src/data-values/tests/Frequency.test.js
+++ b/src/data-values/tests/Frequency.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { Frequency, UnitQuantity } from '@this/data-values';
+import { Duration, Frequency, UnitQuantity } from '@this/data-values';
 
 
 describe('constructor()', () => {
@@ -31,11 +31,26 @@ describe('constructor()', () => {
   });
 });
 
+describe('[UnitQuantity.INVERSE]', () => {
+  test('is `Duration`', () => {
+    const freq = new Frequency(123);
+    expect(freq[UnitQuantity.INVERSE]).toBe(Duration);
+  });
+});
+
 describe('.hertz', () => {
   test('returns the value from the constructor', () => {
     expect(new Frequency(0).hertz).toBe(0);
     expect(new Frequency(123).hertz).toBe(123);
     expect(new Frequency(456.789).hertz).toBe(456.789);
+  });
+});
+
+describe('inverse()', () => {
+  test('returns an instance of `Duration`', () => {
+    const result = new Frequency(123).inverse();
+    expect(result).toBeInstanceOf(Duration);
+    expect(result.sec).toBe(1/123);
   });
 });
 

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -155,7 +155,7 @@ describe('inverse()', () => {
 
     class UqSub2 extends UnitQuantity {
       get [UnitQuantity.INVERSE]() {
-        return UqSub1
+        return UqSub1;
       }
     }
 

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -43,6 +43,13 @@ describe('constructor()', () => {
   });
 });
 
+describe('[UnitQuantity.INVERSE]', () => {
+  test('is this class', () => {
+    const uq = new UnitQuantity(1, 'x', 'y');
+    expect(uq[UnitQuantity.INVERSE]).toBe(UnitQuantity);
+  });
+});
+
 describe('.denominatorUnit', () => {
   test('returns the denominator unit from the constructor', () => {
     expect(new UnitQuantity(0, 'x', 'y').denominatorUnit).toBe('y');
@@ -136,9 +143,24 @@ ${'subtract'}
 });
 
 describe('inverse()', () => {
-  test('returns an instance of this class', () => {
+  test('returns an instance of this class, given a concrete `UnitQuantity`', () => {
     const result = new UnitQuantity(123, 'x', 'y').inverse();
     expect(result).toBeInstanceOf(UnitQuantity);
+  });
+
+  test('returns an instance of the preferred inverse class for a subclass that specifies it', () => {
+    class UqSub1 extends UnitQuantity {
+      // This space intentionally left blank.
+    }
+
+    class UqSub2 extends UnitQuantity {
+      get [UnitQuantity.INVERSE]() {
+        return UqSub1
+      }
+    }
+
+    const result = new UqSub2(123, 'x', 'y').inverse();
+    expect(result).toBeInstanceOf(UqSub1);
   });
 
   test('inverts the value', () => {
@@ -153,6 +175,17 @@ describe('inverse()', () => {
 
     expect(result.numeratorUnit).toBe('y');
     expect(result.denominatorUnit).toBe('x');
+  });
+});
+
+
+//
+// Static members
+//
+
+describe('.INVERSE', () => {
+  test('is a symbol', () => {
+    expect(UnitQuantity.INVERSE).toBeSymbol();
   });
 });
 

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -207,8 +207,9 @@ describe('parse()', () => {
   test.each`
   value
   ${''}
-  ${'123'}       // No unit.
+  ${'123'}       // No unit. (Units are required by default.)
   ${' 123 '}     // Ditto.
+  ${'1 bop/bop'} // Ditto. (Identical units cancel out.)
   ${'a'}         // No number.
   ${'1z abc'}    // Invalid character in number.
   ${'$1 xyz'}    // Ditto.
@@ -320,6 +321,26 @@ describe('parse()', () => {
     const uq = new UnitQuantity(123, 'x', 'y');
 
     expect(UnitQuantity.parse(uq, { allowInstance: false })).toBeNull();
+  });
+
+  describe('with `{ requireUnit: false }`', () => {
+    test('allows unitless input', () => {
+      const uq = UnitQuantity.parse('123', { requireUnit: false });
+
+      expect(uq).toBeInstanceOf(UnitQuantity);
+      expect(uq.value).toBe(123);
+      expect(uq.numeratorUnit).toBeNull();
+      expect(uq.denominatorUnit).toBeNull();
+    });
+
+    test('returns a unitless instance when given identical numerator and denominator', () => {
+      const uq = UnitQuantity.parse('0.987 bop/bop', { requireUnit: false });
+
+      expect(uq).toBeInstanceOf(UnitQuantity);
+      expect(uq.value).toBe(0.987);
+      expect(uq.numeratorUnit).toBeNull();
+      expect(uq.denominatorUnit).toBeNull();
+    });
   });
 
   // Success cases, no options.


### PR DESCRIPTION
This PR (I think) wraps up the time-related work for now. Highlights:

* Made `UnitQuantity` have a way for subclasses to specify their `inverse()` class, and used it to make `Frequency` and `Duration` mutually `inverse()`able.
* Changed `TokenBucket` to accept a `Frequency` for `flowRate` instead of taking just-a-number for `flowRateSec`.
* Likewise, changed the `RateLimiter` config to expect a `Frequency` or string-parseable-as-one as the `flowRate` and dropped the use of `flowRateUnit`.