### PR TITLE
Nascent component relationships. Fix instantiation vis-a-vis logging.

### DIFF
--- a/src/built-ins/export/MemoryMonitor.js
+++ b/src/built-ins/export/MemoryMonitor.js
@@ -32,6 +32,11 @@ export class MemoryMonitor extends BaseService {
   // Note: Default constructor is fine for this class.
 
   /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
   async _impl_start(isReload_unused) {
     await this.#runner.start();
   }

--- a/src/built-ins/export/ProcessIdFile.js
+++ b/src/built-ins/export/ProcessIdFile.js
@@ -31,6 +31,11 @@ export class ProcessIdFile extends BaseFileService {
   // Note: Default constructor is fine for this class.
 
   /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
   async _impl_start(isReload_unused) {
     await this.#runner.start();
   }

--- a/src/built-ins/export/ProcessInfoFile.js
+++ b/src/built-ins/export/ProcessInfoFile.js
@@ -9,7 +9,6 @@ import { Duration } from '@this/data-values';
 import { Statter } from '@this/fs-util';
 import { Host, ProcessInfo, ProcessUtil, ProductInfo }
   from '@this/host';
-import { IntfLogger } from '@this/loggy-intf';
 import { FileServiceConfig } from '@this/sys-config';
 import { BaseFileService, Saver } from '@this/sys-util';
 import { MustBe } from '@this/typey';

--- a/src/built-ins/export/ProcessInfoFile.js
+++ b/src/built-ins/export/ProcessInfoFile.js
@@ -28,7 +28,7 @@ export class ProcessInfoFile extends BaseFileService {
   #contents = null;
 
   /** @type {?Saver} File saver (preserver) to use, if any. */
-  #saver;
+  #saver = null;
 
   /** @type {Threadlet} Threadlet which runs this service. */
   #runner = new Threadlet(() => this.#start(), () => this.#run());
@@ -37,17 +37,15 @@ export class ProcessInfoFile extends BaseFileService {
    * Constructs an instance.
    *
    * @param {FileServiceConfig} config Configuration for this service.
-   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
-  constructor(config, logger) {
-    super(config, logger);
-
-    this.#saver = config.save ? new Saver(config, this.logger) : null;
+  constructor(config) {
+    super(config);
   }
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // Nothing needed here for this class.
+    const { config } = this;
+    this.#saver = config.save ? new Saver(config, this.logger) : null;
   }
 
   /** @override */

--- a/src/built-ins/export/ProcessInfoFile.js
+++ b/src/built-ins/export/ProcessInfoFile.js
@@ -46,6 +46,11 @@ export class ProcessInfoFile extends BaseFileService {
   }
 
   /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
   async _impl_start(isReload) {
     if (this.#saver) {
       if (!isReload) {

--- a/src/built-ins/export/RateLimiter.js
+++ b/src/built-ins/export/RateLimiter.js
@@ -65,6 +65,11 @@ export class RateLimiter extends BaseService {
   }
 
   /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
   async _impl_start(isReload_unused) {
     // Nothing to do here.
   }

--- a/src/built-ins/export/RateLimiter.js
+++ b/src/built-ins/export/RateLimiter.js
@@ -33,10 +33,9 @@ export class RateLimiter extends BaseService {
    * Constructs an instance.
    *
    * @param {ServiceConfig} config Configuration for this service.
-   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
-  constructor(config, logger) {
-    super(config, logger);
+  constructor(config) {
+    super(config);
 
     const { connections, data, requests } = config;
 

--- a/src/built-ins/export/Redirector.js
+++ b/src/built-ins/export/Redirector.js
@@ -54,6 +54,11 @@ export class Redirector extends BaseApplication {
   }
 
   /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
   async _impl_start(isReload_unused) {
     // Nothing to do here.
   }

--- a/src/built-ins/export/Redirector.js
+++ b/src/built-ins/export/Redirector.js
@@ -1,7 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IntfLogger } from '@this/loggy-intf';
 import { HttpUtil, OutgoingResponse, Uris } from '@this/net-util';
 import { ApplicationConfig } from '@this/sys-config';
 import { BaseApplication } from '@this/sys-framework';
@@ -29,10 +28,9 @@ export class Redirector extends BaseApplication {
    * Constructs an instance.
    *
    * @param {ApplicationConfig} config Configuration for this application.
-   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
-  constructor(config, logger) {
-    super(config, logger);
+  constructor(config) {
+    super(config);
 
     this.#cacheControl = config.cacheControl;
     this.#statusCode   = config.statusCode;

--- a/src/built-ins/export/RequestLogger.js
+++ b/src/built-ins/export/RequestLogger.js
@@ -4,7 +4,7 @@
 import * as fs from 'node:fs/promises';
 
 import { WallClock } from '@this/clocks';
-import { FormatUtils, IntfLogger } from '@this/loggy-intf';
+import { FormatUtils } from '@this/loggy-intf';
 import { IntfRequestLogger } from '@this/net-protocol';
 import { OutgoingResponse } from '@this/net-util';
 import { FileServiceConfig } from '@this/sys-config';
@@ -21,7 +21,7 @@ import { MustBe } from '@this/typey';
  */
 export class RequestLogger extends BaseFileService {
   /** @type {?Rotator} File rotator to use, if any. */
-  #rotator;
+  #rotator = null;
 
   /** @type {boolean} Also log to the system log? */
   #doSyslog;
@@ -30,12 +30,10 @@ export class RequestLogger extends BaseFileService {
    * Constructs an instance.
    *
    * @param {FileServiceConfig} config Configuration for this service.
-   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
-  constructor(config, logger) {
-    super(config, logger);
+  constructor(config) {
+    super(config);
 
-    this.#rotator  = config.rotate ? new Rotator(config, this.logger) : null;
     this.#doSyslog = config.doSyslog;
   }
 
@@ -95,7 +93,8 @@ export class RequestLogger extends BaseFileService {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // Nothing needed here for this class.
+    const { config } = this;
+    this.#rotator = config.rotate ? new Rotator(config, this.logger) : null;
   }
 
   /** @override */

--- a/src/built-ins/export/RequestLogger.js
+++ b/src/built-ins/export/RequestLogger.js
@@ -94,6 +94,11 @@ export class RequestLogger extends BaseFileService {
   }
 
   /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
   async _impl_start(isReload) {
     await this._prot_createDirectoryIfNecessary();
     await this._prot_touchPath();

--- a/src/built-ins/export/RequestSyslogger.js
+++ b/src/built-ins/export/RequestSyslogger.js
@@ -45,6 +45,11 @@ export class RequestSyslogger extends BaseService {
   }
 
   /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
   async _impl_start(isReload_unused) {
     // No need to do anything.
   }

--- a/src/built-ins/export/SimpleResponse.js
+++ b/src/built-ins/export/SimpleResponse.js
@@ -33,6 +33,11 @@ export class SimpleResponse extends BaseApplication {
   }
 
   /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
   async _impl_start(isReload_unused) {
     if (this.#response) {
       return;

--- a/src/built-ins/export/StaticFiles.js
+++ b/src/built-ins/export/StaticFiles.js
@@ -4,7 +4,6 @@
 import fs from 'node:fs/promises';
 
 import { Paths, Statter } from '@this/fs-util';
-import { IntfLogger } from '@this/loggy-intf';
 import { DispatchInfo, EtagGenerator, HttpUtil, MimeTypes, OutgoingResponse }
   from '@this/net-util';
 import { ApplicationConfig } from '@this/sys-config';
@@ -46,10 +45,9 @@ export class StaticFiles extends BaseApplication {
    * Constructs an instance.
    *
    * @param {ApplicationConfig} config Configuration for this application.
-   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
-  constructor(config, logger) {
-    super(config, logger);
+  constructor(config) {
+    super(config);
 
     const { cacheControl, etagOptions, notFoundPath, siteDirectory } = config;
 

--- a/src/built-ins/export/StaticFiles.js
+++ b/src/built-ins/export/StaticFiles.js
@@ -111,6 +111,11 @@ export class StaticFiles extends BaseApplication {
   }
 
   /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
   async _impl_start(isReload_unused) {
     const siteDirectory = this.#siteDirectory;
 

--- a/src/built-ins/export/SystemLogger.js
+++ b/src/built-ins/export/SystemLogger.js
@@ -4,7 +4,6 @@
 import { EventTracker, LinkedEvent } from '@this/async';
 import { WallClock } from '@this/clocks';
 import { Loggy, TextFileSink } from '@this/loggy';
-import { IntfLogger } from '@this/loggy-intf';
 import { FileServiceConfig } from '@this/sys-config';
 import { BaseFileService, Rotator } from '@this/sys-util';
 import { MustBe } from '@this/typey';

--- a/src/built-ins/export/SystemLogger.js
+++ b/src/built-ins/export/SystemLogger.js
@@ -17,7 +17,7 @@ import { MustBe } from '@this/typey';
  */
 export class SystemLogger extends BaseFileService {
   /** @type {?Rotator} File rotator to use, if any. */
-  #rotator;
+  #rotator = null;
 
   /**
    * @type {?TextFileSink} Event sink which does the actual writing, or `null`
@@ -29,21 +29,21 @@ export class SystemLogger extends BaseFileService {
    * Constructs an instance.
    *
    * @param {FileServiceConfig} config Configuration for this service.
-   * @param {IntfLogger} logger Logger to use. Required for this class!
    */
-  constructor(config, logger) {
-    // Note: Loggers are all supposed to be callable functions. The interface
-    // type `IntfLogger` (above) should also be true, but interfaces aren't
-    // actually reified in the JavaScript runtime, so we can't easily check it.
-    MustBe.function(logger);
-    super(config, logger);
-
-    this.#rotator = config.rotate ? new Rotator(config, this.logger) : null;
+  constructor(config) {
+    super(config);
   }
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // Nothing needed here for this class.
+    // Having a logger available is optional for most classes, but for this one
+    // it is essential!
+    if (!this.logger) {
+      throw new Error('Cannot use this class without a logger.');
+    };
+
+    const { config } = this;
+    this.#rotator = config.rotate ? new Rotator(config, this.logger) : null;
   }
 
 

--- a/src/built-ins/export/SystemLogger.js
+++ b/src/built-ins/export/SystemLogger.js
@@ -42,6 +42,12 @@ export class SystemLogger extends BaseFileService {
   }
 
   /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+
+  /** @override */
   async _impl_start(isReload) {
     await this._prot_createDirectoryIfNecessary();
     await this._prot_touchPath();

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -149,7 +149,6 @@ export class ProtocolWrangler {
    * Initializes this instance as needed prior to getting `start()`ed, including
    * optionally setting up a logger to use.
    *
-   *
    * @param {?IntfLogger} logger System logger to use, or `null` if to not do
    *   logging.
    * @param {boolean} isReload Is this action due to an in-process reload?

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IntfLogger, IntfLoggingEnvironment } from '@this/loggy-intf';
+import { IntfLoggingEnvironment } from '@this/loggy-intf';
 import { DispatchInfo, IncomingRequest, IntfRequestHandler, OutgoingResponse }
   from '@this/net-util';
 import { ApplicationConfig } from '@this/sys-config';
@@ -26,12 +26,9 @@ export class BaseApplication extends BaseComponent {
    * Constructs an instance.
    *
    * @param {ApplicationConfig} config Configuration for this application.
-   * @param {?IntfLogger} logger Logger to use at the application layer
-   *   (incoming requests have their own logger), or `null` to not do any
-   *   logging.
    */
-  constructor(config, logger) {
-    super(config, logger);
+  constructor(config) {
+    super(config);
 
     this.#filterConfig = (config instanceof BaseApplication.FilterConfig) ? config : null;
   }

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -1,7 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IntfLoggingEnvironment } from '@this/loggy-intf';
 import { DispatchInfo, IncomingRequest, IntfRequestHandler, OutgoingResponse }
   from '@this/net-util';
 import { ApplicationConfig } from '@this/sys-config';

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -23,12 +23,6 @@ export class BaseApplication extends BaseComponent {
   #filterConfig;
 
   /**
-   * @type {?IntfLoggingEnvironment} Logging environment, or `null` the instance
-   * is not doing logging.
-   */
-  #loggingEnv;
-
-  /**
    * Constructs an instance.
    *
    * @param {ApplicationConfig} config Configuration for this application.
@@ -40,7 +34,6 @@ export class BaseApplication extends BaseComponent {
     super(config, logger);
 
     this.#filterConfig = (config instanceof BaseApplication.FilterConfig) ? config : null;
-    this.#loggingEnv   = this.logger?.$env ?? null;
   }
 
   /** @override */
@@ -149,14 +142,15 @@ export class BaseApplication extends BaseComponent {
    * @returns {?OutgoingResponse} Response to the request, if any.
    */
   async #logHandlerCall(request, dispatch, result) {
-    const startTime = this.#loggingEnv.now();
-    const logger    = this.logger;
-    const id        = request.id;
+    const loggingEnv = this.logger.$env;
+    const startTime  = loggingEnv.now();
+    const logger     = this.logger;
+    const id         = request.id;
 
     logger?.handling(id, dispatch.extraString);
 
     const done = (fate, ...error) => {
-      const endTime  = this.#loggingEnv.now();
+      const endTime  = loggingEnv.now();
       const duration = endTime.subtract(startTime);
       logger[fate](id, duration, ...error);
     };

--- a/src/sys-framework/export/BaseComponent.js
+++ b/src/sys-framework/export/BaseComponent.js
@@ -1,7 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IntfLogger } from '@this/loggy-intf';
 import { BaseConfig } from '@this/sys-config';
 import { MustBe } from '@this/typey';
 
@@ -19,10 +18,9 @@ export class BaseComponent extends BaseControllable {
    * Constructs an instance.
    *
    * @param {BaseConfig} config Configuration for this component.
-   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
-  constructor(config, logger) {
-    super(logger);
+  constructor(config) {
+    super();
     this.#config = MustBe.instanceOf(config, this.constructor.CONFIG_CLASS);
   }
 

--- a/src/sys-framework/export/BaseControllable.js
+++ b/src/sys-framework/export/BaseControllable.js
@@ -59,6 +59,21 @@ export class BaseControllable {
   }
 
   /**
+   * Subclass-specific implementation of {@link #init}. By the time this is
+   * called, the {@link #context} will have been set.
+   *
+   * **Note:** It is not appropriate to take any overt external action in this
+   * method (such as writing files to the filesystem or opening a network
+   * connection) beyond "sensing" (e.g., reading a file).
+   *
+   * @abstract
+   * @param {boolean} isReload Is this action due to an in-process reload?
+   */
+  async _impl_init(isReload) {
+    Methods.abstract(isReload);
+  }
+
+  /**
    * Subclass-specific implementation of {@link #start}.
    *
    * @abstract
@@ -85,6 +100,28 @@ export class BaseControllable {
   //
 
   /**
+   * Logs a message about an item (component, etc.) completing an `init()`
+   * action.
+   *
+   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
+   * @param {boolean} isReload Is this a system reload (vs. first-time init)?
+   */
+  static logInitialized(logger, isReload) {
+    logger?.initialized(isReload ? 'reload' : 'boot');
+  }
+
+  /**
+   * Logs a message about an item (component, etc.) starting an `init()`
+   * action.
+   *
+   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
+   * @param {boolean} isReload Is this a system reload (vs. first-time init)?
+   */
+  static logInitializing(logger, isReload) {
+    logger?.initializing(isReload ? 'reload' : 'boot');
+  }
+
+  /**
    * Logs a message about an item (component, etc.) completing a `start()`
    * action.
    *
@@ -92,7 +129,7 @@ export class BaseControllable {
    * @param {boolean} isReload Is this a system reload (vs. first-time init)?
    */
   static logStarted(logger, isReload) {
-    logger?.started(isReload ? 'reload' : 'init');
+    logger?.started(isReload ? 'reload' : 'boot');
   }
 
   /**
@@ -103,7 +140,7 @@ export class BaseControllable {
    * @param {boolean} isReload Is this a system reload (vs. first-time init)?
    */
   static logStarting(logger, isReload) {
-    logger?.starting(isReload ? 'reload' : 'init');
+    logger?.starting(isReload ? 'reload' : 'boot');
   }
 
   /**

--- a/src/sys-framework/export/BaseControllable.js
+++ b/src/sys-framework/export/BaseControllable.js
@@ -23,21 +23,18 @@ export class BaseControllable {
    */
   #context = null;
 
-  /** @type {?IntfLogger} Logger to use, or `null` to not do any logging. */
-  #logger = null;
-
   /**
    * Constructs an instance.
    *
-   * @param {?ControlContext|IntfLogger} contextOrLogger Associated context or
-   *   logger to use, or `null` to not do any context-related setup (yet).
+   * @param {?ControlContext} [context] Associated context, or `null` to not
+   *   start out with a context. This is typically `null` _except_ when creating
+   *   the instance of this class which represents an entire "world" of
+   *   controllable items.
    */
-  constructor(contextOrLogger) {
-    if (contextOrLogger instanceof ControlContext) {
-      this.#context = contextOrLogger;
-    } else if (contextOrLogger !== null) {
-      this.#logger = contextOrLogger;
-    }
+  constructor(context = null) {
+    this.#context = (context === null)
+      ? null
+      : MustBe.instanceOf(context, ControlContext);
   }
 
   /**
@@ -49,7 +46,7 @@ export class BaseControllable {
 
   /** @returns {?IntfLogger} Logger to use, or `null` to not do any logging. */
   get logger() {
-    return this.#logger;
+    return this.#context?.logger;
   }
 
   /**
@@ -68,14 +65,13 @@ export class BaseControllable {
       throw new Error('Already initialized.');
     } else if (this.#context === null) {
       this.#context = MustBe.instanceOf(context, ControlContext);
-      this.#logger  = context.logger;
     }
 
     this.#initialized = true;
 
-    BaseControllable.logInitializing(this.#logger);
+    BaseControllable.logInitializing(this.logger);
     await this._impl_init(isReload);
-    BaseControllable.logInitialized(this.#logger);
+    BaseControllable.logInitialized(this.logger);
   }
 
   /**
@@ -94,9 +90,9 @@ export class BaseControllable {
       await this.init(null, isReload);
     }
 
-    BaseControllable.logStarting(this.#logger, isReload);
+    BaseControllable.logStarting(this.logger, isReload);
     await this._impl_start(isReload);
-    BaseControllable.logStarted(this.#logger, isReload);
+    BaseControllable.logStarted(this.logger, isReload);
   }
 
   /**
@@ -109,9 +105,9 @@ export class BaseControllable {
   async stop(willReload = false) {
     MustBe.boolean(willReload);
 
-    BaseControllable.logStopping(this.#logger, willReload);
+    BaseControllable.logStopping(this.logger, willReload);
     await this._impl_stop(willReload);
-    BaseControllable.logStopped(this.#logger, willReload);
+    BaseControllable.logStopped(this.logger, willReload);
   }
 
   /**

--- a/src/sys-framework/export/BaseService.js
+++ b/src/sys-framework/export/BaseService.js
@@ -1,7 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IntfLogger } from '@this/loggy-intf';
 import { ServiceConfig } from '@this/sys-config';
 
 import { BaseComponent } from '#x/BaseComponent';
@@ -15,10 +14,9 @@ export class BaseService extends BaseComponent {
    * Constructs an instance.
    *
    * @param {ServiceConfig} config Configuration for this service.
-   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
-  constructor(config, logger) {
-    super(config, logger);
+  constructor(config) {
+    super(config);
   }
 
 

--- a/src/sys-framework/export/ComponentManager.js
+++ b/src/sys-framework/export/ComponentManager.js
@@ -7,6 +7,7 @@ import { AskIf, MustBe } from '@this/typey';
 
 import { BaseComponent } from '#x/BaseComponent';
 import { BaseControllable } from '#x/BaseControllable';
+import { ControlContext } from '#x/ControlContext';
 
 
 /**
@@ -113,9 +114,22 @@ export class ComponentManager extends BaseControllable {
   }
 
   /** @override */
+  async _impl_init(isReload) {
+    const instances = this.getAll();
+
+    const results = instances.map((c) => {
+      const logger  = this.#baseSublogger[c.name];
+      const context = new ControlContext(this.context.world, logger);
+      return c.init(context, isReload);
+    });
+
+    await Promise.all(results);
+  }
+
+  /** @override */
   async _impl_start(isReload) {
     const instances = this.getAll();
-    const results   = instances.map((s) => s.start(isReload));
+    const results   = instances.map((c) => c.start(isReload));
 
     await Promise.all(results);
   }
@@ -123,7 +137,7 @@ export class ComponentManager extends BaseControllable {
   /** @override */
   async _impl_stop(willReload) {
     const instances = this.getAll();
-    const results   = instances.map((s) => s.stop(willReload));
+    const results   = instances.map((c) => c.stop(willReload));
 
     await Promise.all(results);
   }

--- a/src/sys-framework/export/ComponentManager.js
+++ b/src/sys-framework/export/ComponentManager.js
@@ -154,9 +154,7 @@ export class ComponentManager extends BaseControllable {
       throw new Error(`Duplicate component: ${name}`);
     }
 
-    const sublogger = this.#baseSublogger[name];
-    const instance  = new config.class(config, sublogger);
-
+    const instance = new config.class(config);
     this.#instances.set(name, instance);
   }
 

--- a/src/sys-framework/export/ComponentManager.js
+++ b/src/sys-framework/export/ComponentManager.js
@@ -51,17 +51,14 @@ export class ComponentManager extends BaseControllable {
    *   the same as passing `BaseComponent`.
    * @param {?IntfLogger} [options.baseSublogger] Base sublogger to use
    *   for instantiated components, or `null` not to do any logging.
-   * @param {?IntfLogger} [options.logger] Logger to use for this
-   *   instance, or `null` not to do any logging.
    */
   constructor(configs, options) {
     const {
       baseClass = null,
-      baseSublogger = null,
-      logger = null
+      baseSublogger = null
     } = options;
 
-    super(logger);
+    super();
 
     this.#baseClass = (baseClass === null)
       ? BaseComponent
@@ -161,7 +158,6 @@ export class ComponentManager extends BaseControllable {
     const instance  = new config.class(config, sublogger);
 
     this.#instances.set(name, instance);
-    this.logger?.bound(name);
   }
 
   /**

--- a/src/sys-framework/export/ControlContext.js
+++ b/src/sys-framework/export/ControlContext.js
@@ -1,0 +1,75 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { IntfLogger } from '@this/loggy-intf';
+import { MustBe } from '@this/typey';
+
+import { BaseControllable } from '#x/BaseControllable';
+
+
+/**
+ * "Context" in which a {@link BaseControllable} is situated. Instances of this
+ * class are handed to controllables via {@link BaseControllable#init}, which
+ * gets called when they become hooked into a "world" (an environment that
+ * contains and manages all the controllable instances).
+ */
+export class ControlContext {
+  /** @type {?IntfLogger} Logger to use, or `null` to not do any logging. */
+  #logger;
+
+  /**
+   * @type {?BaseControllable} Instance which represents the entire world of
+   * controllable instances, or `null` if this instance's associated instance
+   * _is_ the "world."
+   */
+  #world;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {BaseControllable|string} world Instance which represents the entire
+   *   world of controllable instances, or the string `world` if this instance
+   *   itself is to be the context of the "world" instance.
+   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
+   */
+  constructor(world, logger) {
+    this.#world  = (world === 'world')
+      ? null
+      : MustBe.instanceOf(world, BaseControllable);
+    this.#logger = logger;
+  }
+
+  /** @returns {?IntfLogger} Logger to use, or `null` to not do any logging. */
+  get logger() {
+    return this.#logger;
+  }
+
+  /**
+   * @returns {BaseControllable} Instance which represents the entire world of
+   * controllable instances.
+   */
+  get world() {
+    if (this.#world === null) {
+      throw new Error('Incomplete "world" context.');
+    }
+
+    return this.#world;
+  }
+
+  /**
+   * Sets up the loopback of this instance to the actual "world" object. This
+   * is needed because it's impossible to name the world during its own
+   * construction (due to JavaScript rules around references to `this`).
+   *
+   * @param {BaseControllable} world The actual "world" instance.
+   */
+  linkWorld(world) {
+    if (this.#world !== null) {
+      throw new Error('Already linked to a world.');
+    } else if (world.context !== this) {
+      throw new Error('Context mismatch.');
+    }
+
+    this.#world = world;
+  }
+}

--- a/src/sys-framework/export/EndpointManager.js
+++ b/src/sys-framework/export/EndpointManager.js
@@ -130,7 +130,6 @@ export class EndpointManager extends BaseControllable {
     const extraConfig = {
       applicationMap: this.#makeApplicationMap(mounts),
       hostManager:    hmSubset,
-      logger:         ThisModule.cohortLogger('endpoint')?.[name],
       rateLimiter,
       requestLogger
     };

--- a/src/sys-framework/export/EndpointManager.js
+++ b/src/sys-framework/export/EndpointManager.js
@@ -33,7 +33,7 @@ export class EndpointManager extends BaseControllable {
    * @param {Warehouse} warehouse The warehouse this instance is in.
    */
   constructor(configs, warehouse) {
-    super(ThisModule.subsystemLogger('endpoints'));
+    super();
 
     this.#warehouse = warehouse;
 
@@ -138,7 +138,6 @@ export class EndpointManager extends BaseControllable {
     const instance = new NetworkEndpoint(config, extraConfig);
 
     this.#instances.set(name, instance);
-    this.logger?.bound(name);
   }
 
   /**

--- a/src/sys-framework/export/EndpointManager.js
+++ b/src/sys-framework/export/EndpointManager.js
@@ -5,6 +5,7 @@ import { EndpointConfig, MountConfig } from '@this/sys-config';
 
 import { BaseApplication } from '#x/BaseApplication';
 import { BaseControllable } from '#x/BaseControllable';
+import { ControlContext } from '#x/ControlContext';
 import { NetworkEndpoint } from '#x/NetworkEndpoint';
 import { ThisModule } from '#p/ThisModule';
 import { Warehouse } from '#x/Warehouse';
@@ -68,9 +69,22 @@ export class EndpointManager extends BaseControllable {
   }
 
   /** @override */
+  async _impl_init(isReload) {
+    const endpoints = this.getAll();
+
+    const results = endpoints.map((e) => {
+      const logger  = ThisModule.cohortLogger('endpoint')?.[e.name];
+      const context = new ControlContext(this.context.world, logger);
+      return e.init(context, isReload);
+    });
+
+    await Promise.all(results);
+  }
+
+  /** @override */
   async _impl_start(isReload) {
     const endpoints = this.getAll();
-    const results   = endpoints.map((s) => s.start(isReload));
+    const results   = endpoints.map((e) => e.start(isReload));
 
     await Promise.all(results);
   }
@@ -78,7 +92,7 @@ export class EndpointManager extends BaseControllable {
   /** @override */
   async _impl_stop(willReload) {
     const endpoints = this.getAll();
-    const results = endpoints.map((s) => s.stop(willReload));
+    const results = endpoints.map((e) => e.stop(willReload));
 
     await Promise.all(results);
   }

--- a/src/sys-framework/export/NetworkEndpoint.js
+++ b/src/sys-framework/export/NetworkEndpoint.js
@@ -75,21 +75,6 @@ export class NetworkEndpoint extends BaseComponent {
     };
 
     this.#wrangler = ProtocolWranglers.make(wranglerOptions);
-
-    if (logger) {
-      const mountMap = {};
-
-      for (const [host, hostMounts] of this.#mountMap) {
-        const hostString = host.toHostnameString();
-        const paths      = {};
-        for (const [path, app] of hostMounts) {
-          paths[path.toUriPathString(true)] = app.name;
-        }
-        mountMap[hostString] = paths;
-      }
-
-      logger?.mounts(mountMap);
-    }
   }
 
   /**
@@ -145,7 +130,22 @@ export class NetworkEndpoint extends BaseComponent {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // Nothing needed here for this class.
+    const logger = this.logger;
+
+    if (logger) {
+      const mountMap = {};
+
+      for (const [host, hostMounts] of this.#mountMap) {
+        const hostString = host.toHostnameString();
+        const paths      = {};
+        for (const [path, app] of hostMounts) {
+          paths[path.toUriPathString(true)] = app.name;
+        }
+        mountMap[hostString] = paths;
+      }
+
+      logger?.mounts(mountMap);
+    }
   }
 
   /** @override */

--- a/src/sys-framework/export/NetworkEndpoint.js
+++ b/src/sys-framework/export/NetworkEndpoint.js
@@ -46,8 +46,6 @@ export class NetworkEndpoint extends BaseComponent {
    * @param {Map<string, BaseApplication>} extraConfig.applicationMap Map of
    *   names to applications, for use in building the active mount map.
    * @param {?HostManager} extraConfig.hostManager Replacement for `hostnames`.
-   * @param {?IntfLogger} extraConfig.logger Logger to use for reporting network
-   *   activity, or `null not to do any logging.
    * @param {?IntfRateLimiter} extraConfig.rateLimiter Replacement for
    *   `rateLimiter` (service instance, not just a name).
    * @param {?IntfRequestLogger} extraConfig.requestLogger Replacement for
@@ -55,9 +53,9 @@ export class NetworkEndpoint extends BaseComponent {
    */
   constructor(config, extraConfig) {
     const { interface: iface, mounts, protocol } = config;
-    const { applicationMap, hostManager, logger, rateLimiter, requestLogger } = extraConfig;
+    const { applicationMap, hostManager, rateLimiter, requestLogger } = extraConfig;
 
-    super(config, logger);
+    super(config);
 
     this.#mountMap = NetworkEndpoint.#makeMountMap(mounts, applicationMap);
 
@@ -65,7 +63,6 @@ export class NetworkEndpoint extends BaseComponent {
       rateLimiter,
       requestHandler: this,
       requestLogger,
-      logger,
       protocol,
       interface: iface,
       ...(
@@ -129,8 +126,10 @@ export class NetworkEndpoint extends BaseComponent {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init(isReload) {
     const logger = this.logger;
+
+    await this.#wrangler.init(logger, isReload);
 
     if (logger) {
       const mountMap = {};

--- a/src/sys-framework/export/NetworkEndpoint.js
+++ b/src/sys-framework/export/NetworkEndpoint.js
@@ -144,6 +144,11 @@ export class NetworkEndpoint extends BaseComponent {
   }
 
   /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
   async _impl_start(isReload) {
     await this.#wrangler.start(isReload);
   }

--- a/src/sys-framework/export/NetworkEndpoint.js
+++ b/src/sys-framework/export/NetworkEndpoint.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TreePathKey, TreePathMap } from '@this/collections';
-import { IntfLogger } from '@this/loggy-intf';
 import { IntfRateLimiter, IntfRequestLogger, ProtocolWrangler,
   ProtocolWranglers }
   from '@this/net-protocol';

--- a/src/sys-framework/export/Warehouse.js
+++ b/src/sys-framework/export/Warehouse.js
@@ -47,7 +47,7 @@ export class Warehouse extends BaseControllable {
 
     const context = new ControlContext('world', ThisModule.subsystemLogger('warehouse'));
     super(context);
-    context.linkWorld(this);
+    context.linkWorld(this); // See comment in `ControlContext` for explanation.
 
     const parsed = new WarehouseConfig(config);
 

--- a/src/sys-framework/export/Warehouse.js
+++ b/src/sys-framework/export/Warehouse.js
@@ -10,6 +10,7 @@ import { BaseApplication } from '#x/BaseApplication';
 import { BaseControllable } from '#x/BaseControllable';
 import { BaseService } from '#x/BaseService';
 import { ComponentManager } from '#x/ComponentManager';
+import { ControlContext } from '#x/ControlContext';
 import { EndpointManager } from '#x/EndpointManager';
 import { HostManager } from '#x/HostManager';
 import { ThisModule } from '#p/ThisModule';
@@ -44,7 +45,9 @@ export class Warehouse extends BaseControllable {
   constructor(config) {
     MustBe.plainObject(config);
 
-    super(ThisModule.subsystemLogger('warehouse'));
+    const context = new ControlContext('world', ThisModule.subsystemLogger('warehouse'));
+    super(context);
+    context.linkWorld(this);
 
     const parsed = new WarehouseConfig(config);
 
@@ -85,6 +88,19 @@ export class Warehouse extends BaseControllable {
   /** @returns {ComponentManager} Service manager. */
   get serviceManager() {
     return this.#serviceManager;
+  }
+
+  /** @override */
+  async _impl_init(isReload) {
+    const makeCc = (name) => new ControlContext(this, ThisModule.subsystemLogger(name));
+
+    const results = [
+      this.#serviceManager.init(makeCc('services'), isReload),
+      this.#applicationManager.init(makeCc('applications'), isReload),
+      this.#endpointManager.init(makeCc('endpoints'), isReload)
+    ];
+
+    await Promise.all(results);
   }
 
   /** @override */

--- a/src/sys-framework/export/Warehouse.js
+++ b/src/sys-framework/export/Warehouse.js
@@ -53,14 +53,12 @@ export class Warehouse extends BaseControllable {
 
     this.#applicationManager = new ComponentManager(parsed.applications, {
       baseClass:     BaseApplication,
-      baseSublogger: ThisModule.cohortLogger('app'),
-      logger:        ThisModule.subsystemLogger('apps')
+      baseSublogger: ThisModule.cohortLogger('app')
     });
 
     this.#serviceManager = new ComponentManager(parsed.services, {
       baseClass:     BaseService,
-      baseSublogger: ThisModule.cohortLogger('service'),
-      logger:        ThisModule.subsystemLogger('services')
+      baseSublogger: ThisModule.cohortLogger('service')
     });
 
     this.#hostManager     = new HostManager(parsed.hosts);
@@ -96,7 +94,7 @@ export class Warehouse extends BaseControllable {
 
     const results = [
       this.#serviceManager.init(makeCc('services'), isReload),
-      this.#applicationManager.init(makeCc('applications'), isReload),
+      this.#applicationManager.init(makeCc('apps'), isReload),
       this.#endpointManager.init(makeCc('endpoints'), isReload)
     ];
 

--- a/src/sys-framework/index.js
+++ b/src/sys-framework/index.js
@@ -6,6 +6,7 @@ export * from '#x/BaseComponent';
 export * from '#x/BaseControllable';
 export * from '#x/BaseService';
 export * from '#x/ComponentManager';
+export * from '#x/ControlContext';
 export * from '#x/EndpointManager';
 export * from '#x/HostManager';
 export * from '#x/NetworkEndpoint';


### PR DESCRIPTION
This PR lays the groundwork for treating a set of "controllable" components holistically in terms of how they're managed. The eventual outcome will be that it should be easy to define hierarchical apps, such that an app contains and controls other apps. This will end up being the case once routing stops being a single implementation at the `NetworkEndpoint` layer and starts having multiple different implementations, each a concrete subclass of `BaseApplication`.

Details:
* New class `ControlContext`, an instance of which gets associated with each concrete instance of `BaseControllable`.
* New lifecycle method `init()` on `BaseControllable`, which is where those contexts get hooked up.
* Made `ControlContext` be where a controllable's `logger` is, which means that loggers don't get passed on controllable construction anymore. This _mostly_ simplified things (though it added a little bit of new pain here and there).
