### PR TITLE
Wrangler renaming

### DIFF
--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -188,31 +188,6 @@ export class ProtocolWrangler {
   }
 
   /**
-   * Performs starting actions specifically in service of the high-level
-   * protocol (e.g. HTTP2), in advance of it being handed connections. This
-   * should only async-return once the stack really is ready.
-   *
-   * @abstract
-   * @param {boolean} isReload Is this action due to an in-process reload?
-   */
-  async _impl_serverStart(isReload) {
-    Methods.abstract(isReload);
-  }
-
-  /**
-   * Performs stop/shutdown actions specifically in service of the high-level
-   * protocol (e.g. HTTP2), after it is no longer being handed connections. This
-   * should only async-return once the stack really is stopped.
-   *
-   * @abstract
-   * @param {boolean} willReload Is this action due to an in-process reload
-   *   being requested?
-   */
-  async _impl_serverStop(willReload) {
-    Methods.abstract(willReload);
-  }
-
-  /**
    * Initializes the instance. After this is called and (asynchronously)
    * returns without throwing, {@link #_impl_server} is expected to work without
    * error. This can get called more than once; the second and subsequent times
@@ -243,6 +218,31 @@ export class ProtocolWrangler {
    */
   _impl_server() {
     Methods.abstract();
+  }
+
+  /**
+   * Performs starting actions specifically in service of the high-level
+   * protocol (e.g. HTTP2), in advance of it being handed connections. This
+   * should only async-return once the stack really is ready.
+   *
+   * @abstract
+   * @param {boolean} isReload Is this action due to an in-process reload?
+   */
+  async _impl_serverStart(isReload) {
+    Methods.abstract(isReload);
+  }
+
+  /**
+   * Performs stop/shutdown actions specifically in service of the high-level
+   * protocol (e.g. HTTP2), after it is no longer being handed connections. This
+   * should only async-return once the stack really is stopped.
+   *
+   * @abstract
+   * @param {boolean} willReload Is this action due to an in-process reload
+   *   being requested?
+   */
+  async _impl_serverStop(willReload) {
+    Methods.abstract(willReload);
   }
 
   /**

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -251,7 +251,7 @@ export class ProtocolWrangler {
    * @abstract
    * @param {boolean} isReload Is this action due to an in-process reload?
    */
