### PR TITLE
Log tweakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Other notable changes:
     such as "applications" and "services."
   * Added ANSI coloring / styling to the "human" (non-JSON) logs that go to
     `stdout`, when it's a TTY.
+  * Fixed request logging so that it gets a more accurate (earlier) start time
+    for requests.
 
 ### v0.6.10 -- 2024-03-15
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -597,14 +597,18 @@ the following configuration bindings:
 * `rotate` &mdash; Optional file rotation configuration. If not specified, no
   file rotation is done. See "File Rotation and Preservation" below for
   configuration details.
+* `sendToSystemLog` &mdash; Boolean which, if `true`, causes requests and
+  responses to _also_ get sent to the system log. (It's like getting an instance
+  of `RequestSyslogger` for free.)
 
 ```js
 const services = [
   {
-    name:   'requests',
-    class:  'RequestLogger',
-    path:   '/path/to/var/log/request-log.txt',
-    rotate: { /* ... */ }
+    name:            'requests',
+    class:           'RequestLogger',
+    path:            '/path/to/var/log/request-log.txt',
+    rotate:          { /* ... */ },
+    sendToSystemLog: true
   }
 ];
 ```

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -609,6 +609,22 @@ const services = [
 ];
 ```
 
+### `RequestSyslogger`
+
+A service which logs very detailed information about HTTP-ish requests to the
+_system_ log. Such logging in turn goes to wherever the system log goes (e.g.,
+into a file). It does not accept any configuration bindings beyond the basics
+of any service.
+
+```js
+const services = [
+  {
+    name:  'requestSyslog',
+    class: 'RequestSyslogger'
+  }
+];
+```
+
 ### `SystemLogger`
 
 A service which logs system activity either in a human-friendly or JSON form. It

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -93,6 +93,10 @@ const services = [
     }
   },
   {
+    name:  'requestSyslog',
+    class: 'RequestSyslogger'
+  },
+  {
     name:        'limiter',
     class:       'RateLimiter',
     connections: {

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -90,7 +90,8 @@ const services = [
       atSize:      10000,
       maxOldCount: 10,
       checkPeriod: '1 min'
-    }
+    },
+    sendToSystemLog: true
   },
   {
     name:  'requestSyslog',

--- a/src/builtin-services/export/BuiltinServices.js
+++ b/src/builtin-services/export/BuiltinServices.js
@@ -8,6 +8,7 @@ import { ProcessIdFile } from '#x/ProcessIdFile';
 import { ProcessInfoFile } from '#x/ProcessInfoFile';
 import { RateLimiter } from '#x/RateLimiter';
 import { RequestLogger } from '#x/RequestLogger';
+import { RequestSyslogger } from '#x/RequestSyslogger';
 import { SystemLogger } from '#x/SystemLogger';
 
 
@@ -27,6 +28,7 @@ export class BuiltinServices {
       ProcessInfoFile,
       RateLimiter,
       RequestLogger,
+      RequestSyslogger,
       SystemLogger
     ];
   }

--- a/src/builtin-services/export/RequestLogger.js
+++ b/src/builtin-services/export/RequestLogger.js
@@ -44,6 +44,16 @@ export class RequestLogger extends BaseFileService {
   }
 
   /** @override */
+  async requestStarted(timingInfo_unused, requestInfo_unused) {
+    // This class does not do start-of-request logging.
+  }
+
+  /** @override */
+  async requestEnded(timingInfo_unused, requestInfo_unused, responseInfo_unused) {
+    // TODO
+  }
+
+  /** @override */
   async _impl_start(isReload) {
     await this._prot_createDirectoryIfNecessary();
     await this._prot_touchPath();

--- a/src/builtin-services/export/RequestSyslogger.js
+++ b/src/builtin-services/export/RequestSyslogger.js
@@ -1,0 +1,56 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { WallClock } from '@this/clocks';
+import { IntfRequestLogger } from '@this/net-protocol';
+import { OutgoingResponse } from '@this/net-util';
+import { BaseService } from '@this/sys-framework';
+
+
+/**
+ * Service which writes the request/response log to the system log (which itself
+ * might in turn be written to several possible locations).
+ *
+ * See `doc/configuration.md` for configuration object details.
+ *
+ * @implements {IntfRequestLogger}
+ */
+export class RequestSyslogger extends BaseService {
+  // Note: The default constructor is fine for this class.
+
+  /** @override */
+  async logCompletedRequest(line_unused) {
+    // TODO: Remove this method.
+  }
+
+  /** @override */
+  now() {
+    return WallClock.now();
+  }
+
+  /** @override */
+  async requestStarted(networkInfo_unused, timingInfo_unused, request) {
+    request.logger?.request(request.getLoggableRequestInfo());
+  }
+
+  /** @override */
+  async requestEnded(networkInfo, timingInfo, request, response_unused) {
+    // Note: This call isn't supposed to `throw`, even if there were errors
+    // thrown during handling.
+    const resInfo = await OutgoingResponse.getLoggableResponseInfo(
+      networkInfo.nodeResponse, networkInfo.connectionSocket);
+
+    request.logger?.response(resInfo);
+    request.logger?.timing(timingInfo);
+  }
+
+  /** @override */
+  async _impl_start(isReload_unused) {
+    // No need to do anything.
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // No need to do anything.
+  }
+}

--- a/src/builtin-services/index.js
+++ b/src/builtin-services/index.js
@@ -7,4 +7,5 @@ export * from '#x/ProcessIdFile';
 export * from '#x/ProcessInfoFile';
 export * from '#x/RateLimiter';
 export * from '#x/RequestLogger';
+export * from '#x/RequestSyslogger';
 export * from '#x/SystemLogger';

--- a/src/net-protocol/export/IntfRequestLogger.js
+++ b/src/net-protocol/export/IntfRequestLogger.js
@@ -1,7 +1,10 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { Moment } from '@this/data-values';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Http2ServerRequest, Http2ServerResponse } from 'node:http2';
+
+import { Duration, Moment } from '@this/data-values';
 import { IncomingRequest, OutgoingResponse } from '@this/net-util';
 import { Methods } from '@this/typey';
 
@@ -38,36 +41,42 @@ export class IntfRequestLogger {
    * Indicates to this instance that a request has started.
    *
    * @abstract
+   * @param {object} networkInfo Information about the network environment.
+   * @param {object} networkInfo.connectionSocket The socket (or socket-like
+   *   object) used by the lowest level of the connection that the request is
+   *   running on.
+   * @param {IncomingMessage|Http2ServerRequest} networkInfo.nodeRequest
+   *   Low-level request object.
+   * @param {ServerResponse|Http2ServerResponse} networkInfo.nodeResponse
+   *   Low-level response object.
    * @param {object} timingInfo Information about request timing.
    * @param {Moment} timingInfo.start The moment the request started getting
    *   handled (or at least a reasonably close moment to that). This can be
    *   expected to be a value returned from a call to {@link #now} on this
    *   instance.
-   * @param {object} requestInfo Reasonably-logged information about the
-   *   incoming request. See {@link IncomingRequest#getLoggableRequestInfo} for
-   *   details.
+   * @param {IncomingRequest} request The incoming request.
    */
-  async requestStarted(timingInfo, requestInfo) {
-    Methods.abstract(timingInfo, requestInfo);
+  async requestStarted(networkInfo, timingInfo, request) {
+    Methods.abstract(networkInfo, timingInfo, request);
   }
 
   /**
-   * Indicates to this instance that a request has ended.
+   * Indicates to this instance that a request has ended (that is, its response
+   * has been sent).
    *
    * @abstract
+   * @param {object} networkInfo Information about the network environment. See
+   *   {@link #requestStarted} for details.
    * @param {object} timingInfo Information about request timing.
    * @param {Moment} timingInfo.start Same as with {@link #requestStarted}.
    * @param {Moment} timingInfo.end The moment the request was considered
    *   complete. This can be expected to be a value returned from a call to
    *   {@link #now} on this instance.
-   * @param {object} requestInfo Reasonably-logged information about the
-   *   incoming request. See {@link IncomingRequest#getLoggableRequestInfo} for
-   *   details.
-   * @param {object} responseInfo Reasonably-logged information about the
-   *   incoming request. See {@link OutgoingResponse#getLoggableResponseInfo}
-   *   for details.
+   * @param {Duration} timingInfo.duration The difference `end - start`.
+   * @param {IncomingRequest} request The incoming request.
+   * @param {OutgoingResponse} response The response that was sent.
    */
-  async requestEnded(timingInfo, requestInfo, responseInfo) {
-    Methods.abstract(timingInfo, requestInfo, responseInfo);
+  async requestEnded(networkInfo, timingInfo, request, response) {
+    Methods.abstract(networkInfo, timingInfo, request, response);
   }
 }

--- a/src/net-protocol/export/IntfRequestLogger.js
+++ b/src/net-protocol/export/IntfRequestLogger.js
@@ -74,7 +74,8 @@ export class IntfRequestLogger {
    *   {@link #now} on this instance.
    * @param {Duration} timingInfo.duration The difference `end - start`.
    * @param {IncomingRequest} request The incoming request.
-   * @param {OutgoingResponse} response The response that was sent.
+   * @param {OutgoingResponse} response The response that was sent (or at least
+   *   attempted).
    */
   async requestEnded(networkInfo, timingInfo, request, response) {
     Methods.abstract(networkInfo, timingInfo, request, response);

--- a/src/net-protocol/export/IntfRequestLogger.js
+++ b/src/net-protocol/export/IntfRequestLogger.js
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Moment } from '@this/data-values';
+import { IncomingRequest, OutgoingResponse } from '@this/net-util';
 import { Methods } from '@this/typey';
 
 
 /**
- * Interface for (HTTP-ish) request loggers, as used by this module.
+ * Interface for (HTTP-ish) request loggers, as used by this module. Instances
+ * of this interface get an opportunity to perform logging at the start of
+ * requests and when the request/response cycle has ended. It is of course
+ * a-okay for instances to choose to ignore one or the other.
  *
  * @interface
  */
@@ -28,5 +32,42 @@ export class IntfRequestLogger {
    */
   async logCompletedRequest(line) {
     Methods.abstract(line);
+  }
+
+  /**
+   * Indicates to this instance that a request has started.
+   *
+   * @abstract
+   * @param {object} timingInfo Information about request timing.
+   * @param {Moment} timingInfo.start The moment the request started getting
+   *   handled (or at least a reasonably close moment to that). This can be
+   *   expected to be a value returned from a call to {@link #now} on this
+   *   instance.
+   * @param {object} requestInfo Reasonably-logged information about the
+   *   incoming request. See {@link IncomingRequest#getLoggableRequestInfo} for
+   *   details.
+   */
+  async requestStarted(timingInfo, requestInfo) {
+    Methods.abstract(timingInfo, requestInfo);
+  }
+
+  /**
+   * Indicates to this instance that a request has ended.
+   *
+   * @abstract
+   * @param {object} timingInfo Information about request timing.
+   * @param {Moment} timingInfo.start Same as with {@link #requestStarted}.
+   * @param {Moment} timingInfo.end The moment the request was considered
+   *   complete. This can be expected to be a value returned from a call to
+   *   {@link #now} on this instance.
+   * @param {object} requestInfo Reasonably-logged information about the
+   *   incoming request. See {@link IncomingRequest#getLoggableRequestInfo} for
+   *   details.
+   * @param {object} responseInfo Reasonably-logged information about the
+   *   incoming request. See {@link OutgoingResponse#getLoggableResponseInfo}
+   *   for details.
+   */
+  async requestEnded(timingInfo, requestInfo, responseInfo) {
+    Methods.abstract(timingInfo, requestInfo, responseInfo);
   }
 }

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -521,7 +521,23 @@ export class ProtocolWrangler {
         // with reasonable accuracy, the call to `logRequest()` has to happen
         // early during dispatch, and definitely _not_ after the response has
         // been sent!
-        this.#logHelper.logRequest(request, outerContext, res, responseSent);
+
+        const responsePromise = (async () => {
+          try {
+            await responseSent;
+          } catch {
+            // Ignore the error, if any. Any error will ultimately get revealed
+            // via `getLoggableResponseInfo()` as will also get logged below.
+          }
+          return result;
+        })();
+
+        const networkInfo = {
+          connectionSocket: outerContext.socket,
+          nodeRequest:      res.req,
+          nodeResponse:     res
+        };
+        this.#logHelper.logRequest(request, responsePromise, networkInfo);
       }
 
       await responseSent;

--- a/src/net-protocol/private/RequestLogHelper.js
+++ b/src/net-protocol/private/RequestLogHelper.js
@@ -58,7 +58,7 @@ export class RequestLogHelper {
 
     // Note: This call isn't supposed to `throw`, even if there were errors
     // thrown during handling.
-    const info = await OutgoingResponse.getLoggableResponseInfo(res, context.socket);
+    const resInfo = await OutgoingResponse.getLoggableResponseInfo(res, context.socket);
 
     // Rearrange `info` into preferred loggable form, and augment with
     // connection error info if appropriate.
@@ -68,13 +68,13 @@ export class RequestLogHelper {
       errorCodes,
       ok,
       statusCode
-    } = info;
+    } = resInfo;
 
     const codeStr = ok ? 'ok' : errorCodes.join(',');
 
     // This is to avoid redundancy and to end up with a specific propery order
     // in `finalInfo` (for human readability).
-    const finalInfo = { ok, duration, ...info };
+    const finalInfo = { ok, duration, ...resInfo };
 
     logger?.response(finalInfo);
 

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -137,7 +137,7 @@ export class IncomingRequest {
    * by Node's {@link IncomingMessage#headers}.
    */
   get headers() {
-    // TODO: This should be a `HttpHeaders` object.
+    // TODO: This should be an `HttpHeaders` object.
     return this.#coreRequest.headers;
   }
 

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -215,6 +215,9 @@ export class IncomingRequest {
    * single-element key with empty value, that is `['']`, and _not_ an empty
    * key. This preserves the invariant that the keys for all directory-like
    * requests end with an empty path element.
+   *
+   * **Note:** The name of this field matches the equivalent field of the
+   * standard `URL` class.
    */
   get pathname() {
     return this.#parsedTarget.pathname ?? null;
@@ -226,9 +229,6 @@ export class IncomingRequest {
    * is, the kind that includes a path). This starts with a slash (`/`) and
    * omits the search a/k/a query (`?...`), if any. This also includes
    * "resolving" away any `.` or `..` components.
-   *
-   * **Note:** The name of this field matches the equivalent field of the
-   * standard `URL` class.
    */
   get pathnameString() {
     return this.#parsedTarget.pathnameString ?? null;

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -443,7 +443,7 @@ export class IncomingRequest {
     // Non-obvious: This deletes the symbol property `sensitiveHeaders` from the
     // result (whose value is an array of header names that, per Node docs,
     // aren't supposed to be compressed due to poor interaction with desirable
-    // cryptography properties). This _isn't_ supposed to actually delete th
+    // cryptography properties). This _isn't_ supposed to actually delete the
     // headers _named_ by this value.
     delete result[Http2SensitiveHeaders];
 

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -441,7 +441,7 @@ export class IncomingRequest {
     delete result.host;
 
     // Non-obvious: This deletes the symbol property `sensitiveHeaders` from the
-    // result (whose array is a value of header names that, per Node docs,
+    // result (whose value is an array of header names that, per Node docs,
     // aren't supposed to be compressed due to poor interaction with desirable
     // cryptography properties). This _isn't_ supposed to actually delete th
     // headers _named_ by this value.


### PR DESCRIPTION
This PR is a bunch of tweakage to the request/response logging stuff. Highlights:

* Moved the more "policy" bits (vs. "mechanism") of request logging into the `RequestLogger` service.
* Added a new `RequestSyslogger` service (which just logs to the syslog as opposed to a separate file).
* Added an option to `RequestLogger` to _also_ log to the syslog (so you don't have to define two logging services in a pretty common case).
* Fixed `ProtocolWrangler` so it calls on the request logger earlier, thus enabling it to perform more accurate timing measurements.