### PR TITLE
Return a response, not a boolean.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Breaking changes:
   * Changed the constructor of `Request` to take a `RequestContext` instead of a
     `WranglerContext` (the latter which is a private class in `net-protocol`).
   * Renamed `HttpResponse` to just `Response`.
+  * Changed the `IntfRequestHandler` API so that the return value is the
+    response to send, instead of expecting the handler to do the sending. This
+    enables a pattern where a request handler can be "wrapped" by another one
+    which gets a chance to modify the response before bubbling it up further.
 
 Other notable changes:
 * `net-protocol`: Stopped using Express as a layer between the Node `http*`

--- a/src/builtin-applications/export/Redirector.js
+++ b/src/builtin-applications/export/Redirector.js
@@ -43,7 +43,7 @@ export class Redirector extends BaseApplication {
   }
 
   /** @override */
-  async _impl_handleRequest(request, dispatch) {
+  async _impl_handleRequest(request_unused, dispatch) {
     const response = Response.makeRedirect(
       `${this.#target}${dispatch.extraString}`,
       this.#statusCode);

--- a/src/builtin-applications/export/Redirector.js
+++ b/src/builtin-applications/export/Redirector.js
@@ -50,7 +50,7 @@ export class Redirector extends BaseApplication {
 
     response.cacheControl = this.#cacheControl;
 
-    return await request.respond(response);
+    return response;
   }
 
   /** @override */

--- a/src/builtin-applications/export/SimpleResponse.js
+++ b/src/builtin-applications/export/SimpleResponse.js
@@ -25,7 +25,7 @@ export class SimpleResponse extends BaseApplication {
     const response = this.#response.adjustFor(
       method, headers, { conditional: true, range: true });
 
-    return await request.respond(response);
+    return response;
   }
 
   /** @override */

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -64,9 +64,9 @@ export class StaticFiles extends BaseApplication {
 
     if (!resolved) {
       if (this.#notFoundResponse) {
-        return request.respond(this.#notFoundResponse);
+        return this.#notFoundResponse;
       } else {
-        return false;
+        return null;
       }
     }
 
@@ -102,7 +102,7 @@ export class StaticFiles extends BaseApplication {
       const response = rawResponse.adjustFor(
         method, headers, { conditional: true, range: true });
 
-      return await request.respond(response);
+      return response;
     } else {
       // Shouldn't happen. If we get here, it's a bug in this class.
       throw new Error('Shouldn\'t happen.');

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -78,7 +78,7 @@ export class StaticFiles extends BaseApplication {
         response.cacheControl = this.#cacheControl;
       }
 
-      return await request.respond(response);
+      return await response;
     } else if (resolved.path) {
       const contentType =
         MimeTypes.typeFromPathExtension(resolved.path);

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -413,19 +413,15 @@ export class ProtocolWrangler {
 
       if (result instanceof Response) {
         await request.respond(result);
-      } else if (result === true) {
-        // Validate that the request was actually handled.
-        if (!request.responseCompleted) {
-          reqLogger?.responseNotActuallyHandled();
-          // Gets caught immediately below.
-          throw new Error('Response returned "successfully" without completing.');
-        }
-      } else {
+      } else if (result === null) {
         // The configured `requestHandler` didn't actually handle the request.
         // Respond with a vanilla `404` error. (If the client wants something
         // fancier, they can do it themselves.)
         const bodyExtra = request.urlForLogging;
         await request.respond(Response.makeNotFound({ bodyExtra }));
+      } else {
+        // Caught immediately below.
+        throw new Error(`Strange result from \`handleRequest\`: ${result}`);
       }
     } catch (e) {
       // `500` == "Internal Server Error."

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -411,7 +411,9 @@ export class ProtocolWrangler {
     try {
       const result = await this.#requestHandler.handleRequest(request, null);
 
-      if (result) {
+      if (result instanceof Response) {
+        await request.respond(result);
+      } else if (result === true) {
         // Validate that the request was actually handled.
         if (!request.responseCompleted) {
           reqLogger?.responseNotActuallyHandled();

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -370,14 +370,13 @@ export class ProtocolWrangler {
    * out to the configured `requestHandler` when appropriate (e.g. not
    * rate-limited, etc.).
    *
-   * **Note:** There is nothing set up to catch errors thrown by this method.
+   * **Note:** There is nothing set up to catch errors thrown by this method. It
+   * is not supposed to `throw` (directly or indirectly).
    *
    * @param {Request} request Request object.
-   * @param {WranglerContext} outerContext The outer context of `request`.
+   * @returns {Response} The response to send.
    */
-  async #handleRequest(request, outerContext) {
-    const reqLogger = request.logger;
-
+  async #handleRequest(request) {
     if (!request.pathnameString) {
       // It's not an `origin` request. We don't handle any other type of
       // target... yet.
@@ -387,46 +386,28 @@ export class ProtocolWrangler {
       // echo $'GET * HTTP/1.1\r\nHost: milk.com\r\n\r' \
       //   | curl telnet://localhost:8080
       // ```
-      await request.respond(Response.makeMetaResponse(400)); // "Bad Request."
-      return;
-    } else if (this.#rateLimiter) {
-      const granted = await this.#rateLimiter.newRequest(reqLogger);
-      if (!granted) {
-        // Send the error response, and wait for it to be (believed to be) sent.
-        await request.respond(Response.makeMetaResponse(503)); // "Service Unavailable."
-
-        // ...and then just thwack the underlying socket. The hope is that the
-        // waiting above will make it likely that the far side will actually see
-        // the 503 response.
-        const csock = outerContext.socket;
-        csock.end();
-        csock.once('finish', () => {
-          csock.destroy();
-        });
-
-        return;
-      }
+      return Response.makeMetaResponse(400); // "Bad Request."
     }
 
     try {
       const result = await this.#requestHandler.handleRequest(request, null);
 
       if (result instanceof Response) {
-        await request.respond(result);
+        return result;
       } else if (result === null) {
         // The configured `requestHandler` didn't actually handle the request.
         // Respond with a vanilla `404` error. (If the client wants something
         // fancier, they can do it themselves.)
         const bodyExtra = request.urlForLogging;
-        await request.respond(Response.makeNotFound({ bodyExtra }));
+        return Response.makeNotFound({ bodyExtra });
       } else {
-        // Caught immediately below.
+        // Caught by our direct caller, `#respondToRequest()`.
         throw new Error(`Strange result from \`handleRequest\`: ${result}`);
       }
     } catch (e) {
       // `500` == "Internal Server Error."
       const bodyExtra = e.stack ?? e.message ?? '<unknown>';
-      await request.respond(Response.makeMetaResponse(500, { bodyExtra }));
+      return Response.makeMetaResponse(500, { bodyExtra });
     }
   }
 
@@ -467,12 +448,13 @@ export class ProtocolWrangler {
 
       res.setHeader('Server', this.#serverHeader);
 
-      this.#logHelper?.logRequest(request, context);
-      this.#handleRequest(request, context);
+      this.#respondToRequest(request, context, res);
     } catch (e) {
-      // Note: This is theorized to occur in practice when the socket for a
-      // request gets closed after the request was received but before it
-      // managed to get dispatched.
+      // This probably indicates a bug in this project. That is, our goal is for
+      // this not to be possible. That said, as of this writing, this is
+      // theorized to occur in practice when the socket for a request gets
+      // closed after the request was received but before it managed to get
+      // dispatched.
       logger?.errorDuringIncomingRequest(url, e);
       const socketState = {
         closed:        socket.closed,
@@ -519,6 +501,76 @@ export class ProtocolWrangler {
     // Done!
 
     this.#initialized = true;
+  }
+
+  /**
+   * Top-level of the asynchronous request handling flow. When appropriate, this
+   * in turn calls to our response-creator, which is supposed to always return
+   * _something_ to use as a response. This method also handles request logging.
+   *
+   * **Note:** There is nothing set up to catch errors thrown by this method. It
+   * is not supposed to `throw` (directly or indirectly).
+   *
+   * @param {Request} request Request object.
+   * @param {WranglerContext} outerContext The outer context of `request`.
+   * @param {Http2ServerResponse|ServerResponse} res Low-level response object.
+   */
+  async #respondToRequest(request, outerContext, res) {
+    const reqLogger = request.logger;
+
+    let result;
+    let closeSocket = false;
+
+    try {
+      if (this.#rateLimiter) {
+        const granted = await this.#rateLimiter.newRequest(reqLogger);
+        if (!granted) {
+          // Send the error response, and wait for it to be (believed to be)
+          // sent. Then just thwack the underlying socket. The hope is that the
+          // waiting above will make it likely that the far side will actually
+          // see the 503 ("Service Unavailable") response.
+          result      = request.respond(Response.makeMetaResponse(503));
+          closeSocket = true;
+        }
+      }
+
+      result = await this.#handleRequest(request, outerContext);
+    } catch (e) {
+      // `500` == "Internal Server Error."
+      const bodyExtra = e.stack ?? e.message ?? '<unknown error>';
+      result = Response.makeMetaResponse(500, { bodyExtra });
+    }
+
+    try {
+      const responseSent = request.respond(result);
+
+      if (this.#logHelper) {
+        // Note: In order for it to be able to log the duration of the request
+        // with reasonable accuracy, the call to `logRequest()` has to happen
+        // early during dispatch, and definitely _not_ after the response has
+        // been sent!
+        this.#logHelper.logRequest(request, outerContext, res, responseSent);
+      }
+
+      await responseSent;
+    } catch (e) {
+      // Shouldn't happen, but we probably can't actually let the client know in
+      // any _good_ way, since the call to `respond()` probably already started
+      // the response. So we do what little we can that might help, and then
+      // just close the socket and hope for the best.
+      reqLogger?.errorDuringRespond(e);
+      res.statusCode = 500; // "Internal Server Error."
+      res.end();
+      closeSocket = true;
+    }
+
+    if (closeSocket) {
+      const csock = outerContext.socket;
+      csock.end();
+      csock.once('finish', () => {
+        csock.destroy();
+      });
+    }
   }
 
   /**

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -446,8 +446,6 @@ export class ProtocolWrangler {
         url:       request.urlForLogging
       });
 
-      res.setHeader('Server', this.#serverHeader);
-
       this.#respondToRequest(request, context, res);
     } catch (e) {
       // This probably indicates a bug in this project. That is, our goal is for
@@ -542,6 +540,8 @@ export class ProtocolWrangler {
     }
 
     try {
+      res.setHeader('Server', this.#serverHeader);
+
       const responseSent = request.respond(result);
 
       if (this.#logHelper) {

--- a/src/net-protocol/private/RequestLogHelper.js
+++ b/src/net-protocol/private/RequestLogHelper.js
@@ -1,9 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { ErrorUtil } from '@this/data-values';
 import { FormatUtils } from '@this/loggy';
-import { Request } from '@this/net-util';
+import { Request, Response } from '@this/net-util';
 
 import { IntfRequestLogger } from '#x/IntfRequestLogger';
 import { WranglerContext } from '#p/WranglerContext';
@@ -32,62 +31,38 @@ export class RequestLogHelper {
    * @param {Request} request Request object.
    * @param {WranglerContext} context Outer context around `request`.
    */
-  async logRequest(request, context) {
-    const logger    = request.logger;
+  async logRequest(request, context, res, resSent) {
     const startTime = this.#requestLogger.now();
+
+    const logger    = request.logger;
     const reqInfo   = request.getLoggableRequestInfo();
 
     logger?.request(reqInfo);
 
+    await resSent;
+
+    const endTime   = this.#requestLogger.now();
+    const duration  = endTime.subtract(startTime);
+
     // Note: This call isn't supposed to `throw`, even if there were errors
     // thrown during handling.
-    const info = await request.getLoggableResponseInfo();
-
-    const endTime  = this.#requestLogger.now();
-    const duration = endTime.subtract(startTime);
+    const info = await Response.getLoggableResponseInfo(res, context.socket);
 
     // Rearrange `info` into preferred loggable form, and augment with
     // connection error info if appropriate.
 
     const {
       contentLength,
-      errors,
       errorCodes,
-      headers,
+      ok,
       statusCode
     } = info;
-
-    let { ok } = info;
-
-    const connectionError = context.socket.errored ?? null;
-
-    if (connectionError) {
-      const code = ErrorUtil.extractErrorCode(connectionError);
-
-      errors.connection = connectionError;
-      errorCodes.push(code);
-      ok = false;
-    }
 
     const codeStr = ok ? 'ok' : errorCodes.join(',');
 
     // This is to avoid redundancy and to end up with a specific propery order
     // in `finalInfo` (for human readability).
-    delete info.contentLength;
-    delete info.errorCodes;
-    delete info.headers;
-    delete info.ok;
-    delete info.statusCode;
-
-    const finalInfo = {
-      ok,
-      code: codeStr,
-      duration,
-      status: statusCode,
-      contentLength,
-      headers,
-      ...info
-    };
+    const finalInfo = { ok, duration, ...info };
 
     logger?.response(finalInfo);
 

--- a/src/net-util/export/IntfRequestHandler.js
+++ b/src/net-util/export/IntfRequestHandler.js
@@ -5,6 +5,7 @@ import { Methods } from '@this/typey';
 
 import { DispatchInfo } from '#x/DispatchInfo';
 import { Request } from '#x/Request';
+import { Response } from '#x/Response';
 
 
 /**
@@ -21,11 +22,15 @@ export class IntfRequestHandler {
    * * Returning `true` means that the request was fully handled.
    * * Returning `false` means that the request was not handled.
    * * Throwing an error means that the request failed fatally.
+   * * Returning an instance of {@link #Response} indicates the response to
+   *   ultimately send.
    *
    * @abstract
    * @param {Request} request Request object.
    * @param {?DispatchInfo} dispatch Dispatch information, or `null` if no
-   *   dispatch determination has yet been made.
+   *   dispatch determination was made before calling this instance. (On any
+   *   given instance -- depending on context -- it should be the case that it
+   *   either _always_ or _never_ gets passed `null` for this parameter.)
    * @returns {boolean} Was the request handled? Flag as described above.
    * @throws {Error} Thrown in case of fatal error.
    */

--- a/src/net-util/export/IntfRequestHandler.js
+++ b/src/net-util/export/IntfRequestHandler.js
@@ -31,7 +31,8 @@ export class IntfRequestHandler {
    *   dispatch determination was made before calling this instance. (On any
    *   given instance -- depending on context -- it should be the case that it
    *   either _always_ or _never_ gets passed `null` for this parameter.)
-   * @returns {boolean} Was the request handled? Flag as described above.
+   * @returns {?Response|boolean} Result of handling the request, or `null` if
+   *   not handled by this instance.
    * @throws {Error} Thrown in case of fatal error.
    */
   async handleRequest(request, dispatch) {

--- a/src/net-util/export/IntfRequestHandler.js
+++ b/src/net-util/export/IntfRequestHandler.js
@@ -20,7 +20,7 @@ export class IntfRequestHandler {
    * following meaning:
    *
    * * Returning `true` means that the request was fully handled.
-   * * Returning `false` means that the request was not handled.
+   * * Returning `null` or `false` means that the request was not handled.
    * * Throwing an error means that the request failed fatally.
    * * Returning an instance of {@link Response} indicates the response to
    *   ultimately send.

--- a/src/net-util/export/IntfRequestHandler.js
+++ b/src/net-util/export/IntfRequestHandler.js
@@ -16,14 +16,9 @@ import { Response } from '#x/Response';
 export class IntfRequestHandler {
   /**
    * Asks this instance to handle the given request; that is, parse it, act on
-   * it, and provide a response. Returning / throwing from this method has the
-   * following meaning:
-   *
-   * * Returning `true` means that the request was fully handled.
-   * * Returning `null` or `false` means that the request was not handled.
-   * * Throwing an error means that the request failed fatally.
-   * * Returning an instance of {@link Response} indicates the response to
-   *   ultimately send.
+   * it, and either provide a response to send (or which could possibly be
+   * modified by an intermediary) or return `null` to indicate that the request
+   * was not handled.
    *
    * @abstract
    * @param {Request} request Request object.
@@ -31,8 +26,8 @@ export class IntfRequestHandler {
    *   dispatch determination was made before calling this instance. (On any
    *   given instance -- depending on context -- it should be the case that it
    *   either _always_ or _never_ gets passed `null` for this parameter.)
-   * @returns {?Response|boolean} Result of handling the request, or `null` if
-   *   not handled by this instance.
+   * @returns {?Response} Response to send, or `null` if the request was not in
+   *   fact handled by this instance.
    * @throws {Error} Thrown in case of fatal error.
    */
   async handleRequest(request, dispatch) {

--- a/src/net-util/export/IntfRequestHandler.js
+++ b/src/net-util/export/IntfRequestHandler.js
@@ -22,7 +22,7 @@ export class IntfRequestHandler {
    * * Returning `true` means that the request was fully handled.
    * * Returning `false` means that the request was not handled.
    * * Throwing an error means that the request failed fatally.
-   * * Returning an instance of {@link #Response} indicates the response to
+   * * Returning an instance of {@link Response} indicates the response to
    *   ultimately send.
    *
    * @abstract

--- a/src/net-util/export/Request.js
+++ b/src/net-util/export/Request.js
@@ -360,52 +360,6 @@ export class Request {
   }
 
   /**
-   * Gets all reasonably-logged info about the response that was made. This
-   * method async-returns after the response has been completed, either
-   * successfully or with an error. In case of an error, this method aims to
-   * report the error-ish info via a normal return (not by `throw`ing).
-   *
-   * **Note:** The `headers` in the result omits anything that is redundant
-   * with respect to other parts of the return value. (E.g., the
-   * `content-length` header is always omitted, and the `:status` pseudo-header
-   * is omitted from HTTP2 response headers.)
-   *
-   * @returns {object} Loggable information about the response.
-   */
-  async getLoggableResponseInfo() {
-    let responseError = null;
-
-    try {
-      await this.whenResponseDone();
-    } catch (e) {
-      responseError = e;
-    }
-
-    const res           = this.#coreResponse;
-    const statusCode    = res.statusCode;
-    const headers       = res.getHeaders();
-    const contentLength = headers['content-length'] ?? 0;
-
-    const result = {
-      ok: !responseError,
-      statusCode,
-      contentLength,
-      headers:    Request.#sanitizeResponseHeaders(headers),
-      errorCodes: [],
-      errors:     {}
-    };
-
-    if (responseError) {
-      const code = ErrorUtil.extractErrorCode(responseError);
-
-      result.errorCodes = [code];
-      result.errors     = { response: responseError };
-    }
-
-    return result;
-  }
-
-  /**
    * Sends a response to this request, by asking the given response object to
    * write itself to this instance's underlying {@link ServerResponse} object
    * (or similar).
@@ -542,21 +496,6 @@ export class Request {
     // cryptography properties). This _isn't_ supposed to actually delete th
     // headers _named_ by this value.
     delete result[Http2SensitiveHeaders];
-
-    return result;
-  }
-
-  /**
-   * Cleans up response headers for logging.
-   *
-   * @param {object} headers Original response headers.
-   * @returns {object} Cleaned up version.
-   */
-  static #sanitizeResponseHeaders(headers) {
-    const result = { ...headers };
-
-    delete result[':status'];
-    delete result['content-length'];
 
     return result;
   }

--- a/src/net-util/export/Request.js
+++ b/src/net-util/export/Request.js
@@ -424,6 +424,10 @@ export class Request {
    * @throws {Error} Thrown if there is any trouble sending the response.
    */
   respond(response) {
+    if (this.#responsePromise.isSettled()) {
+      throw new Error('Cannot double-respond!');
+    }
+
     const result = response.writeTo(this.#coreResponse);
 
     this.#responsePromise.resolve(result);

--- a/src/net-util/export/Request.js
+++ b/src/net-util/export/Request.js
@@ -8,7 +8,6 @@ import { Http2ServerRequest, Http2ServerResponse,
 
 import { ManualPromise } from '@this/async';
 import { TreePathKey } from '@this/collections';
-import { ErrorUtil } from '@this/data-values';
 import { FormatUtils, IntfLogger } from '@this/loggy';
 import { MustBe } from '@this/typey';
 

--- a/src/net-util/export/Request.js
+++ b/src/net-util/export/Request.js
@@ -260,15 +260,6 @@ export class Request {
   }
 
   /**
-   * @returns {boolean} An indication of whether this instance believes the
-   * underlying response to have been completed (either successfully or not).
-   */
-  get responseCompleted() {
-    return this.#responsePromise.isSettled
-      && this.#coreResponse.writableEnded;
-  }
-
-  /**
    * @returns {string} The search a/k/a query portion of {@link #targetString},
    * as an unparsed string, or `''` (the empty string) if there is no search
    * string. The result includes anything at or after the first question mark

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -99,8 +99,8 @@ export class BaseApplication extends BaseComponent {
    *
    * @param {Request} request Request object.
    * @param {DispatchInfo} dispatch Dispatch information.
-   * @param {Promise<boolean>} result Promise for the handler result.
-   * @returns {boolean} Was the request handled?
+   * @param {Promise<?Response|boolean>} result Promise for the handler result.
+   * @returns {?Response|boolean} Response to send, if any.
    */
   async #logHandlerCall(request, dispatch, result) {
     const startTime = this.#loggingEnv.now();

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -51,7 +51,7 @@ export class BaseApplication extends BaseComponent {
    * @abstract
    * @param {Request} request Request object.
    * @param {DispatchInfo} dispatch Dispatch information.
-   * @returns {boolean} Was the request handled? Flag as defined by the method
+   * @returns {?Response|boolean} Response to the request, as defined by
    *   {@link IntfRequestHandler#handleRequest}.
    */
   async _impl_handleRequest(request, dispatch) {
@@ -63,7 +63,7 @@ export class BaseApplication extends BaseComponent {
    *
    * @param {Request} request Request object.
    * @param {DispatchInfo} dispatch Dispatch information.
-   * @returns {Response|boolean} Result of handling the request, if any.
+   * @returns {?Response|boolean} Result of handling the request, if any.
    */
   async #callHandler(request, dispatch) {
     const result = this._impl_handleRequest(request, dispatch);
@@ -72,7 +72,7 @@ export class BaseApplication extends BaseComponent {
       return new Error(`\`${this.name}._impl_handleRequest()\` ${msg}.`);
     };
 
-    if ((typeof result === 'boolean') || (result instanceof Response)) {
+    if ((typeof result === 'boolean') || (result === null) || (result instanceof Response)) {
       return result;
     } else if (!(result instanceof Promise)) {
       if (result === undefined) {

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BaseLoggingEnvironment, IntfLogger } from '@this/loggy';
-import { DispatchInfo, IntfRequestHandler, Request } from '@this/net-util';
+import { DispatchInfo, IntfRequestHandler, Request, Response }
+  from '@this/net-util';
 import { ApplicationConfig } from '@this/sys-config';
 import { Methods } from '@this/typey';
 
@@ -62,7 +63,7 @@ export class BaseApplication extends BaseComponent {
    *
    * @param {Request} request Request object.
    * @param {DispatchInfo} dispatch Dispatch information.
-   * @returns {boolean} Was the request handled?
+   * @returns {Response|boolean} Result of handling the request, if any.
    */
   async #callHandler(request, dispatch) {
     const result = this._impl_handleRequest(request, dispatch);
@@ -71,24 +72,24 @@ export class BaseApplication extends BaseComponent {
       return new Error(`\`${this.name}._impl_handleRequest()\` ${msg}.`);
     };
 
-    if (typeof result === 'boolean') {
+    if ((typeof result === 'boolean') || (result instanceof Response)) {
       return result;
     } else if (!(result instanceof Promise)) {
       if (result === undefined) {
         throw error('returned undefined; probably needs an explicit `return`');
       } else {
-        throw error('returned something other than a boolean or a promise');
+        throw error('returned something other than a `Response`, a boolean, or a promise');
       }
     }
 
     const finalResult = await result;
 
-    if (typeof finalResult === 'boolean') {
+    if ((typeof finalResult === 'boolean') || (finalResult instanceof Response)) {
       return finalResult;
     } else if (finalResult === undefined) {
       throw error('async-returned undefined; probably needs an explicit `return`');
     } else {
-      throw error('async-returned something other than a boolean');
+      throw error('async-returned something other than a `Response` or a boolean');
     }
   }
 

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -84,7 +84,7 @@ export class BaseApplication extends BaseComponent {
 
     const finalResult = await result;
 
-    if ((typeof finalResult === 'boolean') || (finalResult instanceof Response)) {
+    if ((typeof finalResult === 'boolean') || (finalResult === null) || (finalResult instanceof Response)) {
       return finalResult;
     } else if (finalResult === undefined) {
       throw error('async-returned undefined; probably needs an explicit `return`');

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -51,7 +51,7 @@ export class BaseApplication extends BaseComponent {
    * @abstract
    * @param {Request} request Request object.
    * @param {DispatchInfo} dispatch Dispatch information.
-   * @returns {?Response|boolean} Response to the request, as defined by
+   * @returns {?Response} Response to the request, if any, as defined by
    *   {@link IntfRequestHandler#handleRequest}.
    */
   async _impl_handleRequest(request, dispatch) {
@@ -63,7 +63,7 @@ export class BaseApplication extends BaseComponent {
    *
    * @param {Request} request Request object.
    * @param {DispatchInfo} dispatch Dispatch information.
-   * @returns {?Response|boolean} Result of handling the request, if any.
+   * @returns {?Response} Response to the request, if any.
    */
   async #callHandler(request, dispatch) {
     const result = this._impl_handleRequest(request, dispatch);
@@ -99,8 +99,8 @@ export class BaseApplication extends BaseComponent {
    *
    * @param {Request} request Request object.
    * @param {DispatchInfo} dispatch Dispatch information.
-   * @param {Promise<?Response|boolean>} result Promise for the handler result.
-   * @returns {?Response|boolean} Response to send, if any.
+   * @param {Promise<?Response>} result Promise for the handler response.
+   * @returns {?Response} Response to the request, if any.
    */
   async #logHandlerCall(request, dispatch, result) {
     const startTime = this.#loggingEnv.now();

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -72,24 +72,24 @@ export class BaseApplication extends BaseComponent {
       return new Error(`\`${this.name}._impl_handleRequest()\` ${msg}.`);
     };
 
-    if ((typeof result === 'boolean') || (result === null) || (result instanceof Response)) {
+    if ((result === null) || (result instanceof Response)) {
       return result;
     } else if (!(result instanceof Promise)) {
       if (result === undefined) {
         throw error('returned undefined; probably needs an explicit `return`');
       } else {
-        throw error('returned something other than a `Response`, a boolean, or a promise');
+        throw error('returned something other than a `Response`, `null`, or a promise');
       }
     }
 
     const finalResult = await result;
 
-    if ((typeof finalResult === 'boolean') || (finalResult === null) || (finalResult instanceof Response)) {
+    if ((finalResult === null) || (finalResult instanceof Response)) {
       return finalResult;
     } else if (finalResult === undefined) {
       throw error('async-returned undefined; probably needs an explicit `return`');
     } else {
-      throw error('async-returned something other than a `Response` or a boolean');
+      throw error('async-returned something other than a `Response` or `null`');
     }
   }
 

--- a/src/sys-framework/export/NetworkEndpoint.js
+++ b/src/sys-framework/export/NetworkEndpoint.js
@@ -6,7 +6,7 @@ import { IntfLogger } from '@this/loggy';
 import { IntfRateLimiter, IntfRequestLogger, ProtocolWrangler,
   ProtocolWranglers }
   from '@this/net-protocol';
-import { DispatchInfo, IntfRequestHandler } from '@this/net-util';
+import { DispatchInfo, IntfRequestHandler, Response } from '@this/net-util';
 import { EndpointConfig, MountConfig } from '@this/sys-config';
 
 import { BaseApplication } from '#x/BaseApplication';

--- a/src/sys-framework/export/NetworkEndpoint.js
+++ b/src/sys-framework/export/NetworkEndpoint.js
@@ -122,8 +122,15 @@ export class NetworkEndpoint extends BaseComponent {
       });
 
       try {
-        if (await application.handleRequest(request, dispatch)) {
-          return true;
+        const result = await application.handleRequest(request, dispatch);
+        if ((result instanceof Response) || (result === true)) {
+          return result;
+        } else if ((result !== null) && (result !== false) && (result !== true)) {
+          // Caught immediately below.
+          const type = ((typeof result === 'object') || (typeof result === 'function'))
+            ? result.constructor.name
+            : typeof result;
+          throw new Error(`Unexpected result type from \`handleRequest\`: ${type}`);
         }
       } catch (e) {
         request.logger?.applicationError(e);

--- a/src/sys-framework/export/NetworkEndpoint.js
+++ b/src/sys-framework/export/NetworkEndpoint.js
@@ -123,9 +123,9 @@ export class NetworkEndpoint extends BaseComponent {
 
       try {
         const result = await application.handleRequest(request, dispatch);
-        if ((result instanceof Response) || (result === true)) {
+        if ((result instanceof Response) || (result === null)) {
           return result;
-        } else if ((result !== null) && (result !== false) && (result !== true)) {
+        } else {
           // Caught immediately below.
           const type = ((typeof result === 'object') || (typeof result === 'function'))
             ? result.constructor.name

--- a/src/sys-framework/export/NetworkEndpoint.js
+++ b/src/sys-framework/export/NetworkEndpoint.js
@@ -104,7 +104,7 @@ export class NetworkEndpoint extends BaseComponent {
     if (!hostMatch) {
       // No matching host.
       request.logger?.hostNotFound(request.host.nameString);
-      return false;
+      return null;
     }
 
     // Iterate from most- to least-specific mounted path.
@@ -139,7 +139,7 @@ export class NetworkEndpoint extends BaseComponent {
 
     // No mounted path actually handled the request.
     request.logger?.pathNotFound(request.pathname);
-    return false;
+    return null;
   }
 
   /** @override */


### PR DESCRIPTION
The main thrust of this PR is to get it so that `IntfRequestHandler.handleRequest()` returns a response object instead of (a) returning a boolean (handled or not?), and (b) in the case of `true` was expected to actually do the responding. The caller of this interface is now expected to undertake the responding, which opens up the possibility of a pattern where a `Response` object can bubble up through handler layers, each of which has an opportunity to modify the response. We don't use that pattern _yet_, but I expect we will. And, in any case, this makes the control flow during requests a lot more straightforward, since we only ever end up doing low-level network stuff at the protocol layer and not as (what amounts to) a callback from the application layer.