### PR TITLE
Framework parentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Breaking changes:
     instances. This will _eventually_ be the key mechanism for treating a set of
     components holistically in a reasonably general way. (Right now there's a
     lot of ad-hoc arrangement.)
+  * Added related new class `RootControlContext`, a subclass of `ControlContext`
+    which specifically represents the root of a hierarchy.
   * Added new lifecycle method `init()` (and abstract implementation method
     `_impl_init()`) to `BaseControllable`, which is where the above contexts get
     hooked up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Breaking changes:
   * Added new class `ControlContext`, which gets associated with each concrete
     instance of `BaseControllable` (the superclass of all app and service
     classes, among other things). This is now where an instance's `logger` is
-    found. This will _eventually_ be the key mechanism for treating a set of
+    found, and it also keeps track of the parent/child relationships between
+    instances. This will _eventually_ be the key mechanism for treating a set of
     components holistically in a reasonably general way. (Right now there's a
     lot of ad-hoc arrangement.)
   * Added new lifecycle method `init()` (and abstract implementation method

--- a/src/sys-framework/export/BaseControllable.js
+++ b/src/sys-framework/export/BaseControllable.js
@@ -28,8 +28,8 @@ export class BaseControllable {
    *
    * @param {?ControlContext} [context] Associated context, or `null` to not
    *   start out with a context. This is typically `null` _except_ when creating
-   *   the instance of this class which represents an entire "world" of
-   *   controllable items.
+   *   the instance of this class which represents the root of a controllable
+   *   hierarchy.
    */
   constructor(context = null) {
     this.#context = (context === null)

--- a/src/sys-framework/export/ComponentManager.js
+++ b/src/sys-framework/export/ComponentManager.js
@@ -116,7 +116,7 @@ export class ComponentManager extends BaseControllable {
 
     const results = instances.map((c) => {
       const logger  = this.#baseSublogger[c.name];
-      const context = new ControlContext(this.context.world, logger);
+      const context = new ControlContext(c, this, logger);
       return c.init(context, isReload);
     });
 

--- a/src/sys-framework/export/ControlContext.js
+++ b/src/sys-framework/export/ControlContext.js
@@ -10,33 +10,59 @@ import { BaseControllable } from '#x/BaseControllable';
 /**
  * "Context" in which a {@link BaseControllable} is situated. Instances of this
  * class are handed to controllables via {@link BaseControllable#init}, which
- * gets called when they become hooked into a "world" (an environment that
- * contains and manages all the controllable instances).
+ * gets called when they become hooked into a hierarchy of instances.
  */
 export class ControlContext {
   /** @type {?IntfLogger} Logger to use, or `null` to not do any logging. */
   #logger;
 
   /**
-   * @type {?BaseControllable} Instance which represents the entire world of
-   * controllable instances, or `null` if this instance's associated instance
-   * _is_ the "world."
+   * @type {?BaseControllable} Associated controllable instance. Is only ever
+   * `null` for the context of the root instance itself, and only briefly while
+   * it gets bootstrapped.
    */
-  #world;
+  #associate;
+
+  /**
+   * @type {?ControlContext} Instance which represents the parent (container)
+   * of this instance's associated controllable, or `null` if this instance has
+   * no parent (that is, is the root of the containership hierarchy).
+   */
+  #parent;
+
+  /**
+   * @type {ControlContext} Instance which represents the root of the
+   * containership hierarchy.
+   */
+  #root;
 
   /**
    * Constructs an instance.
    *
-   * @param {BaseControllable|string} world Instance which represents the entire
-   *   world of controllable instances, or the string `world` if this instance
-   *   itself is to be the context of the "world" instance.
+   * @param {BaseControllable|string} associate Associated controllable
+   *   instance, or the string `root` if this instance is to represent the root
+   *   instance.
+   * @param {?BaseControllable} parent Parent of `associate`, or `null` if this
+   *   instance is to represent the root instance.
    * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
-  constructor(world, logger) {
-    this.#world  = (world === 'world')
-      ? null
-      : MustBe.instanceOf(world, BaseControllable);
+  constructor(associate, parent, logger) {
     this.#logger = logger;
+
+    if (associate === 'root') {
+      this.#associate = null; // Gets set in `linkRoot()`.
+      this.#parent    = null; // ...and it stays that way.
+      this.#root      = this;
+    } else {
+      this.#associate = MustBe.instanceOf(associate, BaseControllable);
+      this.#parent    = MustBe.instanceOf(parent, BaseControllable).context;
+      this.#root      = this.#parent.#root;
+    }
+  }
+
+  /** @returns {BaseControllable} Associated controllable instance. */
+  get associate() {
+    return this.#associate;
   }
 
   /** @returns {?IntfLogger} Logger to use, or `null` to not do any logging. */
@@ -45,31 +71,46 @@ export class ControlContext {
   }
 
   /**
-   * @returns {BaseControllable} Instance which represents the entire world of
-   * controllable instances.
+   * @returns {?ControlContext} Instance which represents the parent of this
+   * instance's {@link #associate}, or `null` if this instance represents the
+   * root of the containership hierarchy.
    */
-  get world() {
-    if (this.#world === null) {
-      throw new Error('Incomplete "world" context.');
-    }
-
-    return this.#world;
+  get parent() {
+    return this.#parent;
   }
 
   /**
-   * Sets up the loopback of this instance to the actual "world" object. This
-   * is needed because it's impossible to name the world during its own
-   * construction (due to JavaScript rules around references to `this`).
-   *
-   * @param {BaseControllable} world The actual "world" instance.
+   * @returns {ControlContext} Instance which represents the root of the
+   * containership hierarchy.
    */
-  linkWorld(world) {
-    if (this.#world !== null) {
-      throw new Error('Already linked to a world.');
-    } else if (world.context !== this) {
+  get root() {
+    if (this.#root === null) {
+      throw new Error('Root setup was incomplete.');
+    }
+
+    return this.#root;
+  }
+
+  /**
+   * Sets up the {@link #associate} of this instance to be the indicated object.
+   * This method is needed because it's impossible for the root to refer to
+   * itself when trying to construct an instance of this class before calling
+   * `super()` in its `constructor()` (due to JavaScript rules around references
+   * to `this` in that context).
+   *
+   * @param {BaseControllable} root The actual "root" instance.
+   */
+  linkRoot(root) {
+    MustBe.instanceOf(root, BaseControllable);
+
+    if (this.#root !== this) {
+      throw new Error('Not a root instance.');
+    } else if (this.#associate !== null) {
+      throw new Error('Already linked.');
+    } else if (root.context !== this) {
       throw new Error('Context mismatch.');
     }
 
-    this.#world = world;
+    this.#associate = root;
   }
 }

--- a/src/sys-framework/export/ControlContext.js
+++ b/src/sys-framework/export/ControlContext.js
@@ -5,6 +5,7 @@ import { IntfLogger } from '@this/loggy-intf';
 import { MustBe } from '@this/typey';
 
 import { BaseControllable } from '#x/BaseControllable';
+import { ThisModule } from '#p/ThisModule';
 
 
 /**
@@ -56,7 +57,7 @@ export class ControlContext {
     } else {
       this.#associate = MustBe.instanceOf(associate, BaseControllable);
       this.#parent    = MustBe.instanceOf(parent, BaseControllable).context;
-      this.#root      = this.#parent.#root;
+      this.#root      = MustBe.instanceOf(this.#parent.#root, ControlContext);
     }
   }
 
@@ -92,15 +93,13 @@ export class ControlContext {
   }
 
   /**
-   * Sets up the {@link #associate} of this instance to be the indicated object.
-   * This method is needed because it's impossible for the root to refer to
-   * itself when trying to construct an instance of this class before calling
-   * `super()` in its `constructor()` (due to JavaScript rules around references
-   * to `this` in that context).
+   * Underlying implementation of the method `linkRoot()` in subclass
+   * `RootControlContext`. This is a module-private method here so that it
+   * doesn't get exposed on non-root instances.
    *
    * @param {BaseControllable} root The actual "root" instance.
    */
-  linkRoot(root) {
+  [ThisModule.SYM_linkRoot](root) {
     MustBe.instanceOf(root, BaseControllable);
 
     if (this.#root !== this) {

--- a/src/sys-framework/export/ControlContext.js
+++ b/src/sys-framework/export/ControlContext.js
@@ -58,6 +58,8 @@ export class ControlContext {
       this.#associate = MustBe.instanceOf(associate, BaseControllable);
       this.#parent    = MustBe.instanceOf(parent, BaseControllable).context;
       this.#root      = MustBe.instanceOf(this.#parent.#root, ControlContext);
+
+      this.#root[ThisModule.SYM_addDescendant](this);
     }
   }
 

--- a/src/sys-framework/export/EndpointManager.js
+++ b/src/sys-framework/export/EndpointManager.js
@@ -74,7 +74,7 @@ export class EndpointManager extends BaseControllable {
 
     const results = endpoints.map((e) => {
       const logger  = ThisModule.cohortLogger('endpoint')?.[e.name];
-      const context = new ControlContext(this.context.world, logger);
+      const context = new ControlContext(e, this, logger);
       return e.init(context, isReload);
     });
 

--- a/src/sys-framework/export/RootControlContext.js
+++ b/src/sys-framework/export/RootControlContext.js
@@ -13,7 +13,7 @@ import { ThisModule } from '#p/ThisModule';
  * hierarchy.
  */
 export class RootControlContext extends ControlContext {
-  /** @type {Set<BaseControllable>} Set of all descendants. */
+  /** @type {Set<ControlContext>} Set of all descendants. */
   #descendants = new Set();
 
   /**
@@ -28,7 +28,7 @@ export class RootControlContext extends ControlContext {
   /**
    * Registers a descendant with this instance.
    *
-   * @param {BaseControllable} descendant The descendant.
+   * @param {ControlContext} descendant The descendant.
    */
   [ThisModule.SYM_addDescendant](descendant) {
     if (this.#descendants.has(descendant)) {

--- a/src/sys-framework/export/RootControlContext.js
+++ b/src/sys-framework/export/RootControlContext.js
@@ -3,6 +3,7 @@
 
 import { IntfLogger } from '@this/loggy-intf';
 
+import { BaseComponent } from '#x/BaseComponent';
 import { BaseControllable } from '#x/BaseControllable';
 import { ControlContext } from '#x/ControlContext';
 import { ThisModule } from '#p/ThisModule';
@@ -13,6 +14,13 @@ import { ThisModule } from '#p/ThisModule';
  * hierarchy.
  */
 export class RootControlContext extends ControlContext {
+  /**
+   * @type {Map<string, ControlContext>} For each context which represents a
+   * component (all of which have `name`s), a mapping from its name to the
+   * context. This represents a subset of all descendants.
+   */
+  #components = new Map();
+
   /** @type {Set<ControlContext>} Set of all descendants. */
   #descendants = new Set();
 
@@ -33,6 +41,15 @@ export class RootControlContext extends ControlContext {
   [ThisModule.SYM_addDescendant](descendant) {
     if (this.#descendants.has(descendant)) {
       throw new Error('Cannot register same descendant twice.');
+    }
+
+    const associate = descendant.associate;
+    if (associate instanceof BaseComponent) {
+      const name = associate.name;
+      if (this.#components.has(name)) {
+        throw new Error('Cannot register two different components with the same name.');
+      }
+      this.#components.set(name, descendant);
     }
 
     this.#descendants.add(descendant);

--- a/src/sys-framework/export/RootControlContext.js
+++ b/src/sys-framework/export/RootControlContext.js
@@ -1,0 +1,53 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { IntfLogger } from '@this/loggy-intf';
+
+import { BaseControllable } from '#x/BaseControllable';
+import { ControlContext } from '#x/ControlContext';
+import { ThisModule } from '#p/ThisModule';
+
+
+/**
+ * Special context subclass which is _only_ used to represent the root of a
+ * hierarchy.
+ */
+export class RootControlContext extends ControlContext {
+  /** @type {Set<BaseControllable>} Set of all descendants. */
+  #descendants = new Set();
+
+  /**
+   * Constructs an instance. It initially has no `associate`.
+   *
+   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
+   */
+  constructor(logger) {
+    super('root', null, logger);
+  }
+
+  /**
+   * Registers a descendant with this instance.
+   *
+   * @param {BaseControllable} descendant The descendant.
+   */
+  [ThisModule.SYM_addDescendant](descendant) {
+    if (this.#descendants.has(descendant)) {
+      throw new Error('Cannot register same descendant twice.');
+    }
+
+    this.#descendants.add(descendant);
+  }
+
+  /**
+   * Sets up the {@link #associate} of this instance to be the indicated object.
+   * This method is needed because it's impossible for the root to refer to
+   * itself when trying to construct an instance of this class before calling
+   * `super()` in its `constructor()` (due to JavaScript rules around references
+   * to `this` in that context).
+   *
+   * @param {BaseControllable} root The actual "root" instance.
+   */
+  linkRoot(root) {
+    this[ThisModule.SYM_linkRoot](root);
+  }
+}

--- a/src/sys-framework/export/Warehouse.js
+++ b/src/sys-framework/export/Warehouse.js
@@ -45,9 +45,9 @@ export class Warehouse extends BaseControllable {
   constructor(config) {
     MustBe.plainObject(config);
 
-    const context = new ControlContext('world', ThisModule.subsystemLogger('warehouse'));
+    const context = new ControlContext('root', null, ThisModule.subsystemLogger('warehouse'));
     super(context);
-    context.linkWorld(this); // See comment in `ControlContext` for explanation.
+    context.linkRoot(this); // See comment in `ControlContext` for explanation.
 
     const parsed = new WarehouseConfig(config);
 
@@ -90,12 +90,15 @@ export class Warehouse extends BaseControllable {
 
   /** @override */
   async _impl_init(isReload) {
-    const makeCc = (name) => new ControlContext(this, ThisModule.subsystemLogger(name));
+    const callInit = (name, obj) => {
+      const context = new ControlContext(obj, this, ThisModule.subsystemLogger(name));
+      return obj.init(context, isReload);
+    };
 
     const results = [
-      this.#serviceManager.init(makeCc('services'), isReload),
-      this.#applicationManager.init(makeCc('apps'), isReload),
-      this.#endpointManager.init(makeCc('endpoints'), isReload)
+      callInit('services',  this.#serviceManager),
+      callInit('apps',      this.#applicationManager),
+      callInit('endpoints', this.#endpointManager)
     ];
 
     await Promise.all(results);

--- a/src/sys-framework/export/Warehouse.js
+++ b/src/sys-framework/export/Warehouse.js
@@ -13,6 +13,7 @@ import { ComponentManager } from '#x/ComponentManager';
 import { ControlContext } from '#x/ControlContext';
 import { EndpointManager } from '#x/EndpointManager';
 import { HostManager } from '#x/HostManager';
+import { RootControlContext } from '#x/RootControlContext';
 import { ThisModule } from '#p/ThisModule';
 
 
@@ -45,9 +46,9 @@ export class Warehouse extends BaseControllable {
   constructor(config) {
     MustBe.plainObject(config);
 
-    const context = new ControlContext('root', null, ThisModule.subsystemLogger('warehouse'));
+    const context = new RootControlContext(ThisModule.subsystemLogger('warehouse'));
     super(context);
-    context.linkRoot(this); // See comment in `ControlContext` for explanation.
+    context.linkRoot(this); // See comment in `RootControlContext` for explanation.
 
     const parsed = new WarehouseConfig(config);
 

--- a/src/sys-framework/index.js
+++ b/src/sys-framework/index.js
@@ -10,4 +10,5 @@ export * from '#x/ControlContext';
 export * from '#x/EndpointManager';
 export * from '#x/HostManager';
 export * from '#x/NetworkEndpoint';
+export * from '#x/RootControlContext';
 export * from '#x/Warehouse';

--- a/src/sys-framework/private/ThisModule.js
+++ b/src/sys-framework/private/ThisModule.js
@@ -23,6 +23,14 @@ export class ThisModule {
   static #logger = Loggy.loggerFor('framework');
 
   /**
+   * @type {symbol} Symbol used for the module-private method `addDescendant`.
+   */
+  static SYM_addDescendant = Symbol('sys-framework.addDescendant');
+
+  /** @type {symbol} Symbol used for the module-private method `linkRoot`. */
+  static SYM_linkRoot = Symbol('sys-framework.linkRoot');
+
+  /**
    * Gets a logger for a particular cohort. A "cohort" is a set of similar
    * items of some sort, e.g. "applications" or "services."
    *


### PR DESCRIPTION
This PR is a follow-on from the last one. In this one, the new context stuff gets expanded so that it keeps track of the parent/child relationships in the controllable hierarchy, which all ends up in an instance of a new subclass of `ControlContext` called `RootControlContext` which — surprise surprise — is the representative of the root of a controllable hierarchy.

Nothing is done with all this info, yet, but it will be instrumental in enabling the whole apps-using-apps thing.