-  async _impl_serverSocketStart(isReload) {
+  async _impl_socketStart(isReload) {
     Methods.abstract(isReload);
   }
 
@@ -263,7 +263,7 @@ export class ProtocolWrangler {
    * @param {boolean} willReload Is this action due to an in-process reload
    *   being requested?
    */
-  async _impl_serverSocketStop(willReload) {
+  async _impl_socketStop(willReload) {
     Methods.abstract(willReload);
   }
 
@@ -537,7 +537,7 @@ export class ProtocolWrangler {
     // We do these in parallel, because there can be mutual dependencies, e.g.
     // the application might need to see the server stopping _and_ vice versa.
     await Promise.all([
-      this._impl_serverSocketStop(this.#reloading),
+      this._impl_socketStop(this.#reloading),
       this._impl_applicationStop(this.#reloading)
     ]);
 
@@ -556,7 +556,7 @@ export class ProtocolWrangler {
     }
 
     await this._impl_applicationStart(this.#reloading);
-    await this._impl_serverSocketStart(this.#reloading);
+    await this._impl_socketStart(this.#reloading);
 
     if (this.#logger) {
       this.#logger.started(this._impl_loggableInfo());

--- a/src/net-protocol/private/Http2Wrangler.js
+++ b/src/net-protocol/private/Http2Wrangler.js
@@ -42,12 +42,12 @@ export class Http2Wrangler extends TcpWrangler {
   }
 
   /** @override */
-  async _impl_applicationStart(isReload_unused) {
+  async _impl_serverStart(isReload_unused) {
     this.#runner.run();
   }
 
   /** @override */
-  async _impl_applicationStop(willReload_unused) {
+  async _impl_serverStop(willReload_unused) {
     return this.#runner.stop();
   }
 

--- a/src/net-protocol/private/Http2Wrangler.js
+++ b/src/net-protocol/private/Http2Wrangler.js
@@ -42,16 +42,6 @@ export class Http2Wrangler extends TcpWrangler {
   }
 
   /** @override */
-  async _impl_serverStart(isReload_unused) {
-    this.#runner.run();
-  }
-
-  /** @override */
-  async _impl_serverStop(willReload_unused) {
-    return this.#runner.stop();
-  }
-
-  /** @override */
   async _impl_initialize() {
     if (!this.#protocolServer) {
       const hostOptions = await this._prot_hostManager.getSecureServerOptions();
@@ -68,6 +58,16 @@ export class Http2Wrangler extends TcpWrangler {
   /** @override */
   _impl_server() {
     return this.#protocolServer;
+  }
+
+  /** @override */
+  async _impl_serverStart(isReload_unused) {
+    this.#runner.run();
+  }
+
+  /** @override */
+  async _impl_serverStop(willReload_unused) {
+    return this.#runner.stop();
   }
 
   /**

--- a/src/net-protocol/private/HttpWrangler.js
+++ b/src/net-protocol/private/HttpWrangler.js
@@ -16,6 +16,18 @@ export class HttpWrangler extends TcpWrangler {
   // Note: The default constructor suffices here.
 
   /** @override */
+  async _impl_initialize() {
+    if (!this.#protocolServer) {
+      this.#protocolServer = http.createServer();
+    }
+  }
+
+  /** @override */
+  _impl_server() {
+    return this.#protocolServer;
+  }
+
+  /** @override */
   async _impl_serverStart(isReload_unused) {
     // Nothing to do in this case.
   }
@@ -27,17 +39,5 @@ export class HttpWrangler extends TcpWrangler {
 
     // TODO: Consider tracking connections and forcing things closed after a
     // timeout, similar to what's done with HTTP2.
-  }
-
-  /** @override */
-  async _impl_initialize() {
-    if (!this.#protocolServer) {
-      this.#protocolServer = http.createServer();
-    }
-  }
-
-  /** @override */
-  _impl_server() {
-    return this.#protocolServer;
   }
 }

--- a/src/net-protocol/private/HttpWrangler.js
+++ b/src/net-protocol/private/HttpWrangler.js
@@ -16,12 +16,12 @@ export class HttpWrangler extends TcpWrangler {
   // Note: The default constructor suffices here.
 
   /** @override */
-  async _impl_applicationStart(isReload_unused) {
+  async _impl_serverStart(isReload_unused) {
     // Nothing to do in this case.
   }
 
   /** @override */
-  async _impl_applicationStop(willReload_unused) {
+  async _impl_serverStop(willReload_unused) {
     this.#protocolServer.close();
     this.#protocolServer.closeIdleConnections();
 

--- a/src/net-protocol/private/HttpsWrangler.js
+++ b/src/net-protocol/private/HttpsWrangler.js
@@ -16,12 +16,12 @@ export class HttpsWrangler extends TcpWrangler {
   // Note: The default constructor suffices here.
 
   /** @override */
-  async _impl_applicationStart(isReload_unused) {
+  async _impl_serverStart(isReload_unused) {
     // Nothing to do in this case.
   }
 
   /** @override */
-  async _impl_applicationStop(willReload_unused) {
+  async _impl_serverStop(willReload_unused) {
     this.#protocolServer.close();
     this.#protocolServer.closeIdleConnections();
 

--- a/src/net-protocol/private/HttpsWrangler.js
+++ b/src/net-protocol/private/HttpsWrangler.js
@@ -16,6 +16,19 @@ export class HttpsWrangler extends TcpWrangler {
   // Note: The default constructor suffices here.
 
   /** @override */
+  async _impl_initialize() {
+    if (!this.#protocolServer) {
+      const hostOptions = await this._prot_hostManager.getSecureServerOptions();
+      this.#protocolServer = https.createServer(hostOptions);
+    }
+  }
+
+  /** @override */
+  _impl_server() {
+    return this.#protocolServer;
+  }
+
+  /** @override */
   async _impl_serverStart(isReload_unused) {
     // Nothing to do in this case.
   }
@@ -27,18 +40,5 @@ export class HttpsWrangler extends TcpWrangler {
 
     // TODO: Consider tracking connections and forcing things closed after a
     // timeout, similar to what's done with HTTP2.
-  }
-
-  /** @override */
-  async _impl_initialize() {
-    if (!this.#protocolServer) {
-      const hostOptions = await this._prot_hostManager.getSecureServerOptions();
-      this.#protocolServer = https.createServer(hostOptions);
-    }
-  }
-
-  /** @override */
-  _impl_server() {
-    return this.#protocolServer;
   }
 }

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -52,6 +52,11 @@ export class TcpWrangler extends ProtocolWrangler {
   }
 
   /** @override */
+  _impl_loggableInfo() {
+    return this.#asyncServer.loggableInfo;
+  }
+
+  /** @override */
   async _impl_socketStart(isReload) {
     await this.#runner.start();
     await this.#asyncServer.start(isReload);
@@ -61,11 +66,6 @@ export class TcpWrangler extends ProtocolWrangler {
   async _impl_socketStop(willReload) {
     await this.#asyncServer.stop(willReload);
     await this.#runner.stop();
-  }
-
-  /** @override */
-  _impl_loggableInfo() {
-    return this.#asyncServer.loggableInfo;
   }
 
   /**

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -52,13 +52,13 @@ export class TcpWrangler extends ProtocolWrangler {
   }
 
   /** @override */
-  async _impl_serverSocketStart(isReload) {
+  async _impl_socketStart(isReload) {
     await this.#runner.start();
     await this.#asyncServer.start(isReload);
   }
 
   /** @override */
-  async _impl_serverSocketStop(willReload) {
+  async _impl_socketStop(willReload) {
     await this.#asyncServer.stop(willReload);
     await this.#runner.stop();
   }


### PR DESCRIPTION
This PR renames a couple internal bits in `net-protocol.ProtocolWrangler`, to jibe with the earlier removal of Express as a dependency.