### PR TITLE
Control tweak

### DIFF
--- a/src/sys-framework/export/BaseControllable.js
+++ b/src/sys-framework/export/BaseControllable.js
@@ -5,6 +5,7 @@ import { IntfLogger } from '@this/loggy-intf';
 import { Methods, MustBe } from '@this/typey';
 
 import { ControlContext } from '#x/ControlContext';
+import { RootControlContext } from '#x/RootControlContext';
 import { ThisModule } from '#p/ThisModule';
 
 
@@ -16,26 +17,25 @@ import { ThisModule } from '#p/ThisModule';
  */
 export class BaseControllable {
   /**
-   * @type {?ControlContext|{ nascentRoot: ControlContext}} Associated context,
-   * possibly wrapped in an object for the special case of the root object
-   * before the instance is considered initialized. Becomes non-`null` (and a
-   * regular instance) during {@link #init}.
+   * @type {?ControlContext|{ nascentRoot: RootControlContext}} Associated
+   * context, if known, possibly wrapped in an object for the special case of
+   * the root context before this instance is considered initialized. If `null`
+   * or wrapped, will get set (to a proper instance) during {@link #init}.
    */
   #context = null;
 
   /**
    * Constructs an instance.
    *
-   * @param {?ControlContext} [context] Associated context, or `null` to not
-   *   start out with a context. This should be `null` _except_ when creating
-   *   the instance of this class which represents the root of a controllable
-   *   hierarchy.
+   * @param {?RootControlContext} [rootContext] Associated context if this
+   *   instance is to be the root of its control hierarchy, or `null` for any
+   *   other instance.
    */
   constructor(context = null) {
     if (context !== null) {
       // Note: We wrap `#context` here, so that it is recognized as
       // "uninitialized" by the time `start()` gets called.
-      this.#context = { nascentRoot: MustBe.instanceOf(context, ControlContext) };
+      this.#context = { nascentRoot: MustBe.instanceOf(context, RootControlContext) };
       context[ThisModule.SYM_linkRoot](this);
     }
   }

--- a/src/sys-framework/export/BaseControllable.js
+++ b/src/sys-framework/export/BaseControllable.js
@@ -17,7 +17,7 @@ import { ThisModule } from '#p/ThisModule';
  */
 export class BaseControllable {
   /**
-   * @type {?ControlContext|{ nascentRoot: RootControlContext}} Associated
+   * @type {?ControlContext|{ nascentRoot: RootControlContext }} Associated
    * context, if known, possibly wrapped in an object for the special case of
    * the root context before this instance is considered initialized. If `null`
    * or wrapped, will get set (to a proper instance) during {@link #init}.

--- a/src/sys-framework/export/BaseControllable.js
+++ b/src/sys-framework/export/BaseControllable.js
@@ -5,6 +5,7 @@ import { IntfLogger } from '@this/loggy-intf';
 import { Methods, MustBe } from '@this/typey';
 
 import { ControlContext } from '#x/ControlContext';
+import { ThisModule } from '#p/ThisModule';
 
 
 /**
@@ -14,12 +15,11 @@ import { ControlContext } from '#x/ControlContext';
  * of lifecycle methods.
  */
 export class BaseControllable {
-  /** @type {boolean} Has {@link #_impl_init} been called? */
-  #initialized = false;
-
   /**
-   * @type {?ControlContext} Associated context. Becomes non-`null` during
-   * {@link #init}.
+   * @type {?ControlContext|{ nascentRoot: ControlContext}} Associated context,
+   * possibly wrapped in an object for the special case of the root object
+   * before the instance is considered initialized. Becomes non-`null` (and a
+   * regular instance) during {@link #init}.
    */
   #context = null;
 
@@ -27,26 +27,26 @@ export class BaseControllable {
    * Constructs an instance.
    *
    * @param {?ControlContext} [context] Associated context, or `null` to not
-   *   start out with a context. This is typically `null` _except_ when creating
+   *   start out with a context. This should be `null` _except_ when creating
    *   the instance of this class which represents the root of a controllable
    *   hierarchy.
    */
   constructor(context = null) {
-    this.#context = (context === null)
-      ? null
-      : MustBe.instanceOf(context, ControlContext);
+    if (context !== null) {
+      this.#context = { nascentRoot: MustBe.instanceOf(context, ControlContext) };
+    }
   }
 
   /**
    * @returns {?ControlContext} Associated context, or `null` if not yet set up.
    */
   get context() {
-    return this.#context;
+    return (this.#initialized ? this.#context : this.#context?.nascentRoot) ?? null;
   }
 
   /** @returns {?IntfLogger} Logger to use, or `null` to not do any logging. */
   get logger() {
-    return this.#context?.logger;
+    return this.context?.logger ?? null;
   }
 
   /**
@@ -55,19 +55,19 @@ export class BaseControllable {
    *
    * @param {ControlContext} context Context that indicates this instance's
    *   active environment.
-   * @param {boolean} [isReload] Is this action due to an in-process
-   *   reload?
+   * @param {boolean} [isReload] Is this action due to an in-process reload?
    */
   async init(context, isReload = false) {
+    MustBe.instanceOf(context, ControlContext);
     MustBe.boolean(isReload);
 
     if (this.#initialized) {
       throw new Error('Already initialized.');
-    } else if (this.#context === null) {
-      this.#context = MustBe.instanceOf(context, ControlContext);
+    } else if ((this.#context !== null) && (this.#context.nascentRoot !== context)) {
+      throw new Error('Inconsistent context setup.');
     }
 
-    this.#initialized = true;
+    this.#context = context;
 
     BaseControllable.logInitializing(this.logger);
     await this._impl_init(isReload);
@@ -75,19 +75,43 @@ export class BaseControllable {
   }
 
   /**
-   * Starts this instance.
+   * Links this instance up to its context, as a root. This needs to be called
+   * after the `super()` call in the constructor of a root instance, either in
+   * the constructor itself or soon after it completes. This method must not be
+   * called in any other case.
    *
-   * @param {boolean} [isReload] Is this action due to an in-process
-   *   reload?
+   * This method is needed because it's impossible for the root to refer to
+   * itself when trying to construct an instance of this class before calling
+   * `super()` in its `constructor()` (due to JavaScript rules around references
+   * to `this` in that context).
+   */
+  linkRoot() {
+    if (this.#initialized) {
+      throw new Error('Already initialized.');
+    } else if (this.#context === null) {
+      throw new Error('Not an uninitialized root.');
+    }
+
+    // Note: We don't actually set `#context` here, so that it is still
+    // considered "uninitialized" by the time `start()` gets called.
+    this.#context.nascentRoot[ThisModule.SYM_linkRoot](this);
+  }
+
+  /**
+   * Starts this instance. It is only valid to call this after {@link #init} has
+   * been called, _except_ if this instance is the root, in which case this
+   * method will call {@link #init} itself before doing the start-per-se.
+   *
+   * @param {boolean} [isReload] Is this action due to an in-process reload?
    */
   async start(isReload = false) {
     MustBe.boolean(isReload);
 
     if (!this.#initialized) {
       if (this.#context === null) {
-        throw new Error('No associated context set up in constructor or `init()`.');
+        throw new Error('No context was set up in constructor or `init()`.');
       }
-      await this.init(null, isReload);
+      await this.init(this.#context.nascentRoot, isReload);
     }
 
     BaseControllable.logStarting(this.logger, isReload);
@@ -99,8 +123,8 @@ export class BaseControllable {
    * Stops this this instance. This method returns when the instance is fully
    * stopped.
    *
-   * @param {boolean} [willReload] Is this action due to an in-process
-   *   reload being requested?
+   * @param {boolean} [willReload] Is this action due to an in-process reload
+   *   being requested?
    */
   async stop(willReload = false) {
     MustBe.boolean(willReload);
@@ -144,6 +168,11 @@ export class BaseControllable {
    */
   async _impl_stop(willReload) {
     Methods.abstract(willReload);
+  }
+
+  /** @returns {boolean} Whether or not this instance is initialized. */
+  get #initialized() {
+    return this.#context instanceof ControlContext;
   }
 
 

--- a/src/sys-framework/export/BaseControllable.js
+++ b/src/sys-framework/export/BaseControllable.js
@@ -33,7 +33,10 @@ export class BaseControllable {
    */
   constructor(context = null) {
     if (context !== null) {
+      // Note: We wrap `#context` here, so that it is recognized as
+      // "uninitialized" by the time `start()` gets called.
       this.#context = { nascentRoot: MustBe.instanceOf(context, ControlContext) };
+      context[ThisModule.SYM_linkRoot](this);
     }
   }
 
@@ -72,29 +75,6 @@ export class BaseControllable {
     BaseControllable.logInitializing(this.logger);
     await this._impl_init(isReload);
     BaseControllable.logInitialized(this.logger);
-  }
-
-  /**
-   * Links this instance up to its context, as a root. This needs to be called
-   * after the `super()` call in the constructor of a root instance, either in
-   * the constructor itself or soon after it completes. This method must not be
-   * called in any other case.
-   *
-   * This method is needed because it's impossible for the root to refer to
-   * itself when trying to construct an instance of this class before calling
-   * `super()` in its `constructor()` (due to JavaScript rules around references
-   * to `this` in that context).
-   */
-  linkRoot() {
-    if (this.#initialized) {
-      throw new Error('Already initialized.');
-    } else if (this.#context === null) {
-      throw new Error('Not an uninitialized root.');
-    }
-
-    // Note: We don't actually set `#context` here, so that it is still
-    // considered "uninitialized" by the time `start()` gets called.
-    this.#context.nascentRoot[ThisModule.SYM_linkRoot](this);
   }
 
   /**

--- a/src/sys-framework/export/ControlContext.js
+++ b/src/sys-framework/export/ControlContext.js
@@ -95,9 +95,9 @@ export class ControlContext {
   }
 
   /**
-   * Underlying implementation of the method `linkRoot()` in subclass
-   * `RootControlContext`. This is a module-private method here so that it
-   * doesn't get exposed on non-root instances.
+   * Underlying implementation of the method `BaseControllable.linkRoot()`. This
+   * is a module-private method, so that it can only be called when appropriate
+   * (and thus avoid inconsistent state).
    *
    * @param {BaseControllable} root The actual "root" instance.
    */
@@ -106,10 +106,10 @@ export class ControlContext {
 
     if (this.#root !== this) {
       throw new Error('Not a root instance.');
-    } else if (this.#associate !== null) {
-      throw new Error('Already linked.');
     } else if (root.context !== this) {
       throw new Error('Context mismatch.');
+    } else if (this.#associate !== null) {
+      throw new Error('Already linked.');
     }
 
     this.#associate = root;

--- a/src/sys-framework/export/RootControlContext.js
+++ b/src/sys-framework/export/RootControlContext.js
@@ -4,7 +4,6 @@
 import { IntfLogger } from '@this/loggy-intf';
 
 import { BaseComponent } from '#x/BaseComponent';
-import { BaseControllable } from '#x/BaseControllable';
 import { ControlContext } from '#x/ControlContext';
 import { ThisModule } from '#p/ThisModule';
 
@@ -53,18 +52,5 @@ export class RootControlContext extends ControlContext {
     }
 
     this.#descendants.add(descendant);
-  }
-
-  /**
-   * Sets up the {@link #associate} of this instance to be the indicated object.
-   * This method is needed because it's impossible for the root to refer to
-   * itself when trying to construct an instance of this class before calling
-   * `super()` in its `constructor()` (due to JavaScript rules around references
-   * to `this` in that context).
-   *
-   * @param {BaseControllable} root The actual "root" instance.
-   */
-  linkRoot(root) {
-    this[ThisModule.SYM_linkRoot](root);
   }
 }

--- a/src/sys-framework/export/Warehouse.js
+++ b/src/sys-framework/export/Warehouse.js
@@ -46,9 +46,10 @@ export class Warehouse extends BaseControllable {
   constructor(config) {
     MustBe.plainObject(config);
 
+    // See comment in `BaseControllable` for an explanation about this setup.
     const context = new RootControlContext(ThisModule.subsystemLogger('warehouse'));
     super(context);
-    context.linkRoot(this); // See comment in `RootControlContext` for explanation.
+    this.linkRoot();
 
     const parsed = new WarehouseConfig(config);
 

--- a/src/sys-framework/export/Warehouse.js
+++ b/src/sys-framework/export/Warehouse.js
@@ -46,10 +46,10 @@ export class Warehouse extends BaseControllable {
   constructor(config) {
     MustBe.plainObject(config);
 
-    // See comment in `BaseControllable` for an explanation about this setup.
+    // Note: `super()` is called with an argument exactly because this instance
+    // is the root of its hierarchy.
     const context = new RootControlContext(ThisModule.subsystemLogger('warehouse'));
     super(context);
-    this.linkRoot();
 
     const parsed = new WarehouseConfig(config);
 

--- a/src/sys-framework/export/Warehouse.js
+++ b/src/sys-framework/export/Warehouse.js
@@ -48,8 +48,7 @@ export class Warehouse extends BaseControllable {
 
     // Note: `super()` is called with an argument exactly because this instance
     // is the root of its hierarchy.
-    const context = new RootControlContext(ThisModule.subsystemLogger('warehouse'));
-    super(context);
+    super(new RootControlContext(ThisModule.subsystemLogger('warehouse')));
 
     const parsed = new WarehouseConfig(config);
 


### PR DESCRIPTION
This PR cleans up how the root of a controllable hierarchy gets set up, making it much more straightforward from the client perspective and also avoiding having to have an extra `#initialized` field on `BaseController`.