### PR TITLE
`SerialRouter` and a couple other related bits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Other notable changes:
   * New class `HostRouter` which does what you probably expect from the name.
   * Likewise, new class `PathRouter`. This and its buddy are the replacements
     for the routing implementation that used to be baked into `EndpointManager`.
+  * Added `statusCode` configuration to `SimpleResponse`. Notably, it can now be
+    used to define simple `404` responses.
 
 ### v0.6.10 -- 2024-03-15
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ framework.
   modules.)
   * Uses Node's standard library for low-level networking and protocol
     implementation (TCP, TLS, HTTP*).
-  * Only modest use of external module dependencies (via `npm`).
-  * Notably, does _not_ depend on any other webapp framework (Express, Fastify,
-    etc.).
+  * Only sparingly uses external module dependencies (via `npm`).
+  * Notably, does _not_ depend on any other web application framework (Express,
+    Fastify, etc.).
 * Built to be installed as a normal POSIX-ish service (though _without_ Node
   bundled into the installation).
 * Developed using automated unit and integration tests. (As of this writing,

--- a/README.md
+++ b/README.md
@@ -27,30 +27,36 @@ framework.
 
 ### Features
 
-* Can run multiple network endpoints, each serving a different set of high-level
-  applications.
+* Networking:
+  * Can run multiple network endpoints, each serving a different application or
+    set thereof.
+  * Can serve all of HTTP, HTTPS, and HTTP2. (HTTP2 will automatically downgrade
+    to HTTPS for clients that can't do HTTP2.)
+  * Provides optional "token bucket" / "leaky bucket" rate limiting for
+    connections, requests, and/or sent data (bytes / bandwidth).
+  * Optionally produces request logs, in a standard-ish form.
 * Several built-in applications:
-  * A small handful of request routing applications, to cover basic routing
-    needs.
-  * Simple response server (approximately a single-file static server).
+  * Several request routing applications, to cover most routing needs:
+    * `HostRouter`, which dispatches to an application depending on the `host`
+      (or equivalent) header of requests.
+    * `PathRouter`, which dispatches based on matching the path prefix in a
+      hierarchical fashion, falling back to less-specific path matches until
+      finding one which responds.
+    * `SerialRouter`, which dispatches to a list of applications in order,
+      stopping at the first one which responds. (This is the "classic" style of
+      routing as implemented by most popular Node web application frameworks.)
+  * Simple response server (approximately a single-file static server), which
+    can be used for both normal and error responses.
   * Static file (directory tree) server.
   * Redirect server.
   * More to come!
-* Path-hierarchy specificity-based endpoint configuration, for endpoints that
-  serve multiple applications. This is as opposed to, notably, many (most?) of
-  the "competing" Node webapp frameworks, which just do linear dispatch.
-* Can serve all of HTTP, HTTPS, and HTTP2. (HTTP2 will automatically downgrade
-  to HTTPS for clients that can't do HTTP2.)
-* Provides optional "token bucket" / "leaky bucket" rate limiting for
-  connections, requests, and/or sent data (bytes / bandwidth).
-* Optionally produces request logs, in a standard-ish form.
+* The ability to define custom applications, using a reasonably modern
+  `async`-forward application framework. Instead of directly dealing with the
+  quirky core Node request and response objects, this framework exposes a more
+  friendly and approachable API. Maximum ergonomics: Very straightforward
+  application logic bottoms out at a well-tested low-level implementation.
 * Optionally produces detailed system activity logs.
 * JS-based configuration file format, which isn't actually that awful!
-* For custom (non-built-in) applications, reasonably modern `async`-forward
-  application framework, which uses wrappers around the underlying Node request
-  and response objects, providing a friendly and approachable API. Maximum
-  ergonomics: Very straightforward application logic bottoming out at a
-  well-tested low-level implementation.
 
 ### Implementation features
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -319,17 +319,17 @@ the next most specific match is asked, and so on, until there are no path
 matches left.
 
 ```js
-import { HostRouter } from '@lactoserv/built-ins';
+import { PathRouter } from '@lactoserv/built-ins';
 
 const applications = [
   {
-    name:  'myHosts',
-    class: HostRouter,
-    hosts: {
-      '*':             'myCatchAllApp',
-      '127.0.0.1':     'myLocalhostApp',
-      'localhost':     'myLocalhostApp',
-      '*.example.com': 'myExampleApp'
+    name:  'myPaths',
+    class: PathRouter,
+    paths: {
+      '/*':         'myCatchAllApp',
+      '/file':      'myFileApp',
+      '/dir/':      'myDirApp',
+      '/general/*': 'myGeneralApp',
     }
   },
   {
@@ -337,11 +337,15 @@ const applications = [
     // ... more ...
   },
   {
-    name: 'myExampleApp',
+    name: 'myFileApp',
     // ... more ...
   },
   {
-    name: 'myLocalhostApp',
+    name: 'myDirApp',
+    // ... more ...
+  },
+  {
+    name: 'myGeneralApp',
     // ... more ...
   }
 ];

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -418,7 +418,6 @@ const applications = [
 ];
 ```
 
-
 ### `SimpleResponse`
 
 An application which only ever sends one particular response. It's approximately

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -403,6 +403,10 @@ following configuration bindings:
   details.
 * `filePath` &mdash; Optional absolute filesystem path to the file to respond
   with.
+* `statusCode` &mdash; Optional fixed status code to report. If present and not
+  `null`, this is the numeric status code that will be used for all responses.
+  Setting this also prevents range requests and not-modified responses from
+  being generated.
 
 It is valid to specify neither `body` nor `filePath`; this indicates that the
 application should only ever produce no-content (status `204`) responses. It is
@@ -424,13 +428,14 @@ const applications = [
     body:                'Hello!\n',
     cacheControl:        { public: true, maxAge: '1_day' },
     maxPathLength:       0,
-    redirectDirectories: true
+    redirectDirectories: true,
   },
   {
     name:         'fromFile',
     class:        'SimpleResponse',
-    filePath:     '/etc/site/someFile.txt',
-    cacheControl: 'immutable; max-age=100'
+    filePath:     '/etc/site/notFoundMessage.txt',
+    cacheControl: 'immutable; max-age=1000',
+    statusCode:   404
   },
   {
     name:  'empty',
@@ -448,10 +453,12 @@ reasonable demand:
 * Caching:
   * The `Last-Modified` response header is always sent when given a `filePath`,
     and not sent when given a `body`.
-  * Conditional request headers are honored.
+  * Unless `statusCode` is set in the configuration, conditional request headers
+    are honored.
 * Ranges:
-  * The `Accept-Ranges` response header is always sent.
-  * Range request headers are honored, including conditional range requests.
+  * Unless `statusCode` is set in the configuration:
+    * The `Accept-Ranges` response header is always sent.
+    * Range request headers are honored, including conditional range requests.
 
 ### `StaticFiles`
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -153,8 +153,8 @@ naming and configuring one of them. Each element has the following bindings:
 * `name` &mdash; The name of the endpoint. This is just used for logging and
   related informational purposes.
 * `hostnames` &mdash; A list of one or more hostnames to recognize, each name
-  in the same form as accepted in the `hosts` section of the configuration. In
-  most cases, it will suffice to just specify this as `['*']`.
+  in the same form as accepted in the `hosts` section of the configuration.
+  Defaults to `['*']`, which should suffice in most cases.
 * `interface` &mdash; The network interface to listen on. This is a string which
   can take one of two forms:
   * `<address>:<port>` &mdash; Specifies a normal network-attached interface.

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -10,7 +10,18 @@ configuration. Very skeletally (and reductively):
 
 ```js
 const config = {
-  // ... configuration ...
+  services: [
+    // ... configuration ...
+  ],
+  hosts: [
+    // ... configuration ...
+  ],
+  endpoints: [
+    // ... configuration ...
+  ],
+  applications: [
+    // ... configuration ...
+  ]
 };
 
 export default config;

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -381,6 +381,44 @@ const applications = [
 ];
 ```
 
+### `SerialRouter`
+
+An application which routes requests to one of a list of applications, which are
+tried in order. (This is the default / built-in routing strategy of the most
+common Node web application frameworks.) In addition to the
+[`BaseApplication`](#baseapplication) configuration options, it accepts the
+following bindings:
+
+* `applications` &mdash; An array listing the _names_ of other applications as
+  values.
+
+The routing works by starting with the first element of `applications`, asking
+it to handle an incoming request. If that app does not try to handle the request
+&mdash; note that it counts as a "try" to end up `throw`ing out of the handler
+&mdash; the next application in the list is asked, and so on, until the final
+one has been tried.
+
+```js
+import { SerialRouter } from '@lactoserv/built-ins';
+
+const applications = [
+  {
+    name:         'mySeries',
+    class:        SerialRouter,
+    applications: ['firstApp', 'secondApp']
+  },
+  {
+    name: 'firstApp',
+    // ... more ...
+  },
+  {
+    name: 'secondApp',
+    // ... more ...
+  }
+];
+```
+
+
 ### `SimpleResponse`
 
 An application which only ever sends one particular response. It's approximately

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -205,12 +205,12 @@ hostname. (It will not fall back to less specific hostnames.)
 
 ## Built-in Applications
 
-### `BaseApplication`
+### Common Application Configuration
 
-`BaseApplication` can be subclassed to implement custom behavior. In addition,
-it optionally provides request filtering for application subclasses in general,
-including the built-in applications. It accepts the following configuration
-bindings:
+Most built-in applications implement a set of common configuration options,
+which are generally about filtering out or automatically responding to certain
+kinds of requests. Exceptions to the use of these configurations are noted in
+the documentation of applications, as appropriate. Here are the options:
 
 * `acceptMethods` &mdash; Array of strings indicating which request methods to
   accept. The array can include any of `connect`, `delete`, `get`, `head`,
@@ -239,7 +239,8 @@ With regards to the `redirect*` options:
 
 With regards to the other options, when a request is filtered out, the result is
 that the application simply _doesn't handle_ the request, meaning that the
-request will get re-dispatched to the next application in the chain (if any).
+request will get re-dispatched to the next application in its routing chain (if
+any).
 
 ```js
 import { BaseApplication } from '@lactoserv/sys-framework';
@@ -262,8 +263,8 @@ const applications = [
 
 An application which can route requests to another application, based on the
 `host` (or equivalent) header in the requests. In addition to the
-[`BaseApplication`](#baseapplication) configuration options, it accepts the
-following bindings:
+[common application configuration](#common-application-configuration) options,
+it accepts the following bindings:
 
 * `hosts` &mdash; A plain object with possibly-wildcarded hostnames as keys, and
   the _names_ of other applications as values. A wildcard only covers the prefix
@@ -305,8 +306,9 @@ const applications = [
 ### `PathRouter`
 
 An application which can route requests to another application, based on the
-path of the requests. In addition to the [`BaseApplication`](#baseapplication)
-configuration options, it accepts the following bindings:
+path of the requests. In addition to the
+[common application configuration](#common-application-configuration) options,
+it accepts the following bindings:
 
 * `paths` &mdash; A plain object with possibly-wildcarded paths as keys, and
   the _names_ of other applications as values. A wildcard only covers the suffix
@@ -354,10 +356,11 @@ const applications = [
 ### `Redirector`
 
 An application which responds to all requests with an HTTP "redirect" response.
-In addition to the [`BaseApplication`](#baseapplication) configuration options,
-it accepts the following bindings:
+In addition to the
+[common application configuration](#common-application-configuration)
+options, it accepts the following bindings:
 
-* `acceptMethods` &mdash; `BaseApplication` configuration, but in this case the
+* `acceptMethods` &mdash; Common configuration option, but in this case the
   default is `['delete', 'get', 'head', 'patch', 'post', 'put']`.
 * `statusCode` &mdash; Optional HTTP status code to respond with. If not
   specified, it defaults to `301` ("Moved Permanently").
@@ -386,8 +389,8 @@ const applications = [
 An application which routes requests to one of a list of applications, which are
 tried in order. (This is the default / built-in routing strategy of the most
 common Node web application frameworks.) In addition to the
-[`BaseApplication`](#baseapplication) configuration options, it accepts the
-following bindings:
+[common application configuration](#common-application-configuration) options,
+it accepts the following bindings:
 
 * `applications` &mdash; An array listing the _names_ of other applications as
   values.
@@ -422,10 +425,10 @@ const applications = [
 
 An application which only ever sends one particular response. It's approximately
 like `StaticFiles`, except just one file. In addition to the
-[`BaseApplication`](#baseapplication) configuration options, it accepts the
-following configuration bindings:
+[common application configuration](#common-application-configuration) options,
+it accepts the following configuration bindings:
 
-* `acceptMethods` &mdash; `BaseApplication` configuration, but in this case the
+* `acceptMethods` &mdash; Common configuration option, but in this case the
   default is `['get', 'head']`.
 * `body` &mdash; Optional body contents to respond with. If specified, this must
   be either a string or a Node `Buffer` object.
@@ -504,11 +507,12 @@ reasonable demand:
 ### `StaticFiles`
 
 An application which serves static files from a local directory. In addition to
-most of the [`BaseApplication`](#baseapplication) configuration options (all
-but the `redirect*` options, which could cause chaos in this case), it accepts
-the following configuration bindings:
+most of the
+[common application configuration](#common-application-configuration) options
+(all but the `redirect*` options, which could cause chaos in this case), it
+accepts the following configuration bindings:
 
-* `acceptMethods` &mdash; `BaseApplication` configuration, but in this case the
+* `acceptMethods` &mdash; Common configuration option, but in this case the
   default is `['get', 'head']`.
 * `etag` &mdash; ETag-generating options. If present and not `false`, the
   response comes with an `ETag` header. See "ETag Configuration" below for

--- a/doc/quick-start/code/config-framework.mjs
+++ b/doc/quick-start/code/config-framework.mjs
@@ -15,18 +15,18 @@ const config = {
   ],
   endpoints: [
     {
-      name:      'insecure',
-      protocol:  'http',
-      hostnames: ['*'],
-      interface: '*:8080',
-      mounts: [{ application: 'mySite', at: '//*/' }]
+      name:        'insecure',
+      protocol:    'http',
+      hostnames:   ['*'],
+      interface:   '*:8080',
+      application: 'mySite'
     },
     {
-      name:      'secure',
-      protocol:  'http2',
-      hostnames: ['*'],
-      interface: '*:8443',
-      mounts: [{ application: 'mySite', at: '//*/' }]
+      name:        'secure',
+      protocol:    'http2',
+      hostnames:   ['*'],
+      interface:   '*:8443',
+      application: 'mySite'
     }
   ]
 };

--- a/doc/quick-start/code/config-framework.mjs
+++ b/doc/quick-start/code/config-framework.mjs
@@ -17,14 +17,12 @@ const config = {
     {
       name:        'insecure',
       protocol:    'http',
-      hostnames:   ['*'],
       interface:   '*:8080',
       application: 'mySite'
     },
     {
       name:        'secure',
       protocol:    'http2',
-      hostnames:   ['*'],
       interface:   '*:8443',
       application: 'mySite'
     }

--- a/doc/quick-start/code/config-standalone.mjs
+++ b/doc/quick-start/code/config-standalone.mjs
@@ -15,18 +15,18 @@ const config = {
   ],
   endpoints: [
     {
-      name:      'insecure',
-      protocol:  'http',
-      hostnames: ['*'],
-      interface: '*:8080',
-      mounts: [{ application: 'mySite', at: '//*/' }]
+      name:        'insecure',
+      protocol:    'http',
+      hostnames:   ['*'],
+      interface:   '*:8080',
+      application: 'mySite'
     },
     {
-      name:      'secure',
-      protocol:  'http2',
-      hostnames: ['*'],
-      interface: '*:8443',
-      mounts: [{ application: 'mySite', at: '//*/' }]
+      name:        'secure',
+      protocol:    'http2',
+      hostnames:   ['*'],
+      interface:   '*:8443',
+      application: 'mySite'
     }
   ]
 };

--- a/doc/quick-start/code/config-standalone.mjs
+++ b/doc/quick-start/code/config-standalone.mjs
@@ -17,14 +17,12 @@ const config = {
     {
       name:        'insecure',
       protocol:    'http',
-      hostnames:   ['*'],
       interface:   '*:8080',
       application: 'mySite'
     },
     {
       name:        'secure',
       protocol:    'http2',
-      hostnames:   ['*'],
       interface:   '*:8443',
       application: 'mySite'
     }

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -237,7 +237,6 @@ const endpoints = [
   {
     name:      'insecure',
     protocol:  'http',
-    hostnames: ['*'],
     interface: '*:8080',
     services: {
       rateLimiter:   'limiter',

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -193,7 +193,7 @@ const applications = [
     etag:        false,
     body :       'Sorry! Not found!\n',
     contentType: 'text/plain',
-    statusCode:  404 // TODO: Implement `statusCode` on `SimpleResponse`.
+    statusCode:  404
   },
   {
     name:          'responseNoBody',

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -177,7 +177,8 @@ const applications = [
     name:          'myStaticFunNo404',
     class:         StaticFiles,
     siteDirectory: filePath('../site'),
-    cacheControl:  { public: true, maxAge: '5 min' }
+    cacheControl:  { public: true, maxAge: '5 min' },
+    etag:          { dataOnly: true, hashLength: 20 }
   },
   {
     name:                'responseEmptyBody',

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -4,8 +4,8 @@
 import * as fs from 'node:fs/promises';
 
 import { HostRouter, MemoryMonitor, PathRouter, ProcessIdFile, ProcessInfoFile,
-  RateLimiter, Redirector, RequestLogger, SimpleResponse, StaticFiles,
-  SystemLogger } from '@lactoserv/built-ins';
+  RateLimiter, Redirector, RequestLogger, SerialRouter, SimpleResponse,
+  StaticFiles, SystemLogger } from '@lactoserv/built-ins';
 
 
 const fileUrl  = (path) => new URL(path, import.meta.url);
@@ -136,7 +136,7 @@ const applications = [
     class: HostRouter,
     hosts: {
       '*':         'myPaths',
-      '127.0.0.1': 'myStaticFun'
+      '127.0.0.1': 'mySeries'
     }
   },
   {
@@ -152,6 +152,14 @@ const applications = [
       '/resp/one':          'responseOne',
       '/resp/two':          'responseTwo'
     }
+  },
+  {
+    name:  'mySeries',
+    class: SerialRouter,
+    applications: [
+      'myStaticFunNo404',
+      'responseNotFound'
+    ]
   },
 
   // Component apps used by the above.
@@ -178,6 +186,14 @@ const applications = [
     cacheControl:        'public, immutable, max-age=600',
     maxPathLength:       2,
     redirectDirectories: true
+  },
+  {
+    name:        'responseNotFound',
+    class:       SimpleResponse,
+    etag:        false,
+    body :       'Sorry! Not found!\n',
+    contentType: 'text/plain',
+    statusCode:  404 // TODO: Implement `statusCode` on `SimpleResponse`.
   },
   {
     name:          'responseNoBody',
@@ -248,7 +264,7 @@ const endpoints = [
     services: {
       requestLogger: 'requests'
     },
-    application: 'mySite'
+    application: 'mySeries'
   }
 ];
 

--- a/src/built-ins/export/SerialRouter.js
+++ b/src/built-ins/export/SerialRouter.js
@@ -1,0 +1,114 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { Names } from '@this/sys-config';
+import { BaseApplication } from '@this/sys-framework';
+import { MustBe } from '@this/typey';
+
+
+/**
+ * Application that routes requests to a list of applications in order, until
+ * one handles (or tries to handle) the request. See docs for configuration
+ * object details.
+ */
+export class SerialRouter extends BaseApplication {
+  /**
+   * @type {Array<BaseApplication>} List of applications to route to. Gets set
+   * in {@link #_impl_start}.
+   */
+  #routeList = null;
+
+  // Note: The default constructor is fine for this class.
+
+  /** @override */
+  async _impl_handleRequest(request, dispatch) {
+    for (const app of this.#routeList) {
+      request.logger?.dispatching(request.id, { application: app.name });
+
+      const result = await app.handleRequest(request, dispatch);
+      if (result !== null) {
+        return result;
+      }
+      // `result === null`, so we iterate to try the next handler (if any).
+    }
+
+    return null;
+  }
+
+  /** @override */
+  async _impl_init(isReload_unused) {
+    this.logger?.routes(this.config.routes);
+  }
+
+  /** @override */
+  async _impl_start(isReload_unused) {
+    // Note: We can't do this setup in `_impl_init()` because it might not be
+    // the case that all of the referenced apps have already been added when
+    // that runs.
+
+
+    const context   = this.context;
+    const routeList = [];
+
+    for (const name of this.config.routeList) {
+      const app = context.getComponent(name, BaseApplication);
+      routeList.push(app);
+    }
+
+    this.#routeList = routeList;
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // Nothing to do here.
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @override */
+  static get CONFIG_CLASS() {
+    return this.#Config;
+  }
+
+  /**
+   * Configuration item subclass for this (outer) class.
+   */
+  static #Config = class Config extends BaseApplication.FilterConfig {
+    /**
+     * @type {Array<string>} Like the outer `routeList` except with names
+     * instead of application instances.
+     */
+    #routeList;
+
+    /**
+     * Constructs an instance.
+     *
+     * @param {object} config Configuration object.
+     */
+    constructor(config) {
+      super(config);
+
+      const { applications } = config;
+
+      MustBe.arrayOfString(applications);
+
+      for (const name of applications) {
+        Names.checkName(name);
+      }
+
+      // `[...]` to copy the list in order to avoid outside interference.
+      this.#routeList = [...applications];
+    }
+
+    /**
+     * @returns {Array<string>} Like the outer `routeList` except with names
+     * instead of application instances.
+     */
+    get routeList() {
+      return this.#routeList;
+    }
+  };
+}

--- a/src/built-ins/index.js
+++ b/src/built-ins/index.js
@@ -10,6 +10,7 @@ export * from '#x/RateLimiter';
 export * from '#x/Redirector';
 export * from '#x/RequestLogger';
 export * from '#x/RequestSyslogger';
+export * from '#x/SerialRouter';
 export * from '#x/SimpleResponse';
 export * from '#x/StaticFiles';
 export * from '#x/SystemLogger';


### PR DESCRIPTION
The main point of this PR is to add a new routing class, to round out the routing options for the project, but as usual there were a few side quests. Details:

* New class `SerialRouter`, which implements basic linear-order routing, as commonly implemented by pretty much every Node web application framework. We are no longer an exception!
* Added `statusCode` as a configuration option to `SimpleResponse`, which notably makes it suitable for use as the last item in a `SerialRouter` in order to issue a `404` response (instead of getting the very plain-jane default one the framework would otherwise produce).
* Fixed up the example configurations, including doing some fixes which should have been done a few PRs ago.
* Fixed a few problems with the configuration guide.