### PR TITLE
Request filtering

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -229,7 +229,8 @@ request will get re-dispatched to the next application in the chain (if any).
 ### `Redirector`
 
 An application which responds to all requests with an HTTP "redirect" response.
-It accepts the following configuration bindings:
+In addition to the [`BaseApplication`](#baseapplication) configuration options,
+it accepts the following bindings:
 
 * `statusCode` &mdash; Optional HTTP status code to respond with. If not
   specified, it defaults to `301` ("Moved Permanently").

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -219,8 +219,11 @@ the following configuration bindings:
   not ending with an empty path component) should be automatically redirected to
   the directory version of the path. Defaults to `false`.
 
-With regards to the `redirect*` options, it is an error to specify both as
-`true`.
+With regards to the `redirect*` options:
+* It is an error to specify both as `true`.
+* The redirection (or not) is entirely based on the form of the path, not on any
+  file contents (for example). Notably, [`StaticFiles`](#staticfiles) does
+  _content_-driven redirection, which is different than what is done here.
 
 With regards to the other options, when a request is filtered out, the result is
 that the application simply _doesn't handle_ the request, meaning that the
@@ -325,9 +328,13 @@ const applications = [
 
 ### `StaticFiles`
 
-An application which serves static files from a local directory. It accepts the
-following configuration bindings:
+An application which serves static files from a local directory. In addition to
+most of the [`BaseApplication`](#baseapplication) configuration options (all
+but the `redirect*` options, which could cause chaos in this case), it accepts
+the following configuration bindings:
 
+* `acceptMethods` &mdash; `BaseApplication` configuration, but in this case the
+  default is `['get', 'head']`.
 * `etag` &mdash; ETag-generating options. If present and not `false`, the
   response comes with an `ETag` header. See "ETag Configuration" below for
   details.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -205,7 +205,7 @@ the following configuration bindings:
 * `acceptQueries` &mdash; Boolean indicating whether or not to accept requests
   that include a "query" (search) component. Defaults to `true`.
 * `acceptMethods` &mdash; Array of strings indicating which request methods to
-  accept. The array can include any of `connect`, `delete`, `head`, `get`,
+  accept. The array can include any of `connect`, `delete`, `get`, `head`,
   `options`, `patch`, `post`, `put`, and/or `trace`. Defaults to the entire set.
 * `maxPathLength` &mdash; Number indicating the maximum allowed length of a
   dispatched request path not including the mount point, and not including the
@@ -270,6 +270,8 @@ like `StaticFiles`, except just one file. In addition to the
 [`BaseApplication`](#baseapplication) configuration options, it accepts the
 following configuration bindings:
 
+* `acceptMethods` &mdash; `BaseApplication` configuration, but in this case the
+  default is `['get', 'head']`.
 * `body` &mdash; Optional body contents to respond with. If specified, this must
   be either a string or a Node `Buffer` object.
 * `contentType` &mdash; Content type to report. This can be either a MIME type

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -226,6 +226,17 @@ With regards to the other options, when a request is filtered out, the result is
 that the application simply _doesn't handle_ the request, meaning that the
 request will get re-dispatched to the next application in the chain (if any).
 
+```js
+const applications = [
+  {
+    name:          'myCustomApp',
+    class:         'SomeSubclass',
+    acceptQueries: false,
+    acceptMethods: ['delete', 'put']
+  }
+];
+```
+
 ### `Redirector`
 
 An application which responds to all requests with an HTTP "redirect" response.
@@ -242,11 +253,12 @@ it accepts the following bindings:
 ```js
 const applications = [
   {
-    name:         'myRedirector',
-    class:        'Redirector',
-    statusCode:   308,
-    target:       'https://example.com/boop/',
-    cacheControl: { public: true, maxAge: '5 min' }
+    name:          'myRedirector',
+    class:         'Redirector',
+    statusCode:    308,
+    target:        'https://example.com/boop/',
+    cacheControl:  { public: true, maxAge: '5 min' },
+    acceptMethods: ['head', 'get']
   }
 ];
 ```
@@ -288,11 +300,13 @@ by a `filePath` behaves.
 ```js
 const applications = [
   {
-    name:        'literal',
-    class:       'SimpleResponse',
-    contentType: 'text/plain',
-    body:        'Hello!\n',
-    cacheControl: { public: true, maxAge: '1_day' }
+    name:                'literal',
+    class:               'SimpleResponse',
+    contentType:         'text/plain',
+    body:                'Hello!\n',
+    cacheControl:        { public: true, maxAge: '1_day' },
+    maxPathLength:       0,
+    redirectDirectories: true
   },
   {
     name:         'fromFile',

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -196,6 +196,36 @@ hostname. (It will not fall back to less specific hostnames.)
 
 ## Built-in Applications
 
+### `BaseApplication`
+
+`BaseApplication` can be subclassed to implement custom behavior. In addition,
+it optionally provides request filtering for application subclasses. It accepts
+the following configuration bindings:
+
+* `acceptQueries` &mdash; Boolean indicating whether or not to accept requests
+  that include a "query" (search) component. Defaults to `true`.
+* `acceptMethods` &mdash; Array of strings indicating which request methods to
+  accept. The array can include any of `connect`, `delete`, `head`, `get`,
+  `options`, `patch`, `post`, `put`, and/or `trace`. Defaults to the entire set.
+* `maxPathLength` &mdash; Number indicating the maximum allowed length of a
+  dispatched request path not including the mount point, and not including the
+  empty path component at the end of a directory path. `null` indicates "no
+  limit." Defaults to `null`.
+* `redirectDirectories` &mdash; Boolean indicating whether or not directory
+  paths (those ending with an empty path component) should be automatically
+  redirected to the file (non-directory) version of the path. Defaults to
+  `false`.
+* `redirectFiles` &mdash; Boolean indicating whether or not file paths (those
+  not ending with an empty path component) should be automatically redirected to
+  the directory version of the path. Defaults to `false`.
+
+With regards to the `redirect*` options, it is an error to specify both as
+`true`.
+
+With regards to the other options, when a request is filtered out, the result is
+that the application simply _doesn't handle_ the request, meaning that the
+request will get re-dispatched to the next application in the chain (if any).
+
 ### `Redirector`
 
 An application which responds to all requests with an HTTP "redirect" response.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -254,8 +254,9 @@ const applications = [
 ### `SimpleResponse`
 
 An application which only ever sends one particular response. It's approximately
-like `StaticFiles`, except just one file. It accepts the following configuration
-bindings:
+like `StaticFiles`, except just one file. In addition to the
+[`BaseApplication`](#baseapplication) configuration options, it accepts the
+following configuration bindings:
 
 * `body` &mdash; Optional body contents to respond with. If specified, this must
   be either a string or a Node `Buffer` object.

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -121,7 +121,7 @@ const applications = [
     class:        'Redirector',
     statusCode:   308,
     target:       'https://localhost:8443/resp/',
-    cacheControl: { public: true, maxAge: '5 min' },
+    cacheControl: { public: true, maxAge: '5 min' }
   },
   {
     name:          'myStaticFun',
@@ -135,7 +135,7 @@ const applications = [
     name:          'myStaticFunNo404',
     class:         'StaticFiles',
     siteDirectory: filePath('../site'),
-    cacheControl:  { public: true, maxAge: '5 min' },
+    cacheControl:  { public: true, maxAge: '5 min' }
   },
   {
     name:         'responseEmptyBody',

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -159,15 +159,19 @@ const applications = [
       hashAlgorithm: 'sha1',
       hashLength:    12,
       tagForm:       'weak'
-    }
+    },
+    maxPathLength:       0,
+    redirectDirectories: true
   },
   {
-    name:         'responseTwo',
-    class:        'SimpleResponse',
-    contentType:  'text/html',
-    body:         '<html><body><h1>Two!</h1></body></html>\n',
-    cacheControl: { public: true, immutable: true, maxAge: '13 min'  },
-    etag:         true
+    name:                'responseTwo',
+    class:               'SimpleResponse',
+    contentType:         'text/html',
+    body:                '<html><body><h1>Two!</h1></body></html>\n',
+    cacheControl:        { public: true, immutable: true, maxAge: '13 min'  },
+    etag:                true,
+    maxPathLength:       0,
+    redirectDirectories: true
   }
 ];
 

--- a/src/builtin-applications/export/Redirector.js
+++ b/src/builtin-applications/export/Redirector.js
@@ -76,7 +76,7 @@ export class Redirector extends BaseApplication {
   /**
    * Configuration item subclass for this (outer) class.
    */
-  static #Config = class Config extends ApplicationConfig {
+  static #Config = class Config extends BaseApplication.FilterConfig {
     /** @type {number} The redirect status code to use. */
     #statusCode;
 

--- a/src/builtin-applications/export/SimpleResponse.js
+++ b/src/builtin-applications/export/SimpleResponse.js
@@ -130,7 +130,10 @@ export class SimpleResponse extends BaseApplication {
      * @param {object} config Configuration object.
      */
     constructor(config) {
-      super(config);
+      super({
+        acceptMethods: ['get', 'head'],
+        ...config
+      });
 
       const {
         body         = null,

--- a/src/builtin-applications/export/SimpleResponse.js
+++ b/src/builtin-applications/export/SimpleResponse.js
@@ -6,7 +6,6 @@ import fs from 'node:fs/promises';
 import { Paths, Statter } from '@this/fs-util';
 import { EtagGenerator, HttpUtil, MimeTypes, OutgoingResponse }
   from '@this/net-util';
-import { ApplicationConfig } from '@this/sys-config';
 import { BaseApplication } from '@this/sys-framework';
 import { MustBe } from '@this/typey';
 
@@ -97,7 +96,7 @@ export class SimpleResponse extends BaseApplication {
   /**
    * Configuration item subclass for this (outer) class.
    */
-  static #Config = class Config extends ApplicationConfig {
+  static #Config = class Config extends BaseApplication.FilterConfig {
     /**
      * @type {?string} Content type of the response, or `null` to infer it from
      * {@link #filePath}.

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -7,6 +7,7 @@ import { Paths, Statter } from '@this/fs-util';
 import { IntfLogger } from '@this/loggy';
 import { DispatchInfo, EtagGenerator, HttpUtil, MimeTypes, OutgoingResponse }
   from '@this/net-util';
+import { ApplicationConfig } from '@this/sys-config';
 import { BaseApplication } from '@this/sys-framework';
 
 

--- a/src/builtin-applications/export/StaticFiles.js
+++ b/src/builtin-applications/export/StaticFiles.js
@@ -7,7 +7,6 @@ import { Paths, Statter } from '@this/fs-util';
 import { IntfLogger } from '@this/loggy';
 import { DispatchInfo, EtagGenerator, HttpUtil, MimeTypes, OutgoingResponse }
   from '@this/net-util';
-import { ApplicationConfig } from '@this/sys-config';
 import { BaseApplication } from '@this/sys-framework';
 
 
@@ -254,7 +253,7 @@ export class StaticFiles extends BaseApplication {
   /**
    * Configuration item subclass for this (outer) class.
    */
-  static #Config = class Config extends ApplicationConfig {
+  static #Config = class Config extends BaseApplication.FilterConfig {
     /**
      * @type {?string} Path to the file to serve for a not-found result, or
      * `null` if not-found handling shouldn't be done.
@@ -282,7 +281,14 @@ export class StaticFiles extends BaseApplication {
      * @param {object} config Configuration object.
      */
     constructor(config) {
-      super(config);
+      super({
+        acceptMethods: ['get', 'head'],
+        ...config,
+
+        // These are always disabled. See configuration docs for explanation.
+        redirectDirectories: false,
+        redirectFiles:       false
+      });
 
       const {
         cacheControl = null,

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -164,14 +164,9 @@ export class DispatchInfo {
     const base    = this.#base;
     const baseLen = base.length;
 
-    if (n < baseLen) {
-      return base.path[n];
-    }
-
-    const extra    = this.#extra;
-    const extraLen = extra.length;
-
-    return extra.path[n - baseLen];
+    return (n < baseLen)
+      ? base.path[n]
+      : this.#extra.path[n - baseLen];
   }
 
   /**

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -294,7 +294,7 @@ export class BaseApplication extends BaseComponent {
 
     /** @type {Set<string>} Allowed values for `methods`. */
     static #METHODS = new Set([
-      'connect', 'delete', 'head', 'get', 'options',
+      'connect', 'delete', 'get', 'head', 'options',
       'patch', 'post', 'put', 'trace'
     ]);
   };

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -62,7 +62,7 @@ export class BaseApplication extends BaseComponent {
       }
 
       if (maxPathLength !== null) {
-        const length = dispatch.fullPathLength - (dispatch.isDirectory() ? 1 : 0);
+        const length = dispatch.extra.length - (dispatch.isDirectory() ? 1 : 0);
         if (length > maxPathLength) {
           return null;
         }

--- a/src/sys-framework/export/NetworkEndpoint.js
+++ b/src/sys-framework/export/NetworkEndpoint.js
@@ -124,15 +124,16 @@ export class NetworkEndpoint extends BaseComponent {
 
       try {
         const result = await application.handleRequest(request, dispatch);
-        if ((result instanceof OutgoingResponse) || (result === null)) {
+        if (result instanceof OutgoingResponse) {
           return result;
-        } else {
+        } else if (result !== null) {
           // Caught immediately below.
           const type = ((typeof result === 'object') || (typeof result === 'function'))
             ? result.constructor.name
             : typeof result;
           throw new Error(`Unexpected result type from \`handleRequest\`: ${type}`);
         }
+        // `result === null`, so we iterate to try the next handler (if any).
       } catch (e) {
         request.logger?.applicationError(e);
       }

