### PR TITLE
`HostRouter` and `PathRouter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
+* Merged all the built-in applications and services into a unified module
+  called `built-ins`.
 * Configuration:
   * Stopped using a component registry to find applications and services.
     Instead, just let the (Node / JavaScript) module system be that. Simplifies
@@ -35,6 +37,11 @@ Other notable changes:
     `stdout`, when it's a TTY.
   * Fixed request logging so that it gets a more accurate (earlier) start time
     for requests.
+* `built-ins`:
+  * New class `HostRouter` which does what you probably expect from the name.
+  * Likewise, new class `PathRouter`. This and its buddy are intended to be
+    replacements for the routing implementation currently baked into
+    `EndpointManager`.
 
 ### v0.6.10 -- 2024-03-15
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -271,6 +271,95 @@ const applications = [
 ];
 ```
 
+### `HostRouter`
+
+An application which can route requests to another application, based on the
+`host` (or equivalent) header in the requests. In addition to the
+[`BaseApplication`](#baseapplication) configuration options, it accepts the
+following bindings:
+
+* `hosts` &mdash; A plain object with possibly-wildcarded hostnames as keys, and
+  the _names_ of other applications as values. A wildcard only covers the prefix
+  of a hostname and cannot be used for hostnames identified by numeric IP
+  address.
+
+**Note:** Unlike `PathRouter`, this application does not do fallback to
+less-and-less specific routes; it just finds (at most) one to route to.
+
+```js
+import { HostRouter } from '@lactoserv/built-ins';
+
+const applications = [
+  {
+    name:  'myHosts',
+    class: HostRouter,
+    hosts: {
+      '*':             'myCatchAllApp',
+      '127.0.0.1':     'myLocalhostApp',
+      'localhost':     'myLocalhostApp',
+      '*.example.com': 'myExampleApp'
+    }
+  },
+  {
+    name: 'myCatchallApp',
+    // ... more ...
+  },
+  {
+    name: 'myExampleApp',
+    // ... more ...
+  },
+  {
+    name: 'myLocalhostApp',
+    // ... more ...
+  }
+];
+```
+
+### `PathRouter`
+
+An application which can route requests to another application, based on the
+path of the requests. In addition to the [`BaseApplication`](#baseapplication)
+configuration options, it accepts the following bindings:
+
+* `paths` &mdash; A plain object with possibly-wildcarded paths as keys, and
+  the _names_ of other applications as values. A wildcard only covers the suffix
+  of a path; it cannot be used for prefixes or infixes.
+
+The routing works by starting with the most specific match to the path of an
+incoming request. If that app does not try to handle the request &mdash;
+note that it counts as a "try" to end up `throw`ing out of the handler &mdash;
+the next most specific match is asked, and so on, until there are no path
+matches left.
+
+```js
+import { HostRouter } from '@lactoserv/built-ins';
+
+const applications = [
+  {
+    name:  'myHosts',
+    class: HostRouter,
+    hosts: {
+      '*':             'myCatchAllApp',
+      '127.0.0.1':     'myLocalhostApp',
+      'localhost':     'myLocalhostApp',
+      '*.example.com': 'myExampleApp'
+    }
+  },
+  {
+    name: 'myCatchallApp',
+    // ... more ...
+  },
+  {
+    name: 'myExampleApp',
+    // ... more ...
+  },
+  {
+    name: 'myLocalhostApp',
+    // ... more ...
+  }
+];
+```
+
 ### `Redirector`
 
 An application which responds to all requests with an HTTP "redirect" response.

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -3,9 +3,9 @@
 
 import * as fs from 'node:fs/promises';
 
-import { MemoryMonitor, ProcessIdFile, ProcessInfoFile, RateLimiter,
-  Redirector, RequestLogger, SimpleResponse, StaticFiles, SystemLogger }
-  from '@lactoserv/built-ins';
+import { MemoryMonitor, PathRouter, ProcessIdFile, ProcessInfoFile,
+  RateLimiter, Redirector, RequestLogger, SimpleResponse, StaticFiles,
+  SystemLogger } from '@lactoserv/built-ins';
 
 
 const fileUrl  = (path) => new URL(path, import.meta.url);
@@ -121,6 +121,8 @@ const services = [
 
 // Application definitions.
 const applications = [
+  // Main apps.
+
   {
     name:         'myWackyRedirector',
     class:        Redirector,
@@ -128,6 +130,22 @@ const applications = [
     target:       'https://localhost:8443/resp/',
     cacheControl: { public: true, maxAge: '5 min' }
   },
+  {
+    name:  'mySite',
+    class: PathRouter,
+    paths: {
+      '/':                 'myStaticFun',
+      '/bonk/':            'myStaticFun',
+      '/florp/':           'myStaticFunNo404',
+      '/resp/empty-body/': 'responseEmptyBody',
+      '/resp/no-body/':    'responseNoBody',
+      '/resp/one/':        'responseOne',
+      '/resp/two/':        'responseTwo'
+    }
+  },
+
+  // Component apps used by the above.
+
   {
     name:          'myStaticFun',
     class:         StaticFiles,
@@ -209,28 +227,8 @@ const endpoints = [
     },
     mounts: [
       {
-        application: 'myStaticFun',
-        at:          ['//*/', '//*/bonk/']
-      },
-      {
-        application: 'myStaticFunNo404',
-        at:          ['//*/florp/']
-      },
-      {
-        application: 'responseEmptyBody',
-        at:          ['//*/resp/empty-body/']
-      },
-      {
-        application: 'responseNoBody',
-        at:          ['//*/resp/no-body/']
-      },
-      {
-        application: 'responseOne',
-        at:          ['//*/resp/one/']
-      },
-      {
-        application: 'responseTwo',
-        at:          ['//*/resp/two/']
+        application: 'mySite',
+        at:          ['//*/']
       }
     ]
   },

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -130,8 +130,17 @@ const applications = [
     target:       'https://localhost:8443/resp/',
     cacheControl: { public: true, maxAge: '5 min' }
   },
+
   {
     name:  'mySite',
+    class: HostRouter,
+    hosts: {
+      '*':         'myPaths',
+      '127.0.0.1': 'myStaticFun'
+    }
+  },
+  {
+    name:  'myPaths',
     class: PathRouter,
     paths: {
       '/*':                 'myStaticFun',

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -134,14 +134,14 @@ const applications = [
     name:  'mySite',
     class: PathRouter,
     paths: {
-      '/*':               'myStaticFun',
-      '/bonk/*':          'myStaticFun',
-      '/florp/*':         'myStaticFunNo404',
-      '/resp/empty-body': 'responseEmptyBody',
-      '/resp/no-body/*':  'responseNoBody',
-      '/resp/dir-only/':  'responseDirOnly',
-      '/resp/one':        'responseOne',
-      '/resp/two':        'responseTwo'
+      '/*':                 'myStaticFun',
+      '/bonk/*':            'myStaticFun',
+      '/florp/*':           'myStaticFunNo404',
+      '/resp/empty-body/*': 'responseEmptyBody',
+      '/resp/no-body/*':    'responseNoBody',
+      '/resp/dir-only/':    'responseDirOnly',
+      '/resp/one':          'responseOne',
+      '/resp/two':          'responseTwo'
     }
   },
 
@@ -162,16 +162,19 @@ const applications = [
     cacheControl:  { public: true, maxAge: '5 min' }
   },
   {
-    name:         'responseEmptyBody',
-    class:        SimpleResponse,
-    filePath:     filePath('../site-extra/empty-file.txt'),
-    cacheControl: 'public, immutable, max-age=600'
+    name:                'responseEmptyBody',
+    class:               SimpleResponse,
+    filePath:            filePath('../site-extra/empty-file.txt'),
+    cacheControl:        'public, immutable, max-age=600',
+    maxPathLength:       2,
+    redirectDirectories: true
   },
   {
-    name:         'responseNoBody',
-    class:        SimpleResponse,
-    cacheControl: { public: true, immutable: true, maxAge: '11 min' },
-    etag:         true
+    name:          'responseNoBody',
+    class:         SimpleResponse,
+    cacheControl:  { public: true, immutable: true, maxAge: '11 min' },
+    etag:          true,
+    maxPathLength: 2,
   },
   {
     name:         'responseDirOnly',
@@ -191,9 +194,7 @@ const applications = [
       hashAlgorithm: 'sha1',
       hashLength:    12,
       tagForm:       'weak'
-    },
-    maxPathLength:       0,
-    redirectDirectories: true
+    }
   },
   {
     name:                'responseTwo',
@@ -201,9 +202,7 @@ const applications = [
     contentType:         'text/html',
     body:                '<html><body><h1>Two!</h1></body></html>\n',
     cacheControl:        { public: true, immutable: true, maxAge: '13 min'  },
-    etag:                true,
-    maxPathLength:       0,
-    redirectDirectories: true
+    etag:                true
   }
 ];
 

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -139,6 +139,7 @@ const applications = [
       '/florp/*':         'myStaticFunNo404',
       '/resp/empty-body': 'responseEmptyBody',
       '/resp/no-body/*':  'responseNoBody',
+      '/resp/dir-only/':  'responseDirOnly',
       '/resp/one':        'responseOne',
       '/resp/two':        'responseTwo'
     }
@@ -170,6 +171,14 @@ const applications = [
     name:         'responseNoBody',
     class:        SimpleResponse,
     cacheControl: { public: true, immutable: true, maxAge: '11 min' },
+    etag:         true
+  },
+  {
+    name:         'responseDirOnly',
+    class:        SimpleResponse,
+    contentType:  'text/plain',
+    body:         'I am a directory!\n',
+    cacheControl: { public: true, immutable: true, maxAge: '12 min'  },
     etag:         true
   },
   {
@@ -228,7 +237,7 @@ const endpoints = [
     mounts: [
       {
         application: 'mySite',
-        at:          ['//*/']
+        at:          '//*/'
       }
     ]
   },

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -3,7 +3,7 @@
 
 import * as fs from 'node:fs/promises';
 
-import { MemoryMonitor, PathRouter, ProcessIdFile, ProcessInfoFile,
+import { HostRouter, MemoryMonitor, PathRouter, ProcessIdFile, ProcessInfoFile,
   RateLimiter, Redirector, RequestLogger, SimpleResponse, StaticFiles,
   SystemLogger } from '@lactoserv/built-ins';
 
@@ -259,7 +259,7 @@ const endpoints = [
     },
     mounts: [
       {
-        application: 'myStaticFun',
+        application: 'mySite',
         at:          '//*/'
       }
     ]

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -134,13 +134,13 @@ const applications = [
     name:  'mySite',
     class: PathRouter,
     paths: {
-      '/':                 'myStaticFun',
-      '/bonk/':            'myStaticFun',
-      '/florp/':           'myStaticFunNo404',
-      '/resp/empty-body/': 'responseEmptyBody',
-      '/resp/no-body/':    'responseNoBody',
-      '/resp/one/':        'responseOne',
-      '/resp/two/':        'responseTwo'
+      '/*':               'myStaticFun',
+      '/bonk/*':          'myStaticFun',
+      '/florp/*':         'myStaticFunNo404',
+      '/resp/empty-body': 'responseEmptyBody',
+      '/resp/no-body/*':  'responseNoBody',
+      '/resp/one':        'responseOne',
+      '/resp/two':        'responseTwo'
     }
   },
 

--- a/src/built-ins/export/HostRouter.js
+++ b/src/built-ins/export/HostRouter.js
@@ -1,0 +1,121 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { TreePathMap } from '@this/collections';
+import { Uris } from '@this/net-util';
+import { Names } from '@this/sys-config';
+import { BaseApplication } from '@this/sys-framework';
+import { MustBe } from '@this/typey';
+
+
+/**
+ * Application that routes requests based on the requests' `host` headers (or
+ * equivalent). See docs for configuration object details.
+ */
+export class HostRouter extends BaseApplication {
+  /**
+   * @type {?TreePathMap<BaseApplication>} Map which goes from a host prefix to
+   * an app which should handle that prefix. Gets set in {@link #_impl_start}.
+   */
+  #routeTree = null;
+
+  // Note: The default constructor is fine for this class.
+
+  /** @override */
+  async _impl_handleRequest(request, dispatch) {
+    const host  = request.host;
+    const found = this.#routeTree.find(host.nameKey);
+
+    if (!found) {
+      return null;
+    }
+
+    const application = found.value;
+
+    request.logger?.dispatchingHost({
+      application: application.name,
+      host:        host.namePortString
+    });
+
+    return application.handleRequest(request, dispatch);
+  }
+
+  /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
+  async _impl_start(isReload_unused) {
+    // Note: We can't do this setup in `_impl_init()` because it might not be
+    // the case that all of the referenced apps have already been added when
+    // that runs.
+
+    const context   = this.context;
+    const routeTree = new TreePathMap();
+
+    for (const [host, name] of this.config.routeTree) {
+      const app = context.getComponent(name, BaseApplication);
+      routeTree.add(host, app);
+    }
+
+    this.#routeTree = routeTree;
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // Nothing to do here.
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @override */
+  static get CONFIG_CLASS() {
+    return this.#Config;
+  }
+
+  /**
+   * Configuration item subclass for this (outer) class.
+   */
+  static #Config = class Config extends BaseApplication.FilterConfig {
+    /**
+     * @type {TreePathMap<string>} Like the outer `routeTree` except with names
+     * instead of application instances.
+     */
+    #routeTree;
+
+    /**
+     * Constructs an instance.
+     *
+     * @param {object} config Configuration object.
+     */
+    constructor(config) {
+      super(config);
+
+      const { hosts } = config;
+
+      MustBe.plainObject(hosts);
+
+      const routeTree = new TreePathMap();
+
+      for (const [host, name] of Object.entries(hosts)) {
+        Names.checkName(name);
+        const key = Uris.parseHostname(host, true);
+        routeTree.add(key, name);
+      }
+
+      this.#routeTree = routeTree;
+    }
+
+    /**
+     * @returns {TreePathMap<string>} Like the outer `routeTree` except with
+     * names instead of application instances.
+     */
+    get routeTree() {
+      return this.#routeTree;
+    }
+  };
+}

--- a/src/built-ins/export/PathRouter.js
+++ b/src/built-ins/export/PathRouter.js
@@ -39,7 +39,7 @@ export class PathRouter extends BaseApplication {
         extra:       subDispatch.extraString
       });
 
-      const result = await application.handleRequest(request, dispatch);
+      const result = await application.handleRequest(request, subDispatch);
       if (result !== null) {
         return result;
       }

--- a/src/built-ins/export/PathRouter.js
+++ b/src/built-ins/export/PathRouter.js
@@ -1,0 +1,195 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { TreePathKey, TreePathMap } from '@this/collections';
+import { DispatchInfo, HttpUtil } from '@this/net-util';
+import { Names } from '@this/sys-config';
+import { BaseApplication } from '@this/sys-framework';
+import { MustBe } from '@this/typey';
+
+
+/**
+ * Application that routes requests based on incoming path prefixes, to one or
+ * more of a set of configured sub-apps. See docs for configuration object
+ * details.
+ */
+export class PathRouter extends BaseApplication {
+  /**
+   * @type {?TreePathMap<BaseApplication>} Map which goes from a path prefix to
+   * an app which should handle that prefix. Gets set in {@link #_impl_start}.
+   */
+  #routeTree = null;
+
+  // Note: The default constructor is fine for this class.
+
+  /** @override */
+  async _impl_handleRequest(request, dispatch) {
+    // Iterate from most- to least-specific mounted path.
+    for (let pathMatch = this.#routeTree.find(dispatch.extra, true);
+      pathMatch;
+      pathMatch = pathMatch.next) {
+      const application = pathMatch.value;
+      const subDispatch = new DispatchInfo(
+        dispatch.base.concat(pathMatch.key),
+        pathMatch.keyRemainder);
+
+      request.logger?.dispatchingPath({
+        application: application.name,
+        base:        subDispatch.baseString,
+        extra:       subDispatch.extraString
+      });
+
+      const result = await application.handleRequest(request, dispatch);
+      if (result !== null) {
+        return result;
+      }
+      // `result === null`, so we iterate to try the next handler (if any).
+    }
+
+    return null;
+  }
+
+  /** @override */
+  async _impl_init(isReload_unused) {
+    // Nothing needed here for this class.
+  }
+
+  /** @override */
+  async _impl_start(isReload_unused) {
+    // Note: We can't do this setup in `_impl_init()` because it might not be
+    // the case that all of the referenced apps have already been added when
+    // that runs.
+
+    const context   = this.context;
+    const routeTree = new TreePathMap();
+
+    for (const [path, name] of this.config.routeTree) {
+      const app = context.getComponent(name, BaseApplication);
+      routeTree.add(path, app);
+    }
+
+    this.#routeTree = routeTree;
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // Nothing to do here.
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @override */
+  static get CONFIG_CLASS() {
+    return this.#Config;
+  }
+
+  /**
+   * Configuration item subclass for this (outer) class.
+   */
+  static #Config = class Config extends BaseApplication.FilterConfig {
+    /**
+     * @type {TreePathMap<string>} Like the outer `routeTree` except with names
+     * instead of application instances.
+     */
+    #routeTree;
+
+    /**
+     * Constructs an instance.
+     *
+     * @param {object} config Configuration object.
+     */
+    constructor(config) {
+      super(config);
+
+      const { paths } = config;
+
+      MustBe.plainObject(paths);
+
+      const routeTree = new TreePathMap();
+
+      for (const [path, name] of Object.entries(paths)) {
+        Names.checkName(name);
+        const key = Config.#parsePath(path);
+        routeTree.add(key, name);
+      }
+
+      this.#routeTree = routeTree;
+    }
+
+    /**
+     * @returns {TreePathMap<string>} Like the outer `routeTree` except with
+     * names instead of application instances.
+     */
+    get routeTree() {
+      return this.#routeTree;
+    }
+
+    /**
+     * Parses a path.
+     *
+     * @param {string} path The path to parse.
+     * @returns {TreePathKey} The parsed form.
+     */
+    static #parsePath(path) {
+      const parts = path.split('/');
+
+      if (parts[0] !== '') {
+        throw new Error(`Path must start with a slash: ${path}`);
+      } else if (parts.length === 1) {
+        throw new Error('Empty path.');
+      }
+
+      parts.shift(); // Shift away the necessarily-empty first part.
+
+      let lastSpecial = null;
+
+      switch (parts[parts.length - 1]) {
+        case '': {
+          lastSpecial = 'directory';
+          parts.pop();
+          break;
+        }
+        case '*': {
+          lastSpecial = 'wildcard';
+          parts.pop();
+          break;
+        }
+      }
+
+      for (const p of parts) {
+        switch (p) {
+          case '': {
+            throw new Error(`Empty path component in: ${path}`);
+          }
+          case '.':
+          case '..': {
+            throw new Error(`Invalid path component \`${p}\` in: ${path}`);
+          }
+          case '*': {
+            throw new Error(`Non-final \`*\` in path: ${path}`);
+          }
+          default: {
+            if (!/^[-_.a-zA-Z0-9]+$/.test(p)) {
+              throw new Error(`Invalid path component \`${p}\` in: ${path}`);
+            }
+          }
+        }
+      }
+
+      switch (lastSpecial) {
+        case 'directory': {
+          return new TreePathKey([...parts, ''], false);
+        }
+        case 'wildcard': {
+          return new TreePathKey([...parts], true);
+        }
+        default: {
+          return new TreePathKey(parts, false);
+        }
+      }
+    }
+  };
+}

--- a/src/built-ins/export/PathRouter.js
+++ b/src/built-ins/export/PathRouter.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TreePathKey, TreePathMap } from '@this/collections';
-import { DispatchInfo, HttpUtil } from '@this/net-util';
+import { DispatchInfo } from '@this/net-util';
 import { Names } from '@this/sys-config';
 import { BaseApplication } from '@this/sys-framework';
 import { MustBe } from '@this/typey';

--- a/src/built-ins/index.js
+++ b/src/built-ins/index.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+export * from '#x/HostRouter';
 export * from '#x/MemoryMonitor';
 export * from '#x/PathRouter';
 export * from '#x/ProcessIdFile';

--- a/src/built-ins/index.js
+++ b/src/built-ins/index.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '#x/MemoryMonitor';
+export * from '#x/PathRouter';
 export * from '#x/ProcessIdFile';
 export * from '#x/ProcessInfoFile';
 export * from '#x/RateLimiter';

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -28,9 +28,7 @@ export class DispatchInfo {
    *
    * @param {TreePathKey} base The base path (that is, the path prefix) to which
    *   the request is being dispatched. This is expected to already have `.` and
-   *   `..` components resolved away. This must not end with an empty component,
-   *   though it _can_ be entirely empty (which corresponds to a dispatched
-   *   mount point at the root of a host).
+   *   `..` components resolved away.
    * @param {TreePathKey} extra The remaining suffix portion of the original
    *   path, after removing `base`. This is expected to already have `.` and
    *   `..` components resolved away.
@@ -38,12 +36,6 @@ export class DispatchInfo {
   constructor(base, extra) {
     this.#base  = MustBe.instanceOf(base, TreePathKey);
     this.#extra = MustBe.instanceOf(extra, TreePathKey);
-
-    const baseLen = base.length;
-
-    if ((baseLen !== 0) && (base.path[baseLen - 1] === '')) {
-      throw new Error('`base` must not end with an empty component.');
-    }
   }
 
   /**

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -36,6 +36,8 @@ export class BaseApplication extends BaseComponent {
   async handleRequest(request, dispatch) {
     const filterConfig = this.#filterConfig;
 
+    this.logger?.handling(request.id, dispatch.extraString);
+
     if (filterConfig) {
       const {
         acceptQueries, acceptMethods,
@@ -142,8 +144,6 @@ export class BaseApplication extends BaseComponent {
     const startTime  = loggingEnv.now();
     const logger     = this.logger;
     const id         = request.id;
-
-    logger?.handling(id, dispatch.extraString);
 
     const done = (fate, ...error) => {
       const endTime  = loggingEnv.now();

--- a/src/sys-framework/export/BaseControllable.js
+++ b/src/sys-framework/export/BaseControllable.js
@@ -31,12 +31,12 @@ export class BaseControllable {
    *   instance is to be the root of its control hierarchy, or `null` for any
    *   other instance.
    */
-  constructor(context = null) {
-    if (context !== null) {
+  constructor(rootContext = null) {
+    if (rootContext !== null) {
       // Note: We wrap `#context` here, so that it is recognized as
       // "uninitialized" by the time `start()` gets called.
-      this.#context = { nascentRoot: MustBe.instanceOf(context, RootControlContext) };
-      context[ThisModule.SYM_linkRoot](this);
+      this.#context = { nascentRoot: MustBe.instanceOf(rootContext, RootControlContext) };
+      rootContext[ThisModule.SYM_linkRoot](this);
     }
   }
 

--- a/src/sys-framework/export/ControlContext.js
+++ b/src/sys-framework/export/ControlContext.js
@@ -4,9 +4,17 @@
 import { IntfLogger } from '@this/loggy-intf';
 import { MustBe } from '@this/typey';
 
+import { BaseComponent } from '#x/BaseComponent';
 import { BaseControllable } from '#x/BaseControllable';
 import { ThisModule } from '#p/ThisModule';
 
+/**
+ * Forward declaration of this subclass, because `import`ing it would cause a
+ * circular dependency while loading.
+ *
+ * @typedef RootControlContext
+ * @type {ControlContext}
+ */
 
 /**
  * "Context" in which a {@link BaseControllable} is situated. Instances of this
@@ -32,7 +40,7 @@ export class ControlContext {
   #parent;
 
   /**
-   * @type {ControlContext} Instance which represents the root of the
+   * @type {RootControlContext} Instance which represents the root of the
    * containership hierarchy.
    */
   #root;
@@ -92,6 +100,20 @@ export class ControlContext {
     }
 
     return this.#root;
+  }
+
+  /**
+   * Gets a named component that has the same root as this instance, which must
+   * also optionally be of a specific class (including a base class).
+   *
+   * @param {string} name Name of the component.
+   * @param {?function(new:BaseComponent)} [cls] Class which the result must be
+   *   an instance of, or `null` to not have a class restriction.
+   * @returns {BaseComponent} Found instance.
+   * @throws {Error} Thrown if a suitable instance was not found.
+   */
+  getComponent(name, cls) {
+    return this.#root.getComponent(name, cls);
   }
 
   /**

--- a/src/sys-framework/export/RootControlContext.js
+++ b/src/sys-framework/export/RootControlContext.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { IntfLogger } from '@this/loggy-intf';
+import { MustBe } from '@this/typey';
 
 import { BaseComponent } from '#x/BaseComponent';
 import { ControlContext } from '#x/ControlContext';
@@ -30,6 +31,22 @@ export class RootControlContext extends ControlContext {
    */
   constructor(logger) {
     super('root', null, logger);
+  }
+
+  /** @override */
+  getComponent(name, cls) {
+    MustBe.string(name);
+    cls = (cls === null) ? BaseComponent : MustBe.constructorFunction(cls);
+
+    const found = this.#components.get(name)?.associate;
+
+    if (!found) {
+      throw new Error(`No such component: ${name}`);
+    } else if (!(found instanceof cls)) {
+      throw new Error(`Component not of class ${cls.name}: ${name}`);
+    }
+
+    return found;
   }
 
   /**


### PR DESCRIPTION
This PR adds two new applications which both route to other applications. `HostRouter` routes based on the `host` header (or equivalent) of requests, and `PathRouter` routes based on the requests' paths. These are meant to replace the routing implementation that is built into `EndpointManager`, though that latter routing code remains in the system as of this PR. (Its removal will come soon.)