### PR TITLE
More time stuff

### DIFF
--- a/src/.eslintrc.cjs
+++ b/src/.eslintrc.cjs
@@ -162,6 +162,14 @@ const disallowedFunctionality = {
         })
       ]
     }
+  ],
+  'no-restricted-properties': [
+    'error',
+    {
+      object:   'Date',
+      property: 'now',
+      message:  'Use module `clocks` from this project.'
+    }
   ]
 };
 

--- a/src/.eslintrc.cjs
+++ b/src/.eslintrc.cjs
@@ -170,6 +170,13 @@ const disallowedFunctionality = {
       property: 'now',
       message:  'Use module `clocks` from this project.'
     }
+  ],
+  'no-restricted-syntax': [
+    'error',
+    {
+      selector: 'NewExpression[callee.name=\'Date\'][arguments.length!=1]',
+      message:  'Use module `clocks` or class `data-values.Moment`.'
+    }
   ]
 };
 

--- a/src/.eslintrc.cjs
+++ b/src/.eslintrc.cjs
@@ -138,6 +138,11 @@ const disallowedFunctionality = {
     {
       paths: [
         {
+          name:        'node:process',
+          importNames: ['hrtime'],
+          message:     'Use module `clocks` from this project.'
+        },
+        {
           name:        'node:timers',
           importNames: ['clearTimeout', 'clearInterval', 'setTimeout', 'setInterval'],
           message:     'Use module `clocks` from this project.'

--- a/src/async/tests/EventSource.test.js
+++ b/src/async/tests/EventSource.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
+import { setImmediate } from 'node:timers/promises';
 
 import { EventPayload, EventSource, LinkedEvent, PromiseState }
   from '@this/async';
@@ -43,7 +43,7 @@ describe.each`
   test('produces an instance whose `currentEvent` is unsettled', async () => {
     const source = new EventSource(...argFn());
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(source.currentEvent)).toBeFalse();
   });
 
@@ -55,7 +55,7 @@ describe.each`
   test('produces an instance whose `earliestEvent` is unsettled', async () => {
     const source = new EventSource(...argFn());
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(source.earliestEvent)).toBeFalse();
   });
 

--- a/src/async/tests/EventTracker.test.js
+++ b/src/async/tests/EventTracker.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
+import { setImmediate } from 'node:timers/promises';
 
 import { EventPayload, EventTracker, LinkedEvent, ManualPromise, PromiseState }
   from '@this/async';
@@ -112,12 +112,12 @@ describe('.headPromise', () => {
     tracker.advance(1);
 
     expect(tracker.headNow).toBeNull();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(tracker.headPromise)).toBeFalse();
 
     event1.emitter(payload2);
     const event2 = event1.nextNow;
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(tracker.headPromise)).toBeTrue();
 
     expect(await tracker.headPromise).toBe(event2);
@@ -130,7 +130,7 @@ describe('.headPromise', () => {
     expect(await tracker.headPromise).toBe(event);
     tracker.advance(1);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(tracker.headPromise)).toBeFalse();
   });
 
@@ -159,7 +159,7 @@ describe('.headNow', () => {
     expect(tracker.headNow).toBeNull();
     mp.resolve(event);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(tracker.headPromise)).toBeTrue();
     expect(await tracker.headPromise).toBe(event);
   });
@@ -279,19 +279,19 @@ describe('advance(type)', () => {
 
     const event1 = new LinkedEvent(payload1);
     mp.resolve(event1);
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeFalse();
 
     const emitter2 = event1.emitter(payload2);
     const event2 = event1.nextNow;
     expect(tracker.headNow).toBeNull();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeFalse();
 
     emitter2(new EventPayload(type));
     const event3 = event2.nextNow;
     expect(tracker.headNow).toBeNull();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBe(event3);
 
@@ -388,7 +388,7 @@ describe('advance(count)', () => {
         expect(await result).toBe(events[advanceCount]);
       } else {
         expect(tracker.headNow).toBeNull();
-        await timers.setImmediate();
+        await setImmediate();
         expect(PromiseState.isSettled(result)).toBeFalse();
       }
     });
@@ -406,11 +406,11 @@ describe('advance(count)', () => {
       expect(tracker.headNow).toBeNull();
 
       if (advanceCount < startCount) {
-        await timers.setImmediate();
+        await setImmediate();
         expect(PromiseState.isSettled(result)).toBeTrue();
         expect(await result).toBe(events[advanceCount]);
       } else {
-        await timers.setImmediate();
+        await setImmediate();
         expect(PromiseState.isSettled(result)).toBeFalse();
 
         let emitter = events[startCount - 1].emitter;
@@ -419,7 +419,7 @@ describe('advance(count)', () => {
           events.push(events[i - 1].nextNow);
         }
 
-        await timers.setImmediate();
+        await setImmediate();
         expect(PromiseState.isSettled(result)).toBeTrue();
         expect(await result).toBe(events[advanceCount]);
       }
@@ -441,13 +441,13 @@ describe('advance(count)', () => {
         let emitter = events[startCount - 1].emitter;
         for (let i = startCount; i <= advanceCount; i++) {
           expect(tracker.headNow).toBeNull();
-          await timers.setImmediate();
+          await setImmediate();
           expect(PromiseState.isSettled(result)).toBeFalse();
           emitter = emitter(new EventPayload('at', i));
           events.push(events[i - 1].nextNow);
         }
 
-        await timers.setImmediate();
+        await setImmediate();
         expect(PromiseState.isSettled(result)).toBeTrue();
         expect(tracker.headNow).toBe(events[advanceCount]);
         expect(await result).toBe(events[advanceCount]);
@@ -535,22 +535,22 @@ describe('advance(function)', () => {
     const result = tracker.advance((e) => e.payload === payload3);
 
     expect(tracker.headNow).toBeNull();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeFalse();
     mp1.resolve(event1);
 
     expect(tracker.headNow).toBeNull();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeFalse();
     mp2.resolve(event2);
 
     expect(tracker.headNow).toBeNull();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeFalse();
     mp3.resolve(event3);
 
     expect(tracker.headNow).toBeNull();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBe(event3);
 
@@ -573,19 +573,19 @@ describe('advance(function)', () => {
       return e.payload === payload3;
     });
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(callCount).toBe(0);
     mp1.resolve(event1);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(callCount).toBe(1);
     mp2.resolve(event2);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(callCount).toBe(2);
     mp3.resolve(event3);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(callCount).toBe(3);
     expect(await result).toBe(event3);
   });
@@ -619,14 +619,14 @@ describe('advance() breakage scenarios', () => {
       const tracker = new EventTracker(Promise.resolve('not-an-event-1'));
 
       expect(tracker.headNow).toBeNull(); // Not yet broken!
-      await timers.setImmediate();
+      await setImmediate();
       await expect(() => tracker.advance(1)).rejects.toThrow();
     });
 
     test('remains broken', async () => {
       const tracker = new EventTracker(Promise.resolve('not-an-event-2'));
 
-      await timers.setImmediate();
+      await setImmediate();
       await expect(() => tracker.advance()).rejects.toThrow();
       await expect(() => tracker.advance(1)).rejects.toThrow();
       await expect(() => tracker.advance('eep')).rejects.toThrow();
@@ -782,7 +782,7 @@ describe('advanceSync()', () => {
 
     expect(tracker.advanceSync(2)).toBeNull();
     expect(tracker.headNow).toBeNull();
-    await timers.setImmediate();
+    await setImmediate();
     expect(tracker.headNow).toBe(event3);
   });
 
@@ -794,7 +794,7 @@ describe('advanceSync()', () => {
 
     const result1 = tracker.advance(1);
     expect(tracker.advanceSync(1)).toBeNull();
-    await timers.setImmediate();
+    await setImmediate();
     expect(tracker.headNow).toBe(event3);
     expect(await result1).toBe(event2);
   });
@@ -812,7 +812,7 @@ describe('advanceSync()', () => {
     expect(tracker.advanceSync(1)).toBe(null);
     expect(tracker.headNow).toBe(null);
     mp.reject(new Error('Oh noes!'));
-    await timers.setImmediate();
+    await setImmediate();
     expect(() => tracker.headNow).toThrow();
   });
 });
@@ -841,7 +841,7 @@ describe('advanceSync() on a broken instance', () => {
     const tracker = new EventTracker(Promise.resolve('not-an-event-3'));
 
     expect(tracker.headNow).toBeNull(); // Not yet broken!
-    await timers.setImmediate();
+    await setImmediate();
     expect(() => tracker.headNow).toThrow(); // Now broken!
     expect(tracker.advanceSync()).toBeNull();
   });
@@ -850,7 +850,7 @@ describe('advanceSync() on a broken instance', () => {
     const tracker = new EventTracker(Promise.resolve('not-an-event-4'));
 
     expect(tracker.headNow).toBeNull(); // Not yet broken!
-    await timers.setImmediate();
+    await setImmediate();
     expect(() => tracker.headNow).toThrow(); // Now broken!
     expect(tracker.advanceSync()).toBeNull();
     expect(tracker.advanceSync(1)).toBeNull();
@@ -901,7 +901,7 @@ describe.each`
     event3.emitter(payload4);
     const event4 = event3.nextNow;
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result4)).toBeTrue();
 
     expect(await result4).toBe(event4);
@@ -929,7 +929,7 @@ describe('next(predicate)', () => {
     const emitter5 = event3.emitter(toFind);
     const event4   = event3.nextNow;
 
-    await timers.setImmediate();
+    await setImmediate();
 
     // If this expectation fails, it's because the implementation of `next()` is
     // waiting for the event after this one to get settled (which is 100% for
@@ -942,7 +942,7 @@ describe('next(predicate)', () => {
     emitter5(payload2);
     const event5 = event4.nextNow;
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result3)).toBeTrue();
     expect(await result3).toBe(event5);
   });
@@ -958,7 +958,7 @@ describe('next(predicate)', () => {
 
     expect(await result1).toBe(event1);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result2)).toBeTrue();
     expect(await result2).toBe(event2);
   });

--- a/src/async/tests/LinkedEvent.test.js
+++ b/src/async/tests/LinkedEvent.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
+import { setImmediate } from 'node:timers/promises';
 
 import { EventPayload, LinkedEvent, ManualPromise, PromiseState }
   from '@this/async';
@@ -29,7 +29,7 @@ describe.each`
   test('has an unsettled `nextPromise`', async () => {
     const event = new LinkedEvent(...args);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(event.nextPromise)).toBeFalse();
   });
 
@@ -95,7 +95,7 @@ describe('constructor(payload, next: Promise)', () => {
     const mp    = new ManualPromise();
     const event = new LinkedEvent(payload1, mp.promise);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(event.nextPromise)).toBeFalse();
   });
 
@@ -306,7 +306,7 @@ describe('.nextPromise', () => {
   test('is an unsettled promise if there is no next event', async () => {
     const event = new LinkedEvent(payload1);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(event.nextPromise)).toBeFalse();
   });
 
@@ -314,7 +314,11 @@ describe('.nextPromise', () => {
     const event = new LinkedEvent(payload1);
 
     (async () => {
-      await timers.setTimeout(10);
+      await setImmediate();
+      await setImmediate();
+      await setImmediate();
+      await setImmediate();
+      await setImmediate();
       event.emitter(payload2);
     })();
 
@@ -431,7 +435,7 @@ describe('withPayload()', () => {
     const event  = new LinkedEvent(payload1);
     const result = event.withPayload(payload2);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(event.nextPromise)).toBeFalse();
 
     event.emitter(payload3);

--- a/src/async/tests/ManualPromise.test.js
+++ b/src/async/tests/ManualPromise.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
+import { setImmediate } from 'node:timers/promises';
 
 import { ManualPromise, PromiseUtil } from '@this/async';
 
@@ -217,7 +217,7 @@ describe('resolve(Promise)', () => {
     expect(mp.isRejected()).toBeFalse();
     expect(mp.isSettled()).toBeFalse();
 
-    await timers.setImmediate();
+    await setImmediate();
 
     // Now fulfilled!
     expect(mp.isFulfilled()).toBeTrue();
@@ -249,7 +249,7 @@ describe('resolve(Promise)', () => {
     expect(mp.isRejected()).toBeFalse();
     expect(mp.isSettled()).toBeFalse();
 
-    await timers.setImmediate();
+    await setImmediate();
 
     // Now rejected!
     expect(mp.isFulfilled()).toBeFalse();

--- a/src/async/tests/PromiseUtil.test.js
+++ b/src/async/tests/PromiseUtil.test.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import process from 'node:process';
-import * as timers from 'node:timers/promises';
+import { setImmediate } from 'node:timers/promises';
 
 import { ManualPromise, PromiseState, PromiseUtil } from '@this/async';
 
@@ -21,11 +21,11 @@ const wasHandled = async (promise) => {
   };
 
   process.on('unhandledRejection', listener);
-  await timers.setImmediate();
-  await timers.setImmediate();
-  await timers.setImmediate();
-  await timers.setImmediate();
-  await timers.setImmediate();
+  await setImmediate();
+  await setImmediate();
+  await setImmediate();
+  await setImmediate();
+  await setImmediate();
   process.removeListener('unhandledRejection', listener);
 
   return !gotCalled;
@@ -62,7 +62,7 @@ describe('race()', () => {
     const result = PromiseUtil.race([]);
 
     expect(PromiseState.isSettled(result)).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeFalse();
   });
 
@@ -75,7 +75,7 @@ describe('race()', () => {
     const result = PromiseUtil.race([value]);
 
     expect(PromiseState.isSettled(result)).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBe(value);
   });
@@ -93,7 +93,7 @@ describe('race()', () => {
     ]);
 
     expect(PromiseState.isSettled(result)).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBe(value);
   });
@@ -103,7 +103,7 @@ describe('race()', () => {
     const result = PromiseUtil.race([Promise.resolve(value)]);
 
     expect(PromiseState.isSettled(result)).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBe(value);
   });
@@ -117,7 +117,7 @@ describe('race()', () => {
     ]);
 
     expect(PromiseState.isSettled(result)).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBe(value);
   });
@@ -132,7 +132,7 @@ describe('race()', () => {
 
     PromiseUtil.handleRejection(result);
     expect(PromiseState.isSettled(result)).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     await expect(result).toReject();
   });
@@ -143,7 +143,7 @@ describe('race()', () => {
 
     PromiseUtil.handleRejection(result);
     expect(PromiseState.isSettled(result)).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     await expect(result).toReject();
   });
@@ -159,7 +159,7 @@ describe('race()', () => {
 
     expect(PromiseState.isSettled(result)).toBeFalse();
     mp.resolve(value);
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBe(value);
   });
@@ -176,7 +176,7 @@ describe('race()', () => {
     PromiseUtil.handleRejection(result);
     expect(PromiseState.isSettled(result)).toBeFalse();
     mp.rejectAndHandle(error);
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     await expect(result).toReject();
   });
@@ -188,7 +188,7 @@ describe('race()', () => {
 
     expect(PromiseState.isSettled(result)).toBeFalse();
     mp.resolve(value);
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBe(value);
   });
@@ -201,7 +201,7 @@ describe('race()', () => {
     PromiseUtil.handleRejection(result);
     expect(PromiseState.isSettled(result)).toBeFalse();
     mp.rejectAndHandle(error);
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     await expect(result).toReject();
   });
@@ -214,7 +214,7 @@ describe('race()', () => {
     ]);
 
     expect(PromiseState.isSettled(result)).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBe(value);
   });
@@ -227,7 +227,7 @@ describe('race()', () => {
     ]);
 
     expect(PromiseState.isSettled(result)).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBe(value);
   });

--- a/src/async/tests/Threadlet.test.js
+++ b/src/async/tests/Threadlet.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
+import { setImmediate } from 'node:timers/promises';
 
 import { ManualPromise, PromiseState, PromiseUtil, Threadlet }
   from '@this/async';
@@ -45,7 +45,7 @@ describe('constructor(function)', () => {
     });
 
     expect(called).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(called).toBeFalse();
   });
 });
@@ -87,13 +87,13 @@ describe('isRunning()', () => {
     let shouldRun = true;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
     });
 
     const runResult = thread.run();
     for (let i = 0; i < 10; i++) {
-      await timers.setImmediate();
+      await setImmediate();
       expect(thread.isRunning()).toBeTrue();
     }
 
@@ -105,18 +105,18 @@ describe('isRunning()', () => {
     let shouldRun = true;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
     });
 
     const runResult = thread.run();
-    await timers.setImmediate();
+    await setImmediate();
     expect(thread.isRunning()).toBeTrue(); // Baseline expectation.
 
     // The actual test.
     thread.stop();
     expect(thread.isRunning()).toBeTrue();
-    await timers.setImmediate();
+    await setImmediate();
     expect(thread.isRunning()).toBeTrue();
 
     shouldRun = false;
@@ -128,20 +128,20 @@ describe('isRunning()', () => {
     let stopped   = false;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
       stopped = true;
     });
 
     const runResult = thread.run();
-    await timers.setImmediate();
+    await setImmediate();
     expect(thread.isRunning()).toBeTrue(); // Baseline expectation.
 
     // The actual test.
 
     shouldRun = false;
     for (let i = 0; (i < 10) && !stopped; i++) {
-      await timers.setImmediate();
+      await setImmediate();
     }
 
     expect(thread.isRunning()).toBeFalse();
@@ -156,7 +156,7 @@ describe('raceWhenStopRequested()', () => {
     let shouldRun = true;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
     });
 
@@ -164,7 +164,7 @@ describe('raceWhenStopRequested()', () => {
     const result    = thread.raceWhenStopRequested([Promise.resolve('boop')]);
 
     expect(PromiseState.isSettled(result)).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBeFalse();
 
@@ -176,7 +176,7 @@ describe('raceWhenStopRequested()', () => {
     let shouldRun = true;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
     });
 
@@ -186,7 +186,7 @@ describe('raceWhenStopRequested()', () => {
 
     PromiseUtil.handleRejection(result);
     expect(PromiseState.isSettled(result)).toBeFalse();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     await expect(result).toReject();
 
@@ -198,7 +198,7 @@ describe('raceWhenStopRequested()', () => {
     let shouldRun = true;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
     });
 
@@ -208,7 +208,7 @@ describe('raceWhenStopRequested()', () => {
 
     expect(PromiseState.isSettled(result)).toBeFalse();
     mp.resolve('boop');
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBeFalse();
 
@@ -220,7 +220,7 @@ describe('raceWhenStopRequested()', () => {
     let shouldRun = true;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
     });
 
@@ -231,7 +231,7 @@ describe('raceWhenStopRequested()', () => {
     PromiseUtil.handleRejection(result);
     expect(PromiseState.isSettled(result)).toBeFalse();
     mp.reject(new Error('eep!'));
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     await expect(result).toReject();
 
@@ -243,7 +243,7 @@ describe('raceWhenStopRequested()', () => {
     const thread = new Threadlet(() => null);
     const result = thread.raceWhenStopRequested([]);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBeTrue();
   });
@@ -253,7 +253,7 @@ describe('raceWhenStopRequested()', () => {
     const mp     = new ManualPromise();
     const result = thread.raceWhenStopRequested([mp.promise]);
 
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(result)).toBeTrue();
     expect(await result).toBeTrue();
   });
@@ -276,7 +276,7 @@ describe('run()', () => {
       });
 
       const runResult = thread.run();
-      await timers.setImmediate();
+      await setImmediate();
       expect(called).toBeTrue();
 
       await expect(runResult).toResolve();
@@ -290,7 +290,7 @@ describe('run()', () => {
 
       const runResult = thread.run();
       expect(called).toBeFalse();
-      await timers.setImmediate();
+      await setImmediate();
       expect(called).toBeTrue();
 
       await expect(runResult).toResolve();
@@ -303,7 +303,7 @@ describe('run()', () => {
       });
 
       const runResult = thread.run();
-      await timers.setImmediate();
+      await setImmediate();
       expect(gotArgs).toStrictEqual([thread]);
 
       await expect(runResult).toResolve();
@@ -316,7 +316,7 @@ describe('run()', () => {
       });
 
       const runResult = thread.run();
-      await timers.setImmediate();
+      await setImmediate();
       expect(gotThis).toBeUndefined();
 
       await expect(runResult).toResolve();
@@ -347,20 +347,20 @@ describe('run()', () => {
         const thread = new Threadlet(...startArg, async () => {
           count++;
           while (shouldRun) {
-            await timers.setImmediate();
+            await setImmediate();
           }
         });
 
         const runResult1 = thread.run();
-        await timers.setImmediate();
+        await setImmediate();
         expect(count).toBe(1);
 
         const runResult2 = thread.run();
-        await timers.setImmediate();
+        await setImmediate();
         expect(count).toBe(1);
 
         const runResult3 = thread.run();
-        await timers.setImmediate();
+        await setImmediate();
         expect(count).toBe(1);
 
         shouldRun = false;
@@ -377,7 +377,7 @@ describe('run()', () => {
           count++;
           const result = `count-was-${count}`;
           while (shouldRun) {
-            await timers.setImmediate();
+            await setImmediate();
           }
 
           return result;
@@ -385,7 +385,7 @@ describe('run()', () => {
 
         const runResult1 = thread.run();
         const runResult2 = thread.run();
-        await timers.setImmediate();
+        await setImmediate();
         const runResult3 = thread.run();
 
         shouldRun = false;
@@ -401,24 +401,24 @@ describe('run()', () => {
           count++;
           const result = `count-was-${count}`;
           while (shouldRun) {
-            await timers.setImmediate();
+            await setImmediate();
           }
 
           return result;
         });
 
         const runResult1 = thread.run();
-        await timers.setImmediate();
+        await setImmediate();
         shouldRun = false;
-        await timers.setImmediate();
+        await setImmediate();
         expect(thread.isRunning()).toBeFalse(); // Baseline expectation.
 
         shouldRun = true;
         const runResult2 = thread.run();
-        await timers.setImmediate();
+        await setImmediate();
         expect(thread.isRunning()).toBeTrue();
         shouldRun = false;
-        await timers.setImmediate();
+        await setImmediate();
         expect(thread.isRunning()).toBeFalse();
 
         expect(await runResult1).toBe('count-was-1');
@@ -438,7 +438,7 @@ describe('run()', () => {
 
       const runResult = thread.run();
       expect(called).toBeFalse();
-      await timers.setImmediate();
+      await setImmediate();
       expect(called).toBeTrue();
 
       await expect(runResult).toResolve();
@@ -449,7 +449,7 @@ describe('run()', () => {
       const thread = new Threadlet((...args) => { gotArgs = args; }, () => null);
 
       const runResult = thread.run();
-      await timers.setImmediate();
+      await setImmediate();
       expect(gotArgs).toStrictEqual([thread]);
 
       await expect(runResult).toResolve();
@@ -460,7 +460,7 @@ describe('run()', () => {
       const thread = new Threadlet(function () { gotThis = this; }, () => null);
 
       const runResult = thread.run();
-      await timers.setImmediate();
+      await setImmediate();
       expect(gotThis).toBeUndefined();
 
       await expect(runResult).toResolve();
@@ -485,21 +485,21 @@ describe('run()', () => {
         const startFn = async () => {
           count++;
           while (shouldRun) {
-            await timers.setImmediate();
+            await setImmediate();
           }
         };
         const thread = new Threadlet(startFn, () => null);
 
         const runResult1 = thread.run();
-        await timers.setImmediate();
+        await setImmediate();
         expect(count).toBe(1);
 
         const runResult2 = thread.run();
-        await timers.setImmediate();
+        await setImmediate();
         expect(count).toBe(1);
 
         const runResult3 = thread.run();
-        await timers.setImmediate();
+        await setImmediate();
         expect(count).toBe(1);
 
         shouldRun = false;
@@ -532,13 +532,13 @@ describe('shouldStop()', () => {
     let shouldRun = true;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
     });
 
     const runResult = thread.run();
     for (let i = 0; i < 10; i++) {
-      await timers.setImmediate();
+      await setImmediate();
       expect(thread.shouldStop()).toBeFalse();
     }
 
@@ -551,20 +551,20 @@ describe('shouldStop()', () => {
     let stopped   = false;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
       stopped = true;
     });
 
     const runResult = thread.run();
-    await timers.setImmediate();
+    await setImmediate();
     expect(thread.shouldStop()).toBeFalse(); // Baseline expectation.
 
     // The actual test.
 
     shouldRun = false;
     for (let i = 0; (i < 10) && !stopped; i++) {
-      await timers.setImmediate();
+      await setImmediate();
     }
 
     expect(thread.shouldStop()).toBeTrue();
@@ -591,7 +591,7 @@ describe('start()', () => {
       });
 
       const result = thread.start();
-      await timers.setImmediate();
+      await setImmediate();
       expect(called).toBeTrue();
 
       await expect(result).toResolve();
@@ -601,12 +601,12 @@ describe('start()', () => {
       let shouldRun = true;
       const thread = new Threadlet(...startArg, async () => {
         while (shouldRun) {
-          await timers.setImmediate();
+          await setImmediate();
         }
       });
 
       const result = thread.start();
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isFulfilled(result)).toBeTrue();
 
       shouldRun = false;
@@ -652,20 +652,20 @@ describe('stop()', () => {
     let stopped = false;
     const thread = new Threadlet(async () => {
       while (!thread.shouldStop()) {
-        await timers.setImmediate();
+        await setImmediate();
       }
       stopped = true;
     });
 
     const runResult = thread.run();
-    await timers.setImmediate();
+    await setImmediate();
     expect(thread.shouldStop()).toBeFalse(); // Baseline expectation.
 
     // The actual test.
 
     thread.stop();
     expect(thread.shouldStop()).toBeTrue();
-    await timers.setImmediate();
+    await setImmediate();
     expect(thread.shouldStop()).toBeTrue();
     expect(stopped).toBeTrue();
 
@@ -679,7 +679,7 @@ describe('stop()', () => {
 
     const runResult     = thread.run();
     const resultPromise = thread.whenStopRequested();
-    await timers.setImmediate();
+    await setImmediate();
 
     // Baseline expectation.
     expect(PromiseState.isSettled(resultPromise)).toBeFalse();
@@ -687,7 +687,7 @@ describe('stop()', () => {
     // The actual test.
 
     thread.stop();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isSettled(resultPromise)).toBeTrue();
 
     await expect(runResult).toResolve();
@@ -697,12 +697,12 @@ describe('stop()', () => {
     let shouldRun = true;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
     });
 
     const runResult = thread.run();
-    await timers.setImmediate();
+    await setImmediate();
     expect(thread.isRunning()).toBeTrue(); // Baseline expectation.
 
     // The actual test.
@@ -710,7 +710,7 @@ describe('stop()', () => {
     thread.stop();
     for (let i = 0; i < 10; i++) {
       expect(thread.isRunning()).toBeTrue();
-      await timers.setImmediate();
+      await setImmediate();
     }
 
     shouldRun = false;
@@ -724,7 +724,7 @@ describe('stop()', () => {
     const runResult = thread.run();
     const result    = thread.stop();
 
-    await timers.setImmediate();
+    await setImmediate();
     await expect(runResult).toResolve();
     expect(await result).toBe(value);
   });
@@ -739,7 +739,7 @@ describe('stop()', () => {
     PromiseUtil.handleRejection(runResult);
     PromiseUtil.handleRejection(result);
 
-    await timers.setImmediate();
+    await setImmediate();
     await expect(runResult).toReject();
     await expect(result).rejects.toThrow(error);
   });
@@ -777,14 +777,14 @@ describe('whenStarted()', () => {
       let shouldRun = true;
       const thread = new Threadlet(...startArg, async () => {
         while (shouldRun) {
-          await timers.setImmediate();
+          await setImmediate();
         }
       });
 
       const runResult = thread.run();
       for (let i = 0; i < 10; i++) {
         const result = thread.whenStarted();
-        await timers.setImmediate();
+        await setImmediate();
         expect(PromiseState.isSettled(result)).toBeTrue();
       }
 
@@ -796,18 +796,18 @@ describe('whenStarted()', () => {
       let shouldRun = true;
       const thread = new Threadlet(...startArg, async () => {
         while (shouldRun) {
-          await timers.setImmediate();
+          await setImmediate();
         }
       });
 
       const runResult = thread.run();
-      await timers.setImmediate();
+      await setImmediate();
       await expect(thread.whenStarted()).toResolve(); // Baseline expectation.
 
       // The actual test.
       thread.stop();
       const result1 = thread.whenStarted();
-      await timers.setImmediate();
+      await setImmediate();
       const result2 = thread.whenStarted();
 
       await expect(result1).toResolve();
@@ -823,20 +823,20 @@ describe('whenStarted()', () => {
       let stopped   = false;
       const thread = new Threadlet(...startArg, async () => {
         while (shouldRun) {
-          await timers.setImmediate();
+          await setImmediate();
         }
         stopped = true;
       });
 
       const runResult = thread.run();
-      await timers.setImmediate();
+      await setImmediate();
       await expect(thread.whenStarted()).toResolve(); // Baseline expectation.
 
       // The actual test.
 
       shouldRun = false;
       for (let i = 0; (i < 10) && !stopped; i++) {
-        await timers.setImmediate();
+        await setImmediate();
       }
 
       const result = thread.whenStarted();
@@ -852,26 +852,26 @@ describe('whenStarted()', () => {
         let shouldRunStart = true;
         const startFn = async () => {
           while (shouldRunStart) {
-            await timers.setImmediate();
+            await setImmediate();
           }
         };
         let shouldRunMain = true;
         const mainFn = async () => {
           while (shouldRunMain) {
-            await timers.setImmediate();
+            await setImmediate();
           }
         };
         const thread = new Threadlet(startFn, mainFn);
 
         const runResult = thread.run();
-        await timers.setImmediate();
+        await setImmediate();
         expect(thread.isRunning()).toBeTrue(); // Baseline expectation.
 
         // Actual test.
         const result = thread.whenStarted();
         expect(PromiseState.isSettled(result)).toBeFalse();
         shouldRunStart = false;
-        await timers.setImmediate();
+        await setImmediate();
         expect(PromiseState.isFulfilled(result)).toBeTrue();
         await expect(result).toResolve();
 
@@ -885,7 +885,7 @@ describe('whenStarted()', () => {
         const runResult = thread.run();
         const result    = thread.whenStarted();
 
-        await timers.setImmediate();
+        await setImmediate();
         expect(PromiseState.isSettled(result)).toBeTrue();
         expect(await result).toBe(123);
 
@@ -902,7 +902,7 @@ describe('whenStarted()', () => {
         PromiseUtil.handleRejection(result);
         PromiseUtil.handleRejection(runResult);
 
-        await timers.setImmediate();
+        await setImmediate();
         expect(PromiseState.isSettled(result)).toBeTrue();
         await expect(result).rejects.toThrow(error);
 
@@ -915,14 +915,14 @@ describe('whenStarted()', () => {
         const thread = new Threadlet(async () => {
           isRunning = true;
           while (shouldRun) {
-            await timers.setImmediate();
+            await setImmediate();
           }
         });
 
         const runResult = thread.run();
         const result = thread.whenStarted();
         while (!isRunning) {
-          await timers.setImmediate();
+          await setImmediate();
         }
         expect(PromiseState.isFulfilled(result)).toBeTrue();
         shouldRun = false;
@@ -937,7 +937,7 @@ describe('whenStarted()', () => {
         const runResult = thread.run();
         const result    = thread.whenStarted();
 
-        await timers.setImmediate();
+        await setImmediate();
         expect(PromiseState.isSettled(result)).toBeTrue();
         expect(await result).toBeNull();
 
@@ -959,7 +959,7 @@ describe('whenStopRequested()', () => {
     let shouldRun = true;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
     });
 
@@ -967,7 +967,7 @@ describe('whenStopRequested()', () => {
     const result    = thread.whenStopRequested();
 
     expect(PromiseState.isPending(result)).toBeTrue();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isPending(result)).toBeTrue();
 
     shouldRun = false;
@@ -978,7 +978,7 @@ describe('whenStopRequested()', () => {
     let shouldRun = true;
     const thread = new Threadlet(async () => {
       while (shouldRun) {
-        await timers.setImmediate();
+        await setImmediate();
       }
     });
 
@@ -989,7 +989,7 @@ describe('whenStopRequested()', () => {
 
     // The actual test.
     thread.stop();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isFulfilled(result)).toBeTrue();
 
     shouldRun = false;

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
+import { setImmediate } from 'node:timers/promises';
 
 import { ManualPromise, PromiseState, TokenBucket } from '@this/async';
 import { IntfTimeSource, StdTimeSource } from '@this/clocks';
@@ -413,7 +413,7 @@ describe('denyAllRequests()', () => {
     const result1 = bucket.requestGrant(1);
     const result2 = bucket.requestGrant(2);
     const result3 = bucket.requestGrant(3);
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isPending(result1)).toBeTrue();
     expect(PromiseState.isPending(result2)).toBeTrue();
     expect(PromiseState.isPending(result3)).toBeTrue();
@@ -423,7 +423,7 @@ describe('denyAllRequests()', () => {
     const result = bucket.denyAllRequests();
     time._setTime(10987);
     expect(PromiseState.isPending(result)).toBeTrue();
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isFulfilled(result)).toBeTrue();
 
     expect(PromiseState.isFulfilled(result1)).toBeTrue();
@@ -508,7 +508,7 @@ describe('requestGrant()', () => {
       // The actual test.
       const request2 = bucket.requestGrant({ minInclusive: 0, maxInclusive: 123 });
       expect(bucket.latestState().waiterCount).toBe(1);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isPending(request1)).toBeTrue();
       expect(PromiseState.isFulfilled(request2)).toBeTrue();
 
@@ -535,7 +535,7 @@ describe('requestGrant()', () => {
       // The actual test.
       const request2 = bucket.requestGrant(1);
       expect(bucket.latestState().waiterCount).toBe(1);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isFulfilled(request2)).toBeTrue();
       await checkGrant(request2, { done: false, grant: 0, reason: 'full', waitTime: 0 });
 
@@ -560,7 +560,7 @@ describe('requestGrant()', () => {
       // The actual test.
       const request2 = bucket.requestGrant(2);
       expect(bucket.latestState().waiterCount).toBe(1);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isFulfilled(request2)).toBeTrue();
       await checkGrant(request2, { done: false, grant: 0, reason: 'full', waitTime: 0 });
 
@@ -581,7 +581,7 @@ describe('requestGrant()', () => {
       const request = bucket.requestGrant({ minInclusive: 25, maxInclusive: 50 });
       expect(bucket.latestState().waiterCount).toBe(1);
       time._setTime(nowSec + 321);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isFulfilled(request)).toBeTrue();
       await checkGrant(request, { done: true, grant: 50, reason: 'grant', waitTime: 321 });
 
@@ -598,7 +598,7 @@ describe('requestGrant()', () => {
       const request = bucket.requestGrant({ minInclusive: 50, maxInclusive: 150 });
       expect(bucket.latestState().waiterCount).toBe(1);
       time._setTime(nowSec + 90909);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isFulfilled(request)).toBeTrue();
       await checkGrant(request, { done: true, grant: 100, reason: 'grant', waitTime: 90909 });
 
@@ -621,19 +621,19 @@ describe('requestGrant()', () => {
       expect(PromiseState.isPending(request3)).toBeTrue();
 
       time._setTime(nowSec + 10);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isFulfilled(request1)).toBeTrue();
       expect(PromiseState.isPending(request2)).toBeTrue();
       expect(PromiseState.isPending(request3)).toBeTrue();
 
       time._setTime(nowSec + 10 + 20);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isFulfilled(request1)).toBeTrue();
       expect(PromiseState.isFulfilled(request2)).toBeTrue();
       expect(PromiseState.isPending(request3)).toBeTrue();
 
       time._setTime(nowSec + 10 + 20 + 30);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isFulfilled(request1)).toBeTrue();
       expect(PromiseState.isFulfilled(request2)).toBeTrue();
       expect(PromiseState.isFulfilled(request3)).toBeTrue();
@@ -669,7 +669,7 @@ describe('requestGrant()', () => {
         maxQueueGrantSize: 10, initialBurstSize: 0, timeSource: time });
 
       const resultPromise = bucket.requestGrant({ minInclusive: 1.5, maxInclusive: 2.5 });
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isPending(resultPromise)).toBeTrue();
       time._setTime(nowSec + 10);
       const result = await resultPromise;
@@ -704,7 +704,7 @@ describe('requestGrant()', () => {
         maxQueueGrantSize: grant, initialBurstSize: 0, timeSource: time });
 
       const resultPromise = bucket.requestGrant({ minInclusive: 1, maxInclusive: 10 });
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isPending(resultPromise)).toBeTrue();
       time._setTime(nowSec + 10);
       const result = await resultPromise;
@@ -770,14 +770,14 @@ describe('latestState()', () => {
     expect(bucket.latestState().availableQueueSize).toBe(1000 - 10 - 15 - 100);
 
     time._setTime(1025); // Enough for the first two requests to get granted.
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isFulfilled(result1)).toBeTrue();
     expect(PromiseState.isFulfilled(result2)).toBeTrue();
     expect(bucket.latestState().waiterCount).toBe(1);
     expect(bucket.latestState().availableQueueSize).toBe(1000 - 100);
 
     time._setTime(1125); // Enough for the last request to get granted.
-    await timers.setImmediate();
+    await setImmediate();
     expect(PromiseState.isFulfilled(result3)).toBeTrue();
     expect(bucket.latestState().waiterCount).toBe(0);
     expect(bucket.latestState().availableQueueSize).toBe(1000);
@@ -937,7 +937,7 @@ describe('takeNow()', () => {
 
       // Setup / baseline assumptions.
       const requestResult = bucket.requestGrant(1300);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isPending(requestResult)).toBeTrue();
 
       // The actual test.
@@ -961,7 +961,7 @@ describe('takeNow()', () => {
 
       // Setup / baseline assumptions.
       const requestResult = bucket.requestGrant(300);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isPending(requestResult)).toBeTrue();
 
       // The actual test.
@@ -985,7 +985,7 @@ describe('takeNow()', () => {
 
       // Setup / baseline assumptions.
       const requestResult = bucket.requestGrant(300);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isPending(requestResult)).toBeTrue();
 
       // The actual test.
@@ -1013,7 +1013,7 @@ describe('takeNow()', () => {
       expect(bucket.latestState().waiterCount).toBe(1);
       const now1 = nowSec + 3;
       time._setTime(now1);
-      await timers.setImmediate();
+      await setImmediate();
       expect(PromiseState.isFulfilled(requestResult)).toBeTrue();
       expect(bucket.latestState().waiterCount).toBe(0);
       expect(bucket.latestState().availableBurstSize).toBe(2);

--- a/src/builtin-services/export/MemoryMonitor.js
+++ b/src/builtin-services/export/MemoryMonitor.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { memoryUsage } from 'node:process';
-import { setTimeout } from 'node:timers/promises';
 
 import { Threadlet } from '@this/async';
 import { WallClock } from '@this/clocks';
@@ -122,7 +121,7 @@ export class MemoryMonitor extends BaseService {
       }
 
       await this.#runner.raceWhenStopRequested([
-        setTimeout(timeoutMsec)
+        WallClock.waitForMsec(timeoutMsec)
       ]);
     }
   }

--- a/src/builtin-services/export/ProcessIdFile.js
+++ b/src/builtin-services/export/ProcessIdFile.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as fs from 'node:fs/promises';
-import * as process from 'node:process';
+import { pid as processPid } from 'node:process';
 
 import { Threadlet } from '@this/async';
 import { WallClock } from '@this/clocks';
@@ -49,7 +49,7 @@ export class ProcessIdFile extends BaseFileService {
    * @returns {string} The file contents.
    */
   async #makeContents(running) {
-    const pid = process.pid;
+    const pid = processPid;
 
     if (!this.config.multiprocess) {
       // Easy case when not handling multiple processes.

--- a/src/builtin-services/export/ProcessIdFile.js
+++ b/src/builtin-services/export/ProcessIdFile.js
@@ -3,9 +3,9 @@
 
 import * as fs from 'node:fs/promises';
 import * as process from 'node:process';
-import * as timers from 'node:timers/promises';
 
 import { Threadlet } from '@this/async';
+import { WallClock } from '@this/clocks';
 import { Duration } from '@this/data-values';
 import { Statter } from '@this/fs-util';
 import { ProcessUtil } from '@this/host';
@@ -121,7 +121,7 @@ export class ProcessIdFile extends BaseFileService {
       await this.#updateFile(true);
 
       if (updateMsec) {
-        const timeout = timers.setTimeout(updateMsec);
+        const timeout = WallClock.waitForMsec(updateMsec);
         await this.#runner.raceWhenStopRequested([timeout]);
       } else {
         await this.#runner.whenStopRequested();
@@ -166,13 +166,13 @@ export class ProcessIdFile extends BaseFileService {
       // we wrote (but only if `running === true`, because if we're about to
       // shut down, we can rely on "partner" processes to ultimately do the
       // right thing).
-      await timers.setTimeout(ProcessIdFile.#PRE_CHECK_DELAY_MSEC);
+      await WallClock.waitForMsec(ProcessIdFile.#PRE_CHECK_DELAY_MSEC);
       const readBack = await this.#readFile();
       if (readBack === contents) {
         return;
       }
 
-      await timers.setTimeout(ProcessIdFile.#RETRY_DELAY_MSEC);
+      await WallClock.waitForMsec(ProcessIdFile.#RETRY_DELAY_MSEC);
     }
 
     this.logger?.writeContention({ attempt: maxAttempts, gaveUp: true });

--- a/src/builtin-services/export/ProcessInfoFile.js
+++ b/src/builtin-services/export/ProcessInfoFile.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as fs from 'node:fs/promises';
-import * as timers from 'node:timers/promises';
 
 import { Threadlet } from '@this/async';
 import { WallClock } from '@this/clocks';
@@ -194,7 +193,7 @@ export class ProcessInfoFile extends BaseFileService {
       await this.#writeFile();
 
       if (updateMsec) {
-        const timeout = timers.setTimeout(updateMsec);
+        const timeout = WallClock.waitForMsec(updateMsec);
         await this.#runner.raceWhenStopRequested([timeout]);
       } else {
         await this.#runner.whenStopRequested();

--- a/src/builtin-services/export/SystemLogger.js
+++ b/src/builtin-services/export/SystemLogger.js
@@ -1,9 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
-
 import { EventTracker, LinkedEvent } from '@this/async';
+import { WallClock } from '@this/clocks';
 import { IntfLogger, Loggy, TextFileSink } from '@this/loggy';
 import { FileServiceConfig } from '@this/sys-config';
 import { BaseFileService, Rotator } from '@this/sys-util';
@@ -60,7 +59,7 @@ export class SystemLogger extends BaseFileService {
     // Wait briefly, so that there's a decent chance that this instance catches
     // most or all of the other stop-time messages before doing its own final
     // message.
-    await timers.setTimeout(100); // 100msec
+    await WallClock.waitForMsec(100); // 100msec
 
     // Note: Upon construction, instances of this class look for an event of the
     // form being logged here, and will start just past it if found. This is to

--- a/src/clocks/export/StdTimeSource.js
+++ b/src/clocks/export/StdTimeSource.js
@@ -30,6 +30,8 @@ export class StdTimeSource extends IntfTimeSource {
       const delayMsec = delay * 1000;
       await timers.setTimeout(delayMsec);
     }
+
+    return null;
   }
 
 

--- a/src/clocks/export/StdTimeSource.js
+++ b/src/clocks/export/StdTimeSource.js
@@ -1,8 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
-
 import { IntfTimeSource } from '#x/IntfTimeSource';
 import { WallClock } from '#x/WallClock';
 
@@ -21,17 +19,7 @@ export class StdTimeSource extends IntfTimeSource {
 
   /** @override */
   async waitUntil(time) {
-    for (;;) {
-      const delay = time.atSec - this.now().atSec;
-      if ((delay <= 0) || !Number.isFinite(delay)) {
-        break;
-      }
-
-      const delayMsec = delay * 1000;
-      await timers.setTimeout(delayMsec);
-    }
-
-    return null;
+    return WallClock.waitUntil(time);
   }
 
 

--- a/src/clocks/export/WallClock.js
+++ b/src/clocks/export/WallClock.js
@@ -1,8 +1,10 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-// This is the one file where it's okay to use `node:timers/promises`.
+// This is the one file where it's okay to use `node:timers/promises`,
+// `process.hrtime`, and `Date.now()`.
 /* eslint-disable no-restricted-imports */
+/* eslint-disable no-restricted-properties */
 
 import * as process from 'node:process';
 import { setTimeout } from 'node:timers/promises';

--- a/src/clocks/export/WallClock.js
+++ b/src/clocks/export/WallClock.js
@@ -4,7 +4,7 @@
 import * as process from 'node:process';
 import { setTimeout } from 'node:timers/promises';
 
-import { Moment } from '@this/data-values';
+import { Duration, Moment } from '@this/data-values';
 
 
 /**

--- a/src/clocks/export/WallClock.js
+++ b/src/clocks/export/WallClock.js
@@ -104,7 +104,7 @@ export class WallClock {
    */
   static async waitForMsec(durMsec) {
     if (durMsec <= 0) {
-      return;
+      return null;
     }
 
     return setTimeout(durMsec, null);

--- a/src/clocks/export/WallClock.js
+++ b/src/clocks/export/WallClock.js
@@ -88,10 +88,12 @@ export class WallClock {
    * @param {Duration} dur How much time to wait before this method is to
    *   async-return. If zero or negative, this method simply does not wait
    *   before returning.
+   * @param {object} [options] Timeout options. This is the same as with
+   *   `node:timers/promises.setTimeout()`.
    * @returns {null} `null`, always.
    */
-  static async waitFor(dur) {
-    return this.waitForMsec(dur.msec);
+  static async waitFor(dur, options = undefined) {
+    return this.waitForMsec(dur.msec, options);
   }
 
   /**
@@ -103,14 +105,16 @@ export class WallClock {
    * @param {number} durMsec How much time to wait before this method is to
    *   async-return, as a number of milliseconds. If zero or negative, this
    *   method simply does not wait before returning.
+   * @param {object} [options] Timeout options. This is the same as with
+   *   `node:timers/promises.setTimeout()`.
    * @returns {null} `null`, always.
    */
-  static async waitForMsec(durMsec) {
+  static async waitForMsec(durMsec, options = undefined) {
     if (durMsec <= 0) {
       return null;
     }
 
-    return setTimeout(durMsec, null);
+    return setTimeout(durMsec, null, options);
   }
 
   /**

--- a/src/clocks/export/WallClock.js
+++ b/src/clocks/export/WallClock.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as process from 'node:process';
-import { setTimeout } as timers from 'node:timers/promises';
+import { setTimeout } from 'node:timers/promises';
 
 import { Moment } from '@this/data-values';
 
@@ -88,13 +88,26 @@ export class WallClock {
    * @returns {null} `null`, always.
    */
   static async waitFor(dur) {
-    const msec = dur.msec;
+    return this.waitForMsec(dur.msec);
+  }
 
-    if (msec <= 0) {
+  /**
+   * Like {@link #waitFor}, but takes a plain number of milliseconds.
+   *
+   * **Note:** This is meant to be a _direct_ replacement for the various
+   * versions and bindings of `setTimeout()` provided by Node.
+   *
+   * @param {number} durMsec How much time to wait before this method is to
+   *   async-return, as a number of milliseconds. If zero or negative, this
+   *   method simply does not wait before returning.
+   * @returns {null} `null`, always.
+   */
+  static async waitForMsec(durMsec) {
+    if (durMsec <= 0) {
       return;
     }
 
-    return setTimeout(msec, null);
+    return setTimeout(durMsec, null);
   }
 
   /**

--- a/src/clocks/export/WallClock.js
+++ b/src/clocks/export/WallClock.js
@@ -1,6 +1,9 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+// This is the one file where it's okay to use `node:timers/promises`.
+/* eslint-disable no-restricted-imports */
+
 import * as process from 'node:process';
 import { setTimeout } from 'node:timers/promises';
 

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -127,6 +127,15 @@ export class Moment {
   }
 
   /**
+   * Returns a `Date` instance that represents the same moment as `this`.
+   *
+   * @returns {Date} The corresponding `Date`.
+   */
+  toDate() {
+    return new Date(this.atMsec)
+  }
+
+  /**
    * Makes a string representing this instance, in the standard HTTP format.
    * See {@link #httpStringFromSec} for more details.
    *

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -132,7 +132,7 @@ export class Moment {
    * @returns {Date} The corresponding `Date`.
    */
   toDate() {
-    return new Date(this.atMsec)
+    return new Date(this.atMsec);
   }
 
   /**

--- a/src/data-values/tests/Moment.test.js
+++ b/src/data-values/tests/Moment.test.js
@@ -107,6 +107,16 @@ describe('subtract()', () => {
   });
 });
 
+describe('toDate()', () => {
+  test('converts to a `Date`', () => {
+    const valueMsec = 12345;
+    const result    = new Moment(valueMsec / 1000).toDate();
+
+    expect(result).toBeInstanceOf(Date);
+    expect(result.valueOf()).toBe(valueMsec);
+  });
+});
+
 describe.each`
 method                 | isStatic
 ${'httpStringFromSec'} | ${true}

--- a/src/host/export/KeepRunning.js
+++ b/src/host/export/KeepRunning.js
@@ -1,9 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
-
 import { Threadlet } from '@this/async';
+import { WallClock } from '@this/clocks';
 import { IntfLogger } from '@this/loggy';
 
 import { ProcessInfo } from '#x/ProcessInfo';
@@ -72,7 +71,7 @@ export class KeepRunning {
     // (one way or another) when it's okay for the process to exit.
     while (!this.#thread.shouldStop()) {
       await this.#thread.raceWhenStopRequested([
-        timers.setTimeout(KeepRunning.#MSEC_PER_DAY)
+        WallClock.waitForMsec(KeepRunning.#MSEC_PER_DAY)
       ]);
 
       this.#logger?.uptime(ProcessInfo.uptime);

--- a/src/host/export/ProcessInfo.js
+++ b/src/host/export/ProcessInfo.js
@@ -1,7 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as process from 'node:process';
+import { memoryUsage, pid as processPid, ppid as processPpid, uptime }
+  from 'node:process';
 
 import { WallClock } from '@this/clocks';
 import { Duration, Moment } from '@this/data-values';
@@ -21,7 +22,7 @@ export class ProcessInfo {
    *
    * **Note:** `process.uptime()` returns a number of seconds.
    */
-  static #startedAt = new Moment(WallClock.now().atSec - process.uptime());
+  static #startedAt = new Moment(WallClock.now().atSec - uptime());
 
   /** @type {?object} All the fixed-at-startup info, if calculated. */
   static #fixedInfo = null;
@@ -41,14 +42,14 @@ export class ProcessInfo {
    * object.
    */
   static get ephemeralInfo() {
-    const memoryUsage = process.memoryUsage();
-    for (const [key, value] of Object.entries(memoryUsage)) {
-      memoryUsage[key] = FormatUtils.byteCountString(value);
+    const memoryInfo = memoryUsage();
+    for (const [key, value] of Object.entries(memoryInfo)) {
+      memoryInfo[key] = FormatUtils.byteCountString(value);
     }
 
-    const uptime = this.uptime.toPlainObject();
+    const uptimeInfo = this.uptime.toPlainObject();
 
-    return { memoryUsage, uptime };
+    return { memoryUsage: memoryInfo, uptime: uptimeInfo };
   }
 
   /** @returns {Moment} The moment that the process started. */
@@ -77,8 +78,8 @@ export class ProcessInfo {
     }
 
     this.#fixedInfo = {
-      pid:       process.pid,
-      ppid:      process.ppid,
+      pid:       processPid,
+      ppid:      processPpid,
       startedAt: this.#startedAt.toPlainObject()
     };
 

--- a/src/host/private/CallbackList.js
+++ b/src/host/private/CallbackList.js
@@ -1,9 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
-
 import { Condition } from '@this/async';
+import { WallClock } from '@this/clocks';
 import { IntfLogger } from '@this/loggy';
 
 import { ThisModule } from '#p/ThisModule';
@@ -99,10 +98,8 @@ export class CallbackList {
     })();
 
     const timeoutProm = (async () => {
-      const timeout = timers.setTimeout(
-        this.#maxRunMsec, null, { signal: abortCtrl.signal });
       try {
-        await timeout;
+        await WallClock.waitForMsec(this.#maxRunMsec, { signal: abortCtrl.signal });
       } catch (e) {
         // If the timeout was aborted, just swallow the "error", and let the
         // system continue to run in peace. But for anything else, rethrow,

--- a/src/host/private/ShutdownHandler.js
+++ b/src/host/private/ShutdownHandler.js
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import process from 'node:process'; // Need to import as such, for `.on*()`.
-import * as timers from 'node:timers/promises';
 
 import { Threadlet } from '@this/async';
+import { WallClock } from '@this/clocks';
 import { IntfLogger } from '@this/loggy';
 
 import { CallbackList } from '#p/CallbackList';
@@ -109,7 +109,7 @@ export class ShutdownHandler {
 
     this.#logger?.bye(this.#exitCode);
 
-    await timers.setTimeout(this.#PRE_EXIT_DELAY_MSEC);
+    await WallClock.waitForMsec(this.#PRE_EXIT_DELAY_MSEC);
 
     const problems = TopErrorHandler.problems;
 

--- a/src/host/private/TopErrorHandler.js
+++ b/src/host/private/TopErrorHandler.js
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import process from 'node:process'; // Need to import as such, for `.on*()`.
-import * as timers from 'node:timers/promises';
+import { setImmediate } from 'node:timers/promises';
 import * as util from 'node:util';
 
+import { WallClock } from '@this/clocks';
 import { IntfLogger } from '@this/loggy';
 
 import { ShutdownHandler } from '#p/ShutdownHandler';
@@ -111,7 +112,7 @@ export class TopErrorHandler {
     // Give the system a moment, so it has a chance to actually flush the log,
     // then attempt first a clean then an abrupt exit.
 
-    await timers.setTimeout(250); // 0.25 second.
+    await WallClock.waitForMsec(250); // 0.25 second.
 
     try {
       // This shouldn't return...
@@ -152,7 +153,7 @@ export class TopErrorHandler {
     this.#unhandledRejections.set(promise, reason);
 
     for (let i = 1; i <= this.#PROMISE_REJECTION_GRACE_PERIOD_TICKS; i++) {
-      await timers.setImmediate();
+      await setImmediate();
       if (!this.#unhandledRejections.has(promise)) {
         this.#logger?.rejectionHandledSlowly(reason, { afterTicks: i });
         return;

--- a/src/main-lactoserv/private/Debugging.js
+++ b/src/main-lactoserv/private/Debugging.js
@@ -1,8 +1,9 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
+import { setImmediate } from 'node:timers/promises';
 
+import { WallClock } from '@this/clocks';
 import { Duration } from '@this/data-values';
 import { Host } from '@this/host';
 import { IntfLogger } from '@this/loggy';
@@ -54,7 +55,7 @@ export class Debugging {
       // but few enough that it's slow-but-handled as far as `TopErrorHandler`
       // is concerned.
       for (let i = 1; i <= 5; i++) {
-        await timers.setImmediate();
+        await setImmediate();
       }
 
       try {
@@ -64,7 +65,7 @@ export class Debugging {
       }
 
       // Wait a moment before continuing with the actually-uncaught examples.
-      await timers.setTimeout(1000);
+      await WallClock.waitForMsec(1000);
 
       // The timeout here is meant to jibe with `TopErrorHandler`'s grace period
       // given for unhandled promise rejections.
@@ -102,7 +103,7 @@ export class Debugging {
 
       let remainingSec = maxRunTimeSec;
       if (maxRunTimeSec > 60) {
-        await timers.setTimeout((maxRunTimeSec - 60) * 1000);
+        await WallClock.waitForMsec((maxRunTimeSec - 60) * 1000);
         remainingSec = 60;
       }
 
@@ -119,7 +120,7 @@ export class Debugging {
           waitSec = HALF_FREQ_SECS + (remainingSec % HALF_FREQ_SECS);
         }
 
-        await timers.setTimeout(waitSec * 1000);
+        await WallClock.waitForMsec(waitSec * 1000);
         remainingSec -= waitSec;
       }
 

--- a/src/main-lactoserv/private/Debugging.js
+++ b/src/main-lactoserv/private/Debugging.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { setImmediate as setImmediateCallback } from 'node:timers';
 import { setImmediate } from 'node:timers/promises';
 
 import { WallClock } from '@this/clocks';
@@ -67,13 +68,16 @@ export class Debugging {
       // Wait a moment before continuing with the actually-uncaught examples.
       await WallClock.waitForMsec(1000);
 
-      // The timeout here is meant to jibe with `TopErrorHandler`'s grace period
-      // given for unhandled promise rejections.
-      setTimeout(() => {
-        const error = new Error('I am an uncaught exception (from a callback).');
-        error.beep = 'boop';
-        throw error;
-      }, 50);
+      // The wait time here is meant to jibe with `TopErrorHandler`'s grace
+      // period given for unhandled promise rejections.
+      (async () => {
+        await WallClock.waitForMsec(50);
+        setImmediateCallback(() => {
+          const error = new Error('I am an uncaught exception (from a callback).');
+          error.beep = 'boop';
+          throw error;
+        });
+      })();
 
       const cause = new TypeError('I am a cause.');
       cause.name = 'CausewayError';

--- a/src/net-protocol/private/AsyncServerSocket.js
+++ b/src/net-protocol/private/AsyncServerSocket.js
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Server, createServer as netCreateServer } from 'node:net';
-import { setTimeout } from 'node:timers/promises';
 
 import lodash from 'lodash';
 
 import { EventPayload, EventSource, LinkedEvent, PromiseUtil }
   from '@this/async';
+import { WallClock } from '@this/clocks';
 import { FormatUtils, IntfLogger } from '@this/loggy';
 import { MustBe } from '@this/typey';
 
@@ -387,7 +387,7 @@ export class AsyncServerSocket {
     instance.#logger?.stashed();
 
     (async () => {
-      await setTimeout(this.#STASH_TIMEOUT_MSEC);
+      await WallClock.waitForMsec(this.#STASH_TIMEOUT_MSEC);
       if (this.#stashedInstances.delete(instance)) {
         instance.#logger?.stashTimeout();
         await instance.#close();

--- a/src/net-protocol/private/Http2Wrangler.js
+++ b/src/net-protocol/private/Http2Wrangler.js
@@ -3,9 +3,9 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import * as http2 from 'node:http2';
-import * as timers from 'node:timers/promises';
 
 import { Condition, PromiseUtil, Threadlet } from '@this/async';
+import { WallClock } from '@this/clocks';
 import { IntfLogger } from '@this/loggy';
 
 import { TcpWrangler } from '#p/TcpWrangler';
@@ -212,7 +212,7 @@ export class Http2Wrangler extends TcpWrangler {
 
       await PromiseUtil.race([
         this.#anySessions.whenFalse(),
-        timers.setTimeout(Http2Wrangler.#STOP_GRACE_PERIOD_MSEC)
+        WallClock.waitForMsec(Http2Wrangler.#STOP_GRACE_PERIOD_MSEC)
       ]);
     }
 

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Socket } from 'node:net';
-import * as timers from 'node:timers/promises';
 
 import { Condition, PromiseUtil, Threadlet } from '@this/async';
+import { WallClock } from '@this/clocks';
 import { FormatUtils, IntfLogger } from '@this/loggy';
 
 import { AsyncServerSocket } from '#p/AsyncServerSocket';
@@ -229,7 +229,7 @@ export class TcpWrangler extends ProtocolWrangler {
 
     await PromiseUtil.race([
       closedCond.whenTrue(),
-      timers.setTimeout(TcpWrangler.#SOCKET_TIMEOUT_CLOSE_GRACE_PERIOD_MSEC)
+      WallClock.waitForMsec(TcpWrangler.#SOCKET_TIMEOUT_CLOSE_GRACE_PERIOD_MSEC)
     ]);
 
     if (socket.destroyed) {
@@ -242,7 +242,7 @@ export class TcpWrangler extends ProtocolWrangler {
 
     await PromiseUtil.race([
       closedCond.whenTrue(),
-      timers.setTimeout(TcpWrangler.#SOCKET_TIMEOUT_CLOSE_GRACE_PERIOD_MSEC)
+      WallClock.waitForMsec(TcpWrangler.#SOCKET_TIMEOUT_CLOSE_GRACE_PERIOD_MSEC)
     ]);
 
     if (socket.destroyed) {

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -270,7 +270,7 @@ describe('set()', () => {
       ${{ expires: true }}
       ${{ expires: 123 }}
       ${{ expires: 'boop' }}
-      ${{ expires: new Date() }}
+      ${{ expires: new Date(123) }}
       ${{ httpOnly: 123 }}
       ${{ httpOnly: 'boop' }}
       ${{ maxAge: true }}

--- a/src/sys-framework/export/Warehouse.js
+++ b/src/sys-framework/export/Warehouse.js
@@ -1,9 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
-
 import { PromiseUtil } from '@this/async';
+import { WallClock } from '@this/clocks';
 import { WarehouseConfig } from '@this/sys-config';
 import { MustBe } from '@this/typey';
 
@@ -106,13 +105,13 @@ export class Warehouse extends BaseControllable {
 
     await PromiseUtil.race([
       endpointsStopped,
-      timers.setTimeout(Warehouse.#ENDPOINT_STOP_GRACE_PERIOD_MSEC)
+      WallClock.waitForMsec(Warehouse.#ENDPOINT_STOP_GRACE_PERIOD_MSEC)
     ]);
 
     const applicationsStopped = this.#applicationManager.stop(willReload);
     await PromiseUtil.race([
       applicationsStopped,
-      timers.setTimeout(Warehouse.#APPLICATION_STOP_GRACE_PERIOD_MSEC)
+      WallClock.waitForMsec(Warehouse.#APPLICATION_STOP_GRACE_PERIOD_MSEC)
     ]);
 
     await Promise.all([

--- a/src/sys-util/export/BaseFileService.js
+++ b/src/sys-util/export/BaseFileService.js
@@ -3,6 +3,7 @@
 
 import * as fs from 'node:fs/promises';
 
+import { WallClock } from '@this/clocks';
 import { Statter } from '@this/fs-util';
 import { FileServiceConfig } from '@this/sys-config';
 import { BaseService } from '@this/sys-framework';
@@ -34,7 +35,7 @@ export class BaseFileService extends BaseService {
 
     if (await Statter.pathExists(path)) {
       // File already exists; just update the modification time.
-      const dateNow = new Date();
+      const dateNow = WallClock.now().toDate();
       await fs.utimes(path, dateNow, dateNow);
     } else {
       await fs.appendFile(path, '');

--- a/src/sys-util/export/BaseFileService.js
+++ b/src/sys-util/export/BaseFileService.js
@@ -28,7 +28,7 @@ export class BaseFileService extends BaseService {
   }
 
   /**
-   * "Touches" (creates if necessary) the file at {@link #path}.
+   * "Touches" (and creates if necessary) the file at {@link #path}.
    */
   async _prot_touchPath() {
     const path = this.config.path;

--- a/src/sys-util/export/Rotator.js
+++ b/src/sys-util/export/Rotator.js
@@ -1,8 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
-
+import { WallClock } from '@this/clocks';
 import { Duration } from '@this/data-values';
 import { Statter } from '@this/fs-util';
 import { IntfLogger } from '@this/loggy';
@@ -65,7 +64,7 @@ export class Rotator extends BaseFilePreserver {
     // anything.
 
     return this.#checkPeriod
-      ? timers.setTimeout(this.#checkPeriod.msec)
+      ? WallClock.waitForMsec(this.#checkPeriod.msec)
       : null;
   }
 }

--- a/src/sys-util/private/BaseFilePreserver.js
+++ b/src/sys-util/private/BaseFilePreserver.js
@@ -4,6 +4,7 @@
 import * as fs from 'node:fs/promises';
 
 import { Condition, Threadlet } from '@this/async';
+import { WallClock } from '@this/clocks';
 import { Statter } from '@this/fs-util';
 import { IntfLogger } from '@this/loggy';
 import { FileServiceConfig } from '@this/sys-config';
@@ -188,7 +189,7 @@ export class BaseFilePreserver {
     } = options;
 
     const { directory, filePrefix, fileSuffix } = this.#config.pathParts;
-    const todayStr = BaseFilePreserver.#makeInfix(new Date());
+    const todayStr = BaseFilePreserver.#makeInfix(WallClock.now().toDate());
     const contents = await fs.readdir(directory);
     const result   = [];
 


### PR DESCRIPTION
This PR cleans up a bunch more time-related stuff, specifically (a) limiting our use of core Node time-ish functions / methods to be in our `clocks` module, and (b) adding ESLint rules to enforce that last bit.

This isn't an airtight arrangement, but it definitely gets us in the zone of not really having to worry too much about time-related inconsistencies should we end up tweaking how the system works in that regard.