--- a/src/typey/export/AskIf.js
+++ b/src/typey/export/AskIf.js
@@ -61,15 +61,17 @@ export class AskIf {
    * Checks for type `string[]`.
    *
    * @param {*} value Arbitrary value.
+   * @param {?RegExp|string|Set<string>} [match] Optional regular expression
+   *  (either per se or as a string) or set of values that `value` must match.
    * @returns {boolean} `true` iff `value` is of the indicated type.
    */
-  static arrayOfString(value) {
+  static arrayOfString(value, match = null) {
     if (!Array.isArray(value)) {
       return false;
     }
 
     for (const v of value) {
-      if (typeof v !== 'string') {
+      if (!AskIf.string(v, match)) {
         return false;
       }
     }

--- a/src/typey/export/AskIf.js
+++ b/src/typey/export/AskIf.js
@@ -300,11 +300,11 @@ export class AskIf {
 
   /**
    * Checks for type `string`, optionally matching a particular regular
-   * expression.
+   * expression or set of values.
    *
    * @param {*} value Arbitrary value.
-   * @param {?RegExp|string} [match] Optional regular expression that
-   *  `value` must match.
+   * @param {?RegExp|string|Set<string>} [match] Optional regular expression
+   *  (either per se or as a string) or set of values that `value` must match.
    * @returns {boolean} `true` iff `value` is of the indicated type.
    */
   static string(value, match = null) {
@@ -312,13 +312,16 @@ export class AskIf {
       return false;
     }
 
-    if (match) {
-      if (typeof match === 'string') {
-        match = new RegExp(match);
-      }
-      if (!match.test(value)) {
-        return false;
-      }
+    if (match === null) {
+      return true;
+    } else if (typeof match === 'string') {
+      return new RegExp(match).test(value);
+    } else if (match instanceof RegExp) {
+      return match.test(value);
+    } else if (match instanceof Set) {
+      return match.has(value);
+    } else {
+      throw new Error('Unrecognized type for `match`.');
     }
 
     return true;

--- a/src/typey/export/AskIf.js
+++ b/src/typey/export/AskIf.js
@@ -325,8 +325,6 @@ export class AskIf {
     } else {
       throw new Error('Unrecognized type for `match`.');
     }
-
-    return true;
   }
 
   /**

--- a/src/typey/export/MustBe.js
+++ b/src/typey/export/MustBe.js
@@ -253,11 +253,11 @@ export class MustBe {
 
   /**
    * Checks for type `string`, optionally matching a particular regular
-   * expression.
+   * expression or set of values.
    *
    * @param {*} value Arbitrary value.
-   * @param {?RegExp|string} [match] Optional regular expression that
-   *  `value` must match.
+   * @param {?RegExp|string|Set<string>} [match] Optional regular expression
+   *  (either per se or as a string) or set of values that `value` must match.
    * @returns {string} `value` if it is of the indicated type.
    * @throws {Error} Thrown if `value` is of any other type or doesn't match.
    */
@@ -267,7 +267,7 @@ export class MustBe {
     }
 
     if (match) {
-      throw new Error(`Must be of type \`string\` and match pattern: ${match}`);
+      throw new Error(`Must be of type \`string\` and match: ${match}`);
     } else {
       throw new Error('Must be of type `string`.');
     }

--- a/src/typey/export/MustBe.js
+++ b/src/typey/export/MustBe.js
@@ -53,15 +53,21 @@ export class MustBe {
    * Checks for type `string[]`.
    *
    * @param {*} value Arbitrary value.
+   * @param {?RegExp|string|Set<string>} [match] Optional regular expression
+   *  (either per se or as a string) or set of values that `value` must match.
    * @returns {string[]} `value` if it is of the indicated type.
    * @throws {Error} Thrown if `value` is of any other type.
    */
-  static arrayOfString(value) {
-    if (AskIf.arrayOfString(value)) {
+  static arrayOfString(value, match = null) {
+    if (AskIf.arrayOfString(value, null)) {
       return value;
     }
 
-    throw new Error('Must be of type `string[]`.');
+    if (match) {
+      throw new Error(`Must be of type \`string[]\` and match: ${match}`);
+    } else {
+      throw new Error('Must be of type `string[]`.');
+    }
   }
 
   /**

--- a/src/typey/tests/AskIf.test.js
+++ b/src/typey/tests/AskIf.test.js
@@ -237,6 +237,47 @@ describe('object()', () => {
   });
 });
 
+describe('string', () => {
+  test.each`
+  arg
+  ${undefined}
+  ${null}
+  ${true}
+  ${123}
+  ${123n}
+  ${Symbol('x')}
+  `('returns `false` given $arg', ({ arg }) => {
+    expect(AskIf.string(arg)).toBeFalse();
+  });
+
+  test.each`
+  arg
+  ${''}
+  ${'x'}
+  ${'floop!'}
+  `('returns `true` given string `$arg`', ({ arg }) => {
+    expect(AskIf.string(arg)).toBeTrue();
+  });
+
+  test('throws given an invalid match `match`', () => {
+    expect(() => AskIf.string('x', ['boop'])).toThrow();
+  });
+
+  test.each`
+  value     | match                        | expected
+  ${'x'}    | ${null}                      | ${true}
+  ${123}    | ${null}                      | ${false}
+  ${'xyz'}  | ${/y/}                       | ${true}
+  ${'xyz'}  | ${/w/}                       | ${false}
+  ${'abc'}  | ${'^ab'}                     | ${true}
+  ${'abc'}  | ${'z'}                       | ${false}
+  ${'boop'} | ${new Set(['beep', 'boop'])} | ${true}
+  ${'bop'}  | ${new Set(['zip', 'zap'])}   | ${false}
+  `('returns $expected given ($value, $match)', ({ value, match, expected }) => {
+    expect(AskIf.string(value, match)).toBe(expected);
+  });
+});
+
 describe('subclassOf()', () => {
   describe('on non-classes', () => {
     test.each`

--- a/src/typey/tests/AskIf.test.js
+++ b/src/typey/tests/AskIf.test.js
@@ -6,6 +6,69 @@ import { AskIf } from '@this/typey';
 
 // TODO: Almost everything.
 
+describe('arrayOfString()', () => {
+  test.each`
+  arg
+  ${'x'}
+  ${undefined}
+  ${null}
+  ${true}
+  ${123}
+  ${123n}
+  ${{ x: 'x' }}
+  ${Symbol('x')}
+  ${[false]}
+  ${['x', null]}
+  ${[[], 'x']}
+  `('returns `false` given $arg', ({ arg }) => {
+    expect(AskIf.arrayOfString(arg)).toBeFalse();
+  });
+
+  test.each`
+  arg
+  ${[]}
+  ${['x']}
+  ${['floop!']}
+  ${['a', 'b', 'c']}
+  `('returns `true` given `$arg`', ({ arg }) => {
+    expect(AskIf.arrayOfString(arg)).toBeTrue();
+  });
+
+  test('throws given an invalid match `match`', () => {
+    expect(() => AskIf.arrayOfString(['x'], ['boop'])).toThrow();
+  });
+
+  test.each`
+  value               | match                        | expected
+  ${[]}               | ${null}                      | ${true}
+  ${['x']}            | ${null}                      | ${true}
+  ${['x', 'y']}       | ${null}                      | ${true}
+  ${123}              | ${null}                      | ${false}
+  ${123}              | ${/blorp/}                   | ${false}
+  ${123}              | ${new Set(['x'])}            | ${false}
+  ${[123]}            | ${null}                      | ${false}
+  ${[123]}            | ${/blorp/}                   | ${false}
+  ${[123]}            | ${new Set(['x'])}            | ${false}
+  ${['x', 123]}       | ${null}                      | ${false}
+  ${[123, 'b']}       | ${/b/}                       | ${false}
+  ${['x', 123]}       | ${new Set(['x'])}            | ${false}
+  ${['xyz']}          | ${/y/}                       | ${true}
+  ${['xyz', 'y']}     | ${/y/}                       | ${true}
+  ${['xyz']}          | ${/w/}                       | ${false}
+  ${['xyz', 'w']}     | ${/w/}                       | ${false}
+  ${['abc']}          | ${'^ab'}                     | ${true}
+  ${['abc', 'abd']}   | ${'^ab'}                     | ${true}
+  ${['abc']}          | ${'z'}                       | ${false}
+  ${['abc', 'z']}     | ${'z'}                       | ${false}
+  ${['boop']}         | ${new Set(['beep', 'boop'])} | ${true}
+  ${['boop', 'beep']} | ${new Set(['beep', 'boop'])} | ${true}
+  ${['bop']}          | ${new Set(['zip', 'zap'])}   | ${false}
+  ${['bop', 'zip']}   | ${new Set(['zip', 'zap'])}   | ${false}
+  `('returns $expected given ($value, $match)', ({ value, match, expected }) => {
+    expect(AskIf.arrayOfString(value, match)).toBe(expected);
+  });
+});
+
 describe('callableFunction()', () => {
   describe('non-functions', () => {
     test.each`
@@ -237,7 +300,7 @@ describe('object()', () => {
   });
 });
 
-describe('string', () => {
+describe('string()', () => {
   test.each`
   arg
   ${undefined}
@@ -246,6 +309,8 @@ describe('string', () => {
   ${123}
   ${123n}
   ${Symbol('x')}
+  ${['x']}
+  ${{ x: 'x' }}
   `('returns `false` given $arg', ({ arg }) => {
     expect(AskIf.string(arg)).toBeFalse();
   });
@@ -267,6 +332,8 @@ describe('string', () => {
   value     | match                        | expected
   ${'x'}    | ${null}                      | ${true}
   ${123}    | ${null}                      | ${false}
+  ${123}    | ${/blorp/}                   | ${false}
+  ${123}    | ${new Set(['x'])}            | ${false}
   ${'xyz'}  | ${/y/}                       | ${true}
   ${'xyz'}  | ${/w/}                       | ${false}
   ${'abc'}  | ${'^ab'}                     | ${true}


### PR DESCRIPTION
This PR adds a request filtering mechanism to `BaseApplication`, which is optionally available to all subclasses. And in fact, it gets implemented on all the existing subclasses.