### PR TITLE
`BaseApplication` filter work, and some work on testing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
-* None.
+* `collections`:
+  * Changed contract of `TreePathKey` methods `toUriPathString()` and
+    `uriPathStringFrom()`.
 
 Other notable changes:
 * `net-util`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ Breaking changes:
 * None.
 
 Other notable changes:
-* None.
+* `net-util`:
+  * Extracted interface `IntfIncomingRequest` from concrete implementation
+    `IncomingRequest`.
+* `sys-framework`:
+  * Renamed filter config `maxPathLength` to `maxPathDepth`, and made a new
+    `maxPathLength` which filters based on the octet count of a path.
 
 ### v0.6.11 -- 2024-03-22
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -226,10 +226,14 @@ the documentation of applications, as appropriate. Here are the options:
 * `acceptMethods` &mdash; Array of strings indicating which request methods to
   accept. The array can include any of `connect`, `delete`, `get`, `head`,
   `options`, `patch`, `post`, `put`, and/or `trace`. Defaults to the entire set.
-* `maxPathLength` &mdash; Number indicating the maximum (inclusive) allowed
+* `maxPathDepth` &mdash; Number indicating the maximum (inclusive) allowed
   length _in path components_ of a dispatched request path not including the
   mount point, and not including the empty path component at the end of a
   directory path. `null` indicates "no limit." Defaults to `null`.
+* `maxPathLength` &mdash; Number indicating the maximum (inclusive) allowed
+  length of the dispatched request path _in octets_. `null` indicates "no
+  limit." `0` indicates that no additional path is ever accepted (including even
+  a directory slash). Defaults to `null`.
 * `maxQueryLength` &mdash; Number indicating the maximum (inclusive) allowed
   length of the query (a/k/a "search") portion of a request URI _in octets_,
   including the leading question mark (`?`). `null` indicates "no limit." `0`
@@ -482,7 +486,7 @@ const applications = [
     contentType:         'text/plain',
     body:                'Hello!\n',
     cacheControl:        { public: true, maxAge: '1_day' },
-    maxPathLength:       0,
+    maxPathDepth:        0,
     redirectDirectories: true,
   },
   {

--- a/src/built-ins/export/HostRouter.js
+++ b/src/built-ins/export/HostRouter.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TreePathMap } from '@this/collections';
-import { Uris } from '@this/net-util';
+import { IntfRequestHandler, Uris } from '@this/net-util';
 import { Names } from '@this/sys-config';
 import { BaseApplication } from '@this/sys-framework';
 import { MustBe } from '@this/typey';
@@ -14,8 +14,9 @@ import { MustBe } from '@this/typey';
  */
 export class HostRouter extends BaseApplication {
   /**
-   * @type {?TreePathMap<BaseApplication>} Map which goes from a host prefix to
-   * an app which should handle that prefix. Gets set in {@link #_impl_start}.
+   * @type {?TreePathMap<IntfRequestHandler>} Map which goes from a host prefix
+   * to a handler (typically a {@link BaseApplication}) which should handle that
+   * prefix. Gets set in {@link #_impl_start}.
    */
   #routeTree = null;
 
@@ -88,7 +89,7 @@ export class HostRouter extends BaseApplication {
   static #Config = class Config extends BaseApplication.FilterConfig {
     /**
      * @type {TreePathMap<string>} Like the outer `routeTree` except with names
-     * instead of application instances.
+     * instead of handler instances.
      */
     #routeTree;
 
@@ -117,7 +118,7 @@ export class HostRouter extends BaseApplication {
 
     /**
      * @returns {TreePathMap<string>} Like the outer `routeTree` except with
-     * names instead of application instances.
+     * names instead of handler instances.
      */
     get routeTree() {
       return this.#routeTree;

--- a/src/built-ins/export/PathRouter.js
+++ b/src/built-ins/export/PathRouter.js
@@ -54,7 +54,7 @@ export class PathRouter extends BaseApplication {
   async _impl_init(isReload_unused) {
     const routes = {};
     for (const [path, name] of this.config.routeTree) {
-      routes[path.toUriPathString(true)] = name;
+      routes[path.toUriPathString()] = name;
     }
 
     this.logger?.routes(routes);

--- a/src/built-ins/export/PathRouter.js
+++ b/src/built-ins/export/PathRouter.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TreePathKey, TreePathMap } from '@this/collections';
-import { DispatchInfo } from '@this/net-util';
+import { DispatchInfo, IntfRequestHandler } from '@this/net-util';
 import { Names } from '@this/sys-config';
 import { BaseApplication } from '@this/sys-framework';
 import { MustBe } from '@this/typey';
@@ -15,8 +15,9 @@ import { MustBe } from '@this/typey';
  */
 export class PathRouter extends BaseApplication {
   /**
-   * @type {?TreePathMap<BaseApplication>} Map which goes from a path prefix to
-   * an app which should handle that prefix. Gets set in {@link #_impl_start}.
+   * @type {?TreePathMap<IntfRequestHandler>} Map which goes from a path prefix
+   * to a handler (typically a {@link BaseApplication}) which should handle that
+   * prefix. Gets set in {@link #_impl_start}.
    */
   #routeTree = null;
 
@@ -97,7 +98,7 @@ export class PathRouter extends BaseApplication {
   static #Config = class Config extends BaseApplication.FilterConfig {
     /**
      * @type {TreePathMap<string>} Like the outer `routeTree` except with names
-     * instead of application instances.
+     * instead of handler instances.
      */
     #routeTree;
 
@@ -126,7 +127,7 @@ export class PathRouter extends BaseApplication {
 
     /**
      * @returns {TreePathMap<string>} Like the outer `routeTree` except with
-     * names instead of application instances.
+     * names instead of handler instances.
      */
     get routeTree() {
       return this.#routeTree;

--- a/src/built-ins/export/SerialRouter.js
+++ b/src/built-ins/export/SerialRouter.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { IntfRequestHandler } from '@this/net-util';
 import { Names } from '@this/sys-config';
 import { BaseApplication } from '@this/sys-framework';
 import { MustBe } from '@this/typey';
@@ -13,8 +14,8 @@ import { MustBe } from '@this/typey';
  */
 export class SerialRouter extends BaseApplication {
   /**
-   * @type {Array<BaseApplication>} List of applications to route to. Gets set
-   * in {@link #_impl_start}.
+   * @type {Array<IntfRequestHandler>} List of handlers (typically instances of
+   * {@link BaseApplication}) to route to. Gets set in {@link #_impl_start}.
    */
   #routeList = null;
 

--- a/src/built-ins/tests/PathRouter.test.js
+++ b/src/built-ins/tests/PathRouter.test.js
@@ -93,7 +93,7 @@ class MockRequest {
     this.#pathString = pathString;
 
     // `slice(1)` to avoid having an empty component as the first element. And
-    // Freezing `parts` lets `new TreePathKey()` avoid making a copy.
+    // freezing `parts` lets `new TreePathKey()` avoid making a copy.
     const pathParts = Object.freeze(pathString.slice(1).split('/'));
     this.#pathKey = new TreePathKey(pathParts, false);
   }

--- a/src/built-ins/tests/PathRouter.test.js
+++ b/src/built-ins/tests/PathRouter.test.js
@@ -38,13 +38,32 @@ export class NopControllable extends BaseControllable {
  * @implements {IntfRequestHandler}
  */
 class MockApp extends BaseApplication {
+  static mockCalls = [];
+
   // The default constructor is fine for this class.
 
   /** @override */
   async _impl_handleRequest(request, dispatch) {
-    const result = new OutgoingResponse();
-    result.mockInfo = { handler: this, request, dispatch };
-    return result;
+    let succeed = true;
+
+    const callInfo = { application: this, request, dispatch };
+    MockApp.mockCalls.push(callInfo);
+
+    if (this.mockHandler) {
+      const handlerResult = this.mockHandler(callInfo);
+      if (typeof handlerResult !== 'boolean') {
+        return handlerResult;
+      }
+      succeed = handlerResult;
+    }
+
+    if (succeed) {
+      const result = new OutgoingResponse();
+      result.mockInfo = callInfo;
+      return result;
+    } else {
+      return null;
+    }
   }
 
   /** @override */
@@ -96,7 +115,7 @@ class MockRequest {
 
   /** @override */
   get id() {
-    return 'mock-id';
+    throw new Error('Not expected to be called.');
   }
 
   /** @override */
@@ -156,9 +175,20 @@ class MockRequest {
 }
 
 describe('_impl_handleRequest()', () => {
-  async function makeInstance(paths) {
-    const app = new MockApp(
-      new MockApp.CONFIG_CLASS({ name: 'mockApp', class: MockApp }));
+  async function makeInstance(paths, { appCount = 1, handlerFunc = null } = {}) {
+    const root = new NopControllable(new RootControlContext(null));
+    await root.start();
+
+    for (let i = 1; i <= appCount; i++) {
+      const app = new MockApp(
+        new MockApp.CONFIG_CLASS({ name: `mockApp${i}`, class: MockApp }));
+      if (handlerFunc) {
+        app.mockHandler = handlerFunc;
+      }
+      await app.init(new ControlContext(app, root, null));
+      await app.start();
+    }
+
     const pr = new PathRouter(
       new PathRouter.CONFIG_CLASS({
         name: 'myRouter',
@@ -166,38 +196,208 @@ describe('_impl_handleRequest()', () => {
         paths
       }));
 
-    const root = new NopControllable(new RootControlContext(null));
-    await root.start();
-    await app.init(new ControlContext(app, root, null));
     await pr.init(new ControlContext(pr, root, null));
-    await app.start();
     await pr.start();
 
     return pr;
   }
 
-  test('provides proper `extra` when routing to `/`', async () => {
-    const pr      = await makeInstance({ '/': 'mockApp' });
-    const req     = new MockRequest('/');
-    const result  = await pr.handleRequest(req, new DispatchInfo(TreePathKey.EMPTY, req.pathname));
+  describe('when dispatched to directly (as if directly from `NetworkEndpoint`)', () => {
+    let pr = null;
+
+    function extractCallInfo() {
+      return MockApp.mockCalls.map(({ application, request, dispatch }) => {
+        return {
+          appName:    application.name,
+          reqPathStr: request.pathnameString,
+          basePath:   dispatch.base.path,
+          extraPath:  dispatch.extra.path
+        };
+      });
+    }
+
+    describe('when the root has a wildcard match', () => {
+      beforeEach(async () => {
+        pr = await makeInstance(
+          {
+            '/*':     'mockApp1',
+            '/':      'mockApp2',
+            '/x/*':   'mockApp3',
+            '/x':     'mockApp4',
+            '/x/':    'mockApp5',
+            '/x/y':   'mockApp6',
+            '/x/y/z': 'mockApp7',
+            '/a':     'mockApp8',
+            '/z':     'mockApp9'
+          },
+          { appCount: 9, handlerFunc: () => false }
+        );
+
+        MockApp.mockCalls = [];
+      });
+
+      test.each`
+      label | requestPath | expectInfo
+      ----------
+      ${'top level'}
+      ${'/'}
+      ${[
+        { appName: 'mockApp2', basePath: [''], extraPath: []   },
+        { appName: 'mockApp1', basePath: [],   extraPath: [''] }
+      ]}
+      ----------
+      ${'exactly matched directory at root which also has a wildcard'}
+      ${'/x/'}
+      ${[
+        { appName: 'mockApp5', basePath: ['x', ''], extraPath: []        },
+        { appName: 'mockApp3', basePath: ['x'],     extraPath: ['']      },
+        { appName: 'mockApp1', basePath: [],        extraPath: ['x', ''] }
+      ]}
+      ----------
+      ${'exactly matched file at root which also has a wildcard'}
+      ${'/x'}
+      ${[
+        { appName: 'mockApp4', basePath: ['x'], extraPath: []    },
+        { appName: 'mockApp3', basePath: ['x'], extraPath: []    },
+        { appName: 'mockApp1', basePath: [],    extraPath: ['x'] }
+      ]}
+      ----------
+      ${'exactly matched file under subdirectory that does not have wildcard'}
+      ${'/x/y/z'}
+      ${[
+        { appName: 'mockApp7', basePath: ['x', 'y', 'z'], extraPath: []              },
+        { appName: 'mockApp3', basePath: ['x'],           extraPath: ['y', 'z']      },
+        { appName: 'mockApp1', basePath: [],              extraPath: ['x', 'y', 'z'] }
+      ]}
+      `('calls correct handler chain for $label', async ({ requestPath, expectInfo }) => {
+        const request = new MockRequest(requestPath);
+        const result  = await pr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
+
+        // Fill in the `reqPathStr` for the expectation.
+        for (const ei of expectInfo) {
+          ei.reqPathStr = request.pathnameString;
+        }
+
+        expect(result).toBeNull();
+        expect(extractCallInfo()).toEqual(expectInfo);
+      });
+    });
+
+    describe('when the root does not have a wildcard match', () => {
+      beforeEach(async () => {
+        pr = await makeInstance(
+          {
+            '/':      'mockApp1',
+            '/x/*':   'mockApp2',
+            '/x':     'mockApp3',
+            '/x/':    'mockApp4',
+            '/x/y':   'mockApp5',
+            '/x/y/z': 'mockApp6',
+            '/a':     'mockApp7',
+            '/z':     'mockApp8'
+          },
+          { appCount: 8, handlerFunc: () => false }
+        );
+
+        MockApp.mockCalls = [];
+      });
+
+      test.each`
+      label | requestPath | expectInfo
+      ----------
+      ${'top level'}
+      ${'/'}
+      ${[
+        { appName: 'mockApp1', basePath: [''], extraPath: [] }
+      ]}
+      ----------
+      ${'exactly matched directory at root which also has a wildcard'}
+      ${'/x/'}
+      ${[
+        { appName: 'mockApp4', basePath: ['x', ''], extraPath: []   },
+        { appName: 'mockApp2', basePath: ['x'],     extraPath: [''] }
+      ]}
+      ----------
+      ${'exactly matched file at root which also has a wildcard'}
+      ${'/x'}
+      ${[
+        { appName: 'mockApp3', basePath: ['x'], extraPath: [] },
+        { appName: 'mockApp2', basePath: ['x'], extraPath: [] }
+      ]}
+      ----------
+      ${'exactly matched file under subdirectory that does not have wildcard'}
+      ${'/x/y/z'}
+      ${[
+        { appName: 'mockApp6', basePath: ['x', 'y', 'z'], extraPath: []         },
+        { appName: 'mockApp2', basePath: ['x'],           extraPath: ['y', 'z'] }
+      ]}
+      `('calls correct handler chain for $label', async ({ requestPath, expectInfo }) => {
+        const request = new MockRequest(requestPath);
+        const result  = await pr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
+
+        // Fill in the `reqPathStr` for the expectation.
+        for (const ei of expectInfo) {
+          ei.reqPathStr = request.pathnameString;
+        }
+
+        expect(result).toBeNull();
+        expect(extractCallInfo()).toEqual(expectInfo);
+      });
+    });
+  });
+
+  test('stops trying fallbacks after it gets a result', async () => {
+    const pr = await makeInstance(
+      {
+        '/*':     'mockApp1',
+        '/x/*':   'mockApp2',
+        '/x/y/*': 'mockApp3',
+        '/x/y/z': 'mockApp4'
+      },
+      { appCount: 4, handlerFunc: ({ application }) => application.name === 'mockApp2' }
+    );
+
+    MockApp.mockCalls = [];
+
+    const request = new MockRequest('/x/y/z');
+    const result  = await pr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
 
     expect(result).not.toBeNull();
-    // TODO: More!
+    expect(result.mockInfo.application.name).toBe('mockApp2');
+
+    const callNames = MockApp.mockCalls.map(({ application }) => application.name);
+    expect(callNames).toEqual(['mockApp4', 'mockApp3', 'mockApp2']);
   });
 
-  test('provides proper `extra` when routing to `/*`', () => {
-    // TODO
+  test('matches on `dispatch.extra` (not `request.pathname`)', async () => {
+    const pr      = await makeInstance({ '/florp/floop/*': 'mockApp1' });
+    const request = new MockRequest('/x/y/z');
+    const result  = await pr.handleRequest(request,
+      new DispatchInfo(TreePathKey.EMPTY, new TreePathKey(['florp', 'floop', 'bop'], false)));
+
+    expect(result).not.toBeNull();
+
+    const callInfo = result.mockInfo;
+    expect(callInfo.application.name).toBe('mockApp1');
+    expect(callInfo.request).toBe(request);
+    expect(callInfo.dispatch.base.path).toEqual(['florp', 'floop']);
+    expect(callInfo.dispatch.extra.path).toEqual(['bop']);
   });
 
-  test('provides proper `extra` when routing to `/x`', () => {
-    // TODO
-  });
+  test('forms new `dispatch` by shifting items from `extra` to `base`', async () => {
+    const pr      = await makeInstance({ '/zonk/*': 'mockApp1' });
+    const request = new MockRequest('/x/y/z');
+    const result  = await pr.handleRequest(request,
+      new DispatchInfo(
+        new TreePathKey(['beep'], false),
+        new TreePathKey(['zonk', 'zorch', 'florp'], false)));
 
-  test('provides proper `extra` when routing to `/x/`', () => {
-    // TODO
-  });
+    expect(result).not.toBeNull();
 
-  test('provides proper `extra` when routing to `/x/*`', () => {
-    // TODO
+    const callInfo = result.mockInfo;
+    expect(callInfo.application.name).toBe('mockApp1');
+    expect(callInfo.request).toBe(request);
+    expect(callInfo.dispatch.base.path).toEqual(['beep', 'zonk']);
+    expect(callInfo.dispatch.extra.path).toEqual(['zorch', 'florp']);
   });
 });

--- a/src/built-ins/tests/PathRouter.test.js
+++ b/src/built-ins/tests/PathRouter.test.js
@@ -8,8 +8,8 @@ import { DispatchInfo, IntfIncomingRequest, IntfRequestHandler,
 import { BaseApplication, BaseControllable, ControlContext, RootControlContext }
   from '@this/sys-framework';
 
-// TODO: This contains a lot of mock implementation that should be extracted for
-// reuse.
+// TODO: This file contains a lot of mock implementation that should be
+// extracted for reuse.
 
 /**
  * Minimal concrete subclass of `BaseControllable`, which has no-op

--- a/src/built-ins/tests/PathRouter.test.js
+++ b/src/built-ins/tests/PathRouter.test.js
@@ -1,0 +1,203 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { TreePathKey } from '@this/collections';
+import { PathRouter } from '@this/built-ins';
+import { DispatchInfo, IntfIncomingRequest, IntfRequestHandler,
+  OutgoingResponse } from '@this/net-util';
+import { BaseApplication, BaseControllable, ControlContext, RootControlContext }
+  from '@this/sys-framework';
+
+// TODO: This contains a lot of mock implementation that should be extracted for
+// reuse.
+
+/**
+ * Minimal concrete subclass of `BaseControllable`, which has no-op
+ * implementations for all `_impl_*` methods.
+ */
+export class NopControllable extends BaseControllable {
+  // The default constructor is fine for this class.
+
+  /** @override */
+  async _impl_init(isReload_unused) {
+    // This space intentionally left blank.
+  }
+
+  /** @override */
+  async _impl_start(isReload_unused) {
+    // This space intentionally left blank.
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // This space intentionally left blank.
+  }
+}
+
+/**
+ * @implements {IntfRequestHandler}
+ */
+class MockApp extends BaseApplication {
+  // The default constructor is fine for this class.
+
+  /** @override */
+  async _impl_handleRequest(request, dispatch) {
+    const result = new OutgoingResponse();
+    result.mockInfo = { handler: this, request, dispatch };
+    return result;
+  }
+
+  /** @override */
+  async _impl_init(isReload_unused) {
+    // This space intentionally left blank.
+  }
+
+  /** @override */
+  async _impl_start(isReload_unused) {
+    // This space intentionally left blank.
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // This space intentionally left blank.
+  }
+}
+
+/**
+ * @implements {IntfIncomingRequest}
+ */
+class MockRequest {
+  #pathString;
+  #pathKey;
+
+  constructor(pathString) {
+    this.#pathString = pathString;
+
+    // `slice(1)` to avoid having an empty component as the first element. And
+    // Freezing `parts` lets `new TreePathKey()` avoid making a copy.
+    const pathParts = Object.freeze(pathString.slice(1).split('/'));
+    this.#pathKey = new TreePathKey(pathParts, false);
+  }
+
+  /** @override */
+  get cookies() {
+    throw new Error('Not expected to be called.');
+  }
+
+  /** @override */
+  get headers() {
+    throw new Error('Not expected to be called.');
+  }
+
+  /** @override */
+  get host() {
+    throw new Error('Not expected to be called.');
+  }
+
+  /** @override */
+  get id() {
+    return 'mock-id';
+  }
+
+  /** @override */
+  get logger() {
+    return null;
+  }
+
+  /** @override */
+  get method() {
+    throw new Error('Not expected to be called.');
+  }
+
+  /** @override */
+  get origin() {
+    throw new Error('Not expected to be called.');
+  }
+
+  /** @override */
+  get pathname() {
+    return this.#pathKey;
+  }
+
+  /** @override */
+  get pathnameString() {
+    return this.#pathString;
+  }
+
+  /** @override */
+  get protocolName() {
+    throw new Error('Not expected to be called.');
+  }
+
+  /** @override */
+  get searchString() {
+    throw new Error('Not expected to be called.');
+  }
+
+  /** @override */
+  get targetString() {
+    throw new Error('Not expected to be called.');
+  }
+
+  /** @override */
+  get urlForLogging() {
+    throw new Error('Not expected to be called.');
+  }
+
+  /** @override */
+  getHeaderOrNull(name_unused) {
+    throw new Error('Not expected to be called.');
+  }
+
+  /** @override */
+  getLoggableRequestInfo() {
+    throw new Error('Not expected to be called.');
+  }
+}
+
+describe('_impl_handleRequest()', () => {
+  async function makeInstance(paths) {
+    const app = new MockApp(
+      new MockApp.CONFIG_CLASS({ name: 'mockApp', class: MockApp }));
+    const pr = new PathRouter(
+      new PathRouter.CONFIG_CLASS({
+        name: 'myRouter',
+        class: PathRouter,
+        paths
+      }));
+
+    const root = new NopControllable(new RootControlContext(null));
+    await root.start();
+    await app.init(new ControlContext(app, root, null));
+    await pr.init(new ControlContext(pr, root, null));
+    await app.start();
+    await pr.start();
+
+    return pr;
+  }
+
+  test('provides proper `extra` when routing to `/`', async () => {
+    const pr      = await makeInstance({ '/': 'mockApp' });
+    const req     = new MockRequest('/');
+    const result  = await pr.handleRequest(req, new DispatchInfo(TreePathKey.EMPTY, req.pathname));
+
+    expect(result).not.toBeNull();
+    // TODO: More!
+  });
+
+  test('provides proper `extra` when routing to `/*`', () => {
+    // TODO
+  });
+
+  test('provides proper `extra` when routing to `/x`', () => {
+    // TODO
+  });
+
+  test('provides proper `extra` when routing to `/x/`', () => {
+    // TODO
+  });
+
+  test('provides proper `extra` when routing to `/x/*`', () => {
+    // TODO
+  });
+});

--- a/src/collections/export/TreePathKey.js
+++ b/src/collections/export/TreePathKey.js
@@ -21,6 +21,12 @@ export class TreePathKey {
   #wildcard;
 
   /**
+   * @type {?number} The result of {@link #charLength}, or `null` if not yet
+   * calculated.
+   */
+  #charLength = null;
+
+  /**
    * Constructs an instance from the given two components.
    *
    * **Note:** If not already frozen, the `path` is copied internally, in order
@@ -38,8 +44,26 @@ export class TreePathKey {
   }
 
   /**
-   * @returns {number} The length of the path, that is, a shorthand for
-   * `this.path.length`.
+   * @returns {number} The length of the path in total characters of all path
+   * components combined. This does not include any count for (would-be) path
+   * component separators or any wildcard indicators.
+   */
+  get charLength() {
+    if (this.#charLength === null) {
+      let result = 0;
+      for (const p of this.#path) {
+        result += p.length;
+      }
+
+      this.#charLength = result;
+    }
+
+    return this.#charLength;
+  }
+
+  /**
+   * @returns {number} The length of the path in components, that is, a
+   * shorthand for `this.path.length`.
    */
   get length() {
     return this.#path.length;

--- a/src/collections/export/TreePathKey.js
+++ b/src/collections/export/TreePathKey.js
@@ -216,24 +216,26 @@ export class TreePathKey {
    *   `false`.
    * @param {boolean} [options.reverse] Render in back-to-front order? Default
    *   `false`.
+   * @param {boolean} [options.separatePrefix] Use the separator between the
+   *   prefix and first component? Default `false`.
    * @param {string} [options.separator] Separator between path components.
    *   Default `'/'`.
    * @param {string} [options.suffix] Suffix for the result. Default empty
    *   (`''`).
-   * @param {string|boolean} [options.wildcard] Wildcard indicator. If
-   *   `false`, then a wildcard key is represented as if it were non-wildcard.
-   *   (This is different than if this is `''` (the empty string)). Default
-   *   `'*'`.
+   * @param {string|boolean} [options.wildcard] Wildcard indicator. If `false`,
+   *   then a wildcard key is represented as if it were non-wildcard. (This is
+   *   different than if this is `''` (the empty string)). Default `'*'`.
    * @returns {string} String form of the instance.
    */
   toString(options = null) {
     const defaultOptions = {
-      prefix:    '/',
-      quote:     false,
-      reverse:   false,
-      separator: '/',
-      suffix:    '',
-      wildcard:  '*'
+      prefix:         '/',
+      quote:          false,
+      reverse:        false,
+      separatePrefix: false,
+      separator:      '/',
+      suffix:         '',
+      wildcard:       '*'
     };
 
     options = options ? { ...defaultOptions, ...options } : defaultOptions;
@@ -252,7 +254,7 @@ export class TreePathKey {
 
     const result = [options.prefix];
     for (const p of path) {
-      if (result.length !== 1) {
+      if (options.separatePrefix || (result.length !== 1)) {
         result.push(options.separator);
       }
       result.push(p);

--- a/src/collections/export/TreePathKey.js
+++ b/src/collections/export/TreePathKey.js
@@ -189,21 +189,22 @@ export class TreePathKey {
   }
 
   /**
-   * Gets the string form of this instance, interpreted as an absolute URI path,
-   * that is, the part of a URI after the hostname. The result always includes
-   * an initial slash (`/`) and never includes a final slash (or more accurately
-   * a final slash indicates an empty path component at the end).
+   * Gets the string form of this instance as a URI path, that is, the part of a
+   * URI after the hostname. The result is in absolute form by default (prefixed
+   * with `/`), and is optionally in relative form (prefixed with `./`). Empty
+   * components are represented as one might expect, with no characters between
+   * two slashes for an empty component in the middle of a path or with a
+   * trailing slash for an empty component at the end of the path.
    *
-   * @param {boolean} [showWildcard] Represent a wildcard key as a final `/*`?
-   *   If `false`, then the result is as if `key` were created with `wildcard
-   *   === false`.
+   * @param {boolean} [relative] Make the result relative (with `./` as the
+   *   prefix).
    * @returns {string} The string form.
    */
-  toUriPathString(showWildcard = true) {
+  toUriPathString(relative = false) {
     return this.toString({
-      prefix:    '/',
-      separator: '/',
-      wildcard:  showWildcard ? '*' : null
+      prefix:         relative ? '.' : '/',
+      separatePrefix: relative,
+      separator:      '/'
     });
   }
 
@@ -308,10 +309,11 @@ export class TreePathKey {
    * convenient use as a stringifier function, e.g. in `TreePathMap`.
    *
    * @param {TreePathKey} key The key to convert.
-   * @param {boolean} [showWildcard] Represent a wildcard key as such?
+   * @param {boolean} [relative] Make the result relative (with `./` as the
+   *   prefix).
    * @returns {string} The string form.
    */
-  static uriPathStringFrom(key, showWildcard = true) {
-    return key.toUriPathString(showWildcard);
+  static uriPathStringFrom(key, relative = false) {
+    return key.toUriPathString(relative);
   }
 }

--- a/src/collections/export/TreePathKey.js
+++ b/src/collections/export/TreePathKey.js
@@ -211,15 +211,19 @@ export class TreePathKey {
    * Gets a human-useful string form of this instance.
    *
    * @param {?object} [options] Formatting options.
-   * @param {string} [options.prefix] Prefix for the result.
-   * @param {boolean} [options.quote] Quote components as strings?
-   * @param {boolean} [options.reverse] Render in back-to-front order?
-   * @param {string} [options.separator] Separator between path
-   *   components.
-   * @param {string} [options.suffix] Suffix for the result.
+   * @param {string} [options.prefix] Prefix for the result. Default `'/'`.
+   * @param {boolean} [options.quote] Quote components as strings? Defalt
+   *   `false`.
+   * @param {boolean} [options.reverse] Render in back-to-front order? Default
+   *   `false`.
+   * @param {string} [options.separator] Separator between path components.
+   *   Default `'/'`.
+   * @param {string} [options.suffix] Suffix for the result. Default empty
+   *   (`''`).
    * @param {string|boolean} [options.wildcard] Wildcard indicator. If
    *   `false`, then a wildcard key is represented as if it were non-wildcard.
-   *   (This is different than if this is `''` (the empty string)).
+   *   (This is different than if this is `''` (the empty string)). Default
+   *   `'*'`.
    * @returns {string} String form of the instance.
    */
   toString(options = null) {

--- a/src/collections/tests/TreePathKey.test.js
+++ b/src/collections/tests/TreePathKey.test.js
@@ -50,6 +50,46 @@ describe('constructor()', () => {
   });
 });
 
+describe('.charLength', () => {
+  test('returns `0` for an empty no-wildcard instance', () => {
+    const key = new TreePathKey([], false);
+    expect(key.charLength).toBe(0);
+  });
+
+  test('returns `0` for an empty wildcard instance', () => {
+    const key = new TreePathKey([], true);
+    expect(key.charLength).toBe(0);
+  });
+
+  test('returns the length of the sole component of a length-1 instance', () => {
+    const key1 = new TreePathKey(['x'], false);
+    expect(key1.charLength).toBe(1);
+
+    const key2 = new TreePathKey(['xyz-pdq'], true);
+    expect(key2.charLength).toBe(7);
+
+    const key3 = new TreePathKey([''], false);
+    expect(key3.charLength).toBe(0);
+  });
+
+  test('returns the total length of both components of a length-2 instance', () => {
+    const key1 = new TreePathKey(['x', 'ab'], false);
+    expect(key1.charLength).toBe(3);
+
+    const key2 = new TreePathKey(['abc', 'defgh'], true);
+    expect(key2.charLength).toBe(8);
+  });
+
+  // This is meant to verify that caching doesn't mess things up.
+  test('returns the same value from repeated calls', () => {
+    const key = new TreePathKey(['ab', 'cde', 'f', 'ghijklmn'], false);
+
+    expect(key.charLength).toBe(14);
+    expect(key.charLength).toBe(14);
+    expect(key.charLength).toBe(14);
+  })
+});
+
 describe('.length', () => {
   for (let len = 0; len < 4; len++) {
     for (let wild = 0; wild < 2; wild++) {

--- a/src/collections/tests/TreePathKey.test.js
+++ b/src/collections/tests/TreePathKey.test.js
@@ -405,6 +405,33 @@ describe('toString()', () => {
     });
   });
 
+  describe('with option `separatePrefix`', () => {
+    test.each`
+    separatePrefix | path           | wildcard | expected
+    ${false}       | ${[]}          | ${false} | ${'#'}
+    ${false}       | ${[]}          | ${true}  | ${'#*'}
+    ${true}        | ${[]}          | ${false} | ${'#'}
+    ${true}        | ${[]}          | ${true}  | ${'#:*'}
+    ${false}       | ${['a']}       | ${false} | ${'#a'}
+    ${false}       | ${['a']}       | ${true}  | ${'#a:*'}
+    ${true}        | ${['a']}       | ${false} | ${'#:a'}
+    ${true}        | ${['a']}       | ${true}  | ${'#:a:*'}
+    ${false}       | ${['']}        | ${false} | ${'#'}
+    ${false}       | ${['']}        | ${true}  | ${'#:*'}
+    ${true}        | ${['']}        | ${false} | ${'#:'}
+    ${true}        | ${['']}        | ${true}  | ${'#::*'}
+    ${false}       | ${['', 'abc']} | ${false} | ${'#:abc'}
+    ${false}       | ${['', 'abc']} | ${true}  | ${'#:abc:*'}
+    ${true}        | ${['', 'abc']} | ${false} | ${'#::abc'}
+    ${true}        | ${['', 'abc']} | ${true}  | ${'#::abc:*'}
+    `('on { path: $path, wildcard: $wildcard }, with $separatePrefix', ({ separatePrefix, path, wildcard, expected }) => {
+      // Note: We use `prefix` and `separator` options here to make sure we can
+      // distinguish what's going on.
+      const key = new TreePathKey(path, wildcard);
+      expect(key.toString({ separatePrefix, prefix: '#', separator: ':' })).toBe(expected);
+    });
+  });
+
   describe('with option `separator`', () => {
     test.each`
     separator | path                  | wildcard | expected

--- a/src/collections/tests/TreePathKey.test.js
+++ b/src/collections/tests/TreePathKey.test.js
@@ -87,7 +87,7 @@ describe('.charLength', () => {
     expect(key.charLength).toBe(14);
     expect(key.charLength).toBe(14);
     expect(key.charLength).toBe(14);
-  })
+  });
 });
 
 describe('.length', () => {

--- a/src/net-protocol/export/IntfRequestLogger.js
+++ b/src/net-protocol/export/IntfRequestLogger.js
@@ -5,7 +5,7 @@ import { IncomingMessage, ServerResponse } from 'node:http';
 import { Http2ServerRequest, Http2ServerResponse } from 'node:http2';
 
 import { Duration, Moment } from '@this/data-values';
-import { IncomingRequest, OutgoingResponse } from '@this/net-util';
+import { IntfIncomingRequest, OutgoingResponse } from '@this/net-util';
 import { Methods } from '@this/typey';
 
 
@@ -54,7 +54,7 @@ export class IntfRequestLogger {
    *   handled (or at least a reasonably close moment to that). This can be
    *   expected to be a value returned from a call to {@link #now} on this
    *   instance.
-   * @param {IncomingRequest} request The incoming request.
+   * @param {IntfIncomingRequest} request The incoming request.
    */
   async requestStarted(networkInfo, timingInfo, request) {
     Methods.abstract(networkInfo, timingInfo, request);
@@ -73,7 +73,7 @@ export class IntfRequestLogger {
    *   complete. This can be expected to be a value returned from a call to
    *   {@link #now} on this instance.
    * @param {Duration} timingInfo.duration The difference `end - start`.
-   * @param {IncomingRequest} request The incoming request.
+   * @param {IntfIncomingRequest} request The incoming request.
    * @param {OutgoingResponse} response The response that was sent (or at least
    *   attempted).
    */

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -5,16 +5,16 @@ import { TreePathKey } from '@this/collections';
 import { BaseConverter, Struct } from '@this/data-values';
 import { MustBe } from '@this/typey';
 
-import { IncomingRequest } from '#x/IncomingRequest';
+import { IntfIncomingRequest } from '#x/IntfIncomingRequest';
 
 
 /**
- * Dispatch information related to an {@link IncomingRequest}.
+ * Dispatch information related to an {@link IntfIncomingRequest}.
  *
- * The idea here is that {@link IncomingRequest} objects are treated in a way
- * that's as immutable as possible (even if we don't quite achieve it), so we
- * need somewhere -- that is, instances of this class -- to hold the ephemera of
- * the request dispatch process.
+ * The idea here is that {@link IntfIncomingRequest} objects are treated in a
+ * way that's as immutable as possible (even if we don't quite achieve it), so
+ * we need somewhere -- that is, instances of this class -- to hold the ephemera
+ * of the request dispatch process.
  */
 export class DispatchInfo {
   /** @type {TreePathKey} The base path. */

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -60,10 +60,14 @@ export class DispatchInfo {
    * @returns {string} {@link #base}, as a path string. It is always prefixed
    * with a slash (`/`) and only ends with a slash if the final path component
    * is empty.
+   *
+   * **Note:** It is strongly recommended to _only_ use this property for
+   * logging/debugging purposes. {@link #base} is a better choice when doing
+   * calculations.
    */
   get baseString() {
-    // `false` == don't append `/*` for a wildcard `TreePathKey` instance.
-    return this.#base.toUriPathString(false);
+    // `true` == relative form.
+    return this.#base.toUriPathString();
   }
 
   /**
@@ -76,12 +80,15 @@ export class DispatchInfo {
 
   /**
    * @returns {string} {@link #extra}, as a path string. It is always prefixed
-   * with a slash (`/`) and only ends with a slash if the final path component
-   * is empty.
+   * with a dot-slash (`./`) and only ends with a slash if the final path
+   * component is empty.
+   *
+   * **Note:** It is strongly recommended to _only_ use this property for
+   * logging/debugging purposes. {@link #base} is a better choice when doing
+   * calculations.
    */
   get extraString() {
-    // `false` == don't append `/*` for a wildcard `TreePathKey` instance.
-    return this.#extra.toUriPathString(false);
+    return this.#extra.toUriPathString();
   }
 
   /**

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -291,7 +291,7 @@ export class IncomingRequest {
       const pathnameString = (urlObj.pathname === '') ? '/' : urlObj.pathname;
 
       // `slice(1)` to avoid having an empty component as the first element. And
-      // Freezing `parts` lets `new TreePathKey()` avoid making a copy.
+      // freezing `parts` lets `new TreePathKey()` avoid making a copy.
       const pathParts = Object.freeze(pathnameString.slice(1).split('/'));
 
       result.type           = 'origin';

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -16,12 +16,11 @@ import { RequestContext } from '#x/RequestContext';
 
 
 /**
- * Representation of an in-progress HTTP(ish) request, including both request
- * data _and_ ways to send a response.
+ * Representation of an in-progress HTTP(ish) request.
  *
- * Ultimately, this class wraps both the request and response objects that are
- * provided by the underlying Node libraries, though it is intended to offer a
- * simpler (less crufty) and friendlier interface to them.
+ * Ultimately, this class wraps the request object that comes from the
+ * underlying Node libraries, though it is intended to offer a simpler (less
+ * crufty) and friendlier interface to them.
  *
  * **Note:** This class does not implement any understanding of reverse proxy
  * headers. It is up to constructors of this class to pass appropriate

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -16,7 +16,8 @@ import { RequestContext } from '#x/RequestContext';
 
 
 /**
- * Representation of an in-progress HTTP(ish) request.
+ * Representation of an in-progress HTTP(ish) request, which is being serviced
+ * by Node's low-level networking code.
  *
  * Ultimately, this class wraps the request object that comes from the
  * underlying Node libraries, though it is intended to offer a simpler (less

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -12,6 +12,7 @@ import { MustBe } from '@this/typey';
 
 import { Cookies } from '#x/Cookies';
 import { HostInfo } from '#x/HostInfo';
+import { IntfIncomingRequest } from '#x/IntfIncomingRequest';
 import { RequestContext } from '#x/RequestContext';
 
 
@@ -29,6 +30,8 @@ import { RequestContext } from '#x/RequestContext';
  * behind a reverse proxy. That said, as of this writing there isn't anything
  * that actually does that. See
  * <https://github.com/danfuzz/lactoserv/issues/213>.
+ *
+ * @implements {IntfIncomingRequest}
  */
 export class IncomingRequest {
   /**
@@ -115,12 +118,7 @@ export class IncomingRequest {
     }
   }
 
-  /**
-   * @returns {Cookies} Cookies that have been parsed from the request, if any.
-   * This is an empty instance if there were no cookies (or at least no
-   * syntactically correct cookies). Whether or not empty, the instance is
-   * always frozen.
-   */
+  /** @override */
   get cookies() {
     if (!this.#cookies) {
       const cookieStr = this.getHeaderOrNull('cookie');
@@ -132,27 +130,13 @@ export class IncomingRequest {
     return this.#cookies;
   }
 
-  /**
-   * @returns {object} Map of all incoming headers to their values, as defined
-   * by Node's {@link IncomingMessage#headers}.
-   */
+  /** @override */
   get headers() {
     // TODO: This should be an `HttpHeaders` object.
     return this.#coreRequest.headers;
   }
 
-  /**
-   * @returns {HostInfo} Info about the `Host` header (or equivalent). If there
-   * is no header (etc.), it is treated as if it were specified as just
-   * `localhost`.
-   *
-   * The `port` of the returned object is as follows:
-   *
-   * * If the `Host` header has a port, use that.
-   * * If the connection has a "declared listening port," use that.
-   * * If the connection has a known listening port, use that.
-   * * Otherwise, use `0` for the port.
-   */
+  /** @override */
   get host() {
     if (!this.#host) {
       const req = this.#coreRequest;
@@ -174,121 +158,52 @@ export class IncomingRequest {
     return this.#host;
   }
 
-  /**
-   * @returns {?string} The unique-ish request ID, or `null` if there is none
-   * (which will happen if there is no associated logger).
-   */
+  /** @override */
   get id() {
     return this.#id;
   }
 
-  /**
-   * @returns {?IntfLogger} The logger to use with this instance, or `null` if
-   * the instance is not doing any logging.
-   */
+  /** @override */
   get logger() {
     return this.#logger;
   }
 
-  /**
-   * @returns {string} The HTTP(ish) request method, downcased, e.g. commonly
-   * one of `'get'`, `'head'`, or `'post'`.
-   */
+  /** @override */
   get method() {
     return this.#requestMethod;
   }
 
-  /**
-   * @returns {{ address: string, port: number }} The IP address and port of
-   * the origin (remote side) of the request.
-   */
+  /** @override */
   get origin() {
     return this.#requestContext.origin;
   }
 
-  /**
-   * @returns {?TreePathKey} Parsed path key form of {@link #pathnameString}, or
-   * `null` if this instance doesn't represent a usual `origin` request.
-   *
-   * **Note:** If the original incoming pathname was just `'/'` (e.g., it was
-   * from an HTTP request of literally `GET /`), then the value here is a
-   * single-element key with empty value, that is `['']`, and _not_ an empty
-   * key. This preserves the invariant that the keys for all directory-like
-   * requests end with an empty path element.
-   *
-   * **Note:** The name of this field matches the equivalent field of the
-   * standard `URL` class.
-   */
+  /** @override */
   get pathname() {
     return this.#parsedTarget.pathname ?? null;
   }
 
-  /**
-   * @returns {?string} The path portion of {@link #targetString}, as a string,
-   * or `null` if this instance doesn't represent a usual `origin` request (that
-   * is, the kind that includes a path). This starts with a slash (`/`) and
-   * omits the search a/k/a query (`?...`), if any. This also includes
-   * "resolving" away any `.` or `..` components.
-   */
+  /** @override */
   get pathnameString() {
     return this.#parsedTarget.pathnameString ?? null;
   }
 
-  /**
-   * @returns {string} The name of the protocol which this instance is using.
-   * This is generally a string starting with `http-` and ending with the
-   * dotted version. This corresponds to the (unencrypted) protocol being used
-   * over the (possibly encrypted) transport, and has nothing to do _per se_
-   * with the port number which the remote side of this request connected to in
-   * order to send the request. That is, `https*` won't be the value of this
-   * property.
-   */
+  /** @override */
   get protocolName() {
     return this.#protocolName;
   }
 
-  /**
-   * @returns {string} The search a/k/a query portion of {@link #targetString},
-   * as an unparsed string, or `''` (the empty string) if there is no search
-   * string. The result includes anything at or after the first question mark
-   * (`?`) in the URL. In the case of a "degenerate" search of _just_ a question
-   * mark with nothing after, this returns `''`.
-   *
-   * **Note:** The name of this field matches the equivalent field of the
-   * standard `URL` class.
-   */
+  /** @override */
   get searchString() {
     return this.#parsedTarget.searchString;
   }
 
-  /**
-   * @returns {string} The unparsed target that was passed in to the original
-   * HTTP(ish) request. In the common case of the target being a path to a
-   * resource, colloquially speaking, this is the suffix of the URL-per-se
-   * starting at the first slash (`/`) after the host identifier. That said,
-   * there are other non-path forms for a target. See
-   * <https://www.rfc-editor.org/rfc/rfc7230#section-5.3> for the excruciating
-   * details.
-   *
-   * For example, for the requested URL
-   * `https://example.com:123/foo/bar?baz=10`, this would be `/foo/bar?baz=10`.
-   * This property name corresponds to the standard Node field
-   * `IncomingRequest.url`, even though it's not actually a URL per se. We chose
-   * to diverge from Node for the sake of clarity.
-   */
+  /** @override */
   get targetString() {
     return this.#parsedTarget.targetString;
   }
 
-  /**
-   * @returns {string} A reasonably-suggestive but possibly incomplete
-   * representation of the incoming request including both the host and target,
-   * in the form of a protocol-less URL in most cases (and something vaguely
-   * URL-like when the target isn't the usual `origin` type).
-   *
-   * This value is meant for logging, and specifically _not_ for any routing or
-   * other more meaningful computation (hence the name).
-   */
+  /** @override */
   get urlForLogging() {
     if (!this.#urlForLogging) {
       const { host }               = this;
@@ -303,27 +218,12 @@ export class IncomingRequest {
     return this.#urlForLogging;
   }
 
-  /**
-   * Gets a request header, by name.
-   *
-   * @param {string} name The header name.
-   * @returns {?string|Array<string>} The corresponding value, or `null` if
-   *   there was no such header.
-   */
+  /** @override */
   getHeaderOrNull(name) {
     return this.#coreRequest.headers[name] ?? null;
   }
 
-  /**
-   * Gets all reasonably-logged info about the request that was made.
-   *
-   * **Note:** The `headers` in the result omits anything that is redundant
-   * with respect to other parts of the return value. (E.g., the `cookie` header
-   * is omitted if it was able to be parsed.)
-   *
-   * @returns {object} Loggable information about the request. The result is
-   *   always frozen.
-   */
+  /** @override */
   getLoggableRequestInfo() {
     if (!this.#loggableRequestInfo) {
       const {

--- a/src/net-util/export/IntfIncomingRequest.js
+++ b/src/net-util/export/IntfIncomingRequest.js
@@ -1,0 +1,198 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { IncomingMessage } from 'node:http';
+
+import { TreePathKey } from '@this/collections';
+import { IntfLogger } from '@this/loggy-intf';
+import { Methods } from '@this/typey';
+
+import { Cookies } from '#x/Cookies';
+import { HostInfo } from '#x/HostInfo';
+
+
+/**
+ * Representation of an in-progress HTTP(ish) request.
+ *
+ * @interface
+ */
+export class IntfIncomingRequest {
+  /**
+   * @returns {Cookies} Cookies that have been parsed from the request, if any.
+   * This is an empty instance if there were no cookies (or at least no
+   * syntactically correct cookies). Whether or not empty, the instance is
+   * always frozen.
+   */
+  get cookies() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {object} Map of all incoming headers to their values, as defined
+   * by Node's {@link IncomingMessage#headers}. TODO: This should be an
+   * `HttpHeaders` object.
+   */
+  get headers() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {HostInfo} Info about the `Host` header (or equivalent). If there
+   * is no header (etc.), it is treated as if it were specified as just
+   * `localhost`.
+   *
+   * The `port` of the returned object is as follows:
+   *
+   * * If the `Host` header has a port, use that.
+   * * If the connection has a "declared listening port," use that.
+   * * If the connection has a known listening port, use that.
+   * * Otherwise, use `0` for the port.
+   */
+  get host() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {?string} The unique-ish request ID, or `null` if there is none
+   * (which will happen if there is no associated logger).
+   */
+  get id() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {?IntfLogger} The logger to use with this instance, or `null` if
+   * the instance is not doing any logging.
+   */
+  get logger() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {string} The HTTP(ish) request method, downcased, e.g. commonly
+   * one of `'get'`, `'head'`, or `'post'`.
+   */
+  get method() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {{ address: string, port: number }} The IP address and port of
+   * the origin (remote side) of the request.
+   */
+  get origin() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {?TreePathKey} Parsed path key form of {@link #pathnameString}, or
+   * `null` if this instance doesn't represent a usual `origin` request.
+   *
+   * **Note:** If the original incoming pathname was just `'/'` (e.g., it was
+   * from an HTTP request of literally `GET /`), then the value here is a
+   * single-element key with empty value, that is `['']`, and _not_ an empty
+   * key. This preserves the invariant that the keys for all directory-like
+   * requests end with an empty path element.
+   *
+   * **Note:** The name of this field matches the equivalent field of the
+   * standard `URL` class.
+   */
+  get pathname() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {?string} The path portion of {@link #targetString}, as a string,
+   * or `null` if this instance doesn't represent a usual `origin` request (that
+   * is, the kind that includes a path). This starts with a slash (`/`) and
+   * omits the search a/k/a query (`?...`), if any. This also includes
+   * "resolving" away any `.` or `..` components.
+   */
+  get pathnameString() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {string} The name of the protocol which this instance is using.
+   * This is generally a string starting with `http-` and ending with the
+   * dotted version. This corresponds to the (unencrypted) protocol being used
+   * over the (possibly encrypted) transport, and has nothing to do _per se_
+   * with the port number which the remote side of this request connected to in
+   * order to send the request. That is, `https*` won't be the value of this
+   * property.
+   */
+  get protocolName() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {string} The search a/k/a query portion of {@link #targetString},
+   * as an unparsed string, or `''` (the empty string) if there is no search
+   * string. The result includes anything at or after the first question mark
+   * (`?`) in the URL. In the case of a "degenerate" search of _just_ a question
+   * mark with nothing after, this returns `''`.
+   *
+   * **Note:** The name of this field matches the equivalent field of the
+   * standard `URL` class.
+   */
+  get searchString() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {string} The unparsed target that was passed in to the original
+   * HTTP(ish) request. In the common case of the target being a path to a
+   * resource, colloquially speaking, this is the suffix of the URL-per-se
+   * starting at the first slash (`/`) after the host identifier. That said,
+   * there are other non-path forms for a target. See
+   * <https://www.rfc-editor.org/rfc/rfc7230#section-5.3> for the excruciating
+   * details.
+   *
+   * For example, for the requested URL
+   * `https://example.com:123/foo/bar?baz=10`, this would be `/foo/bar?baz=10`.
+   * This property name corresponds to the standard Node field
+   * {@link IncomingMessage#url}, even though it's not actually a URL per se. We
+   * chose to diverge from Node for the sake of clarity.
+   */
+  get targetString() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * @returns {string} A reasonably-suggestive but possibly incomplete
+   * representation of the incoming request including both the host and target,
+   * in the form of a protocol-less URL in most cases (and something vaguely
+   * URL-like when the target isn't the usual `origin` type).
+   *
+   * This value is meant for logging, and specifically _not_ for any routing or
+   * other more meaningful computation (hence the name).
+   */
+  get urlForLogging() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * Gets a request header, by name.
+   *
+   * @param {string} name The header name.
+   * @returns {?string|Array<string>} The corresponding value, or `null` if
+   *   there was no such header.
+   */
+  getHeaderOrNull(name) {
+    throw Methods.abstract(name);
+  }
+
+  /**
+   * Gets all reasonably-logged info about the request that was made.
+   *
+   * **Note:** The `headers` in the result omits anything that is redundant
+   * with respect to other parts of the return value. (E.g., the `cookie` header
+   * is omitted if it was able to be parsed.)
+   *
+   * @returns {object} Loggable information about the request. The result is
+   *   always frozen.
+   */
+  getLoggableRequestInfo() {
+    throw Methods.abstract();
+  }
+}

--- a/src/net-util/export/IntfRequestHandler.js
+++ b/src/net-util/export/IntfRequestHandler.js
@@ -4,7 +4,7 @@
 import { Methods } from '@this/typey';
 
 import { DispatchInfo } from '#x/DispatchInfo';
-import { IncomingRequest } from '#x/IncomingRequest';
+import { IntfIncomingRequest } from '#x/IntfIncomingRequest';
 import { OutgoingResponse } from '#x/OutgoingResponse';
 
 
@@ -21,7 +21,7 @@ export class IntfRequestHandler {
    * was not handled.
    *
    * @abstract
-   * @param {IncomingRequest} request Request object.
+   * @param {IntfIncomingRequest} request Request object.
    * @param {?DispatchInfo} dispatch Dispatch information, or `null` if no
    *   dispatch determination was made before calling this instance. (On any
    *   given instance -- depending on context -- it should be the case that it

--- a/src/net-util/index.js
+++ b/src/net-util/index.js
@@ -10,6 +10,7 @@ export * from '#x/HttpHeaders';
 export * from '#x/HttpRange';
 export * from '#x/HttpUtil';
 export * from '#x/IncomingRequest';
+export * from '#x/IntfIncomingRequest';
 export * from '#x/IntfRequestHandler';
 export * from '#x/MimeTypes';
 export * from '#x/OutgoingResponse';

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -112,11 +112,16 @@ export class BaseApplication extends BaseComponent {
     }
 
     if (maxPathLength !== null) {
-      // TODO!!!!! FIXME!!! Change how dispatch path stringifies so that there
-      // is not necessarily a leading slash on extra. Check what happens with
-      // path bindings `/` vs `/*` vs `/x` vs `/x/` vs `/x/*`.
-      const extraString = dispatch.extra.toUriPathString();
-      if (extraString.length > maxPathLength) {
+      // Note: We calculate this based on how the `extra` would get converted
+      // back to a path string if it were the entire `pathname` of the URL. This
+      // is arguably the most sensible tactic, in that if this instance actually
+      // is the one that was immediately dispatched to from an endpoint, `extra`
+      // will in fact be the same as `pathname`.
+      const extra  = dispatch.extra;
+      const length =
+        extra.length +    // One octet per slash if it were `pathname`.
+        extra.charLength; // Total count of characters in all components.
+      if (length > maxPathLength) {
         return null;
       }
     }

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -1,8 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { DispatchInfo, IncomingRequest, IntfRequestHandler, OutgoingResponse }
-  from '@this/net-util';
+import { DispatchInfo, IntfIncomingRequest, IntfRequestHandler,
+  OutgoingResponse } from '@this/net-util';
 import { ApplicationConfig } from '@this/sys-config';
 import { Methods, MustBe } from '@this/typey';
 
@@ -69,7 +69,7 @@ export class BaseApplication extends BaseComponent {
    * Handles a request, as defined by {@link IntfRequestHandler}.
    *
    * @abstract
-   * @param {IncomingRequest} request Request object.
+   * @param {IntfIncomingRequest} request Request object.
    * @param {DispatchInfo} dispatch Dispatch information.
    * @returns {?OutgoingResponse} Response to the request, if any, as defined by
    *   {@link IntfRequestHandler#handleRequest}.
@@ -82,7 +82,7 @@ export class BaseApplication extends BaseComponent {
    * Performs request / dispatch filtering, if the instance is configured to do
    * that. Does nothing (returns `false`) if not.
    *
-   * @param {IncomingRequest} request Request object.
+   * @param {IntfIncomingRequest} request Request object.
    * @param {DispatchInfo} dispatch Dispatch information.
    * @returns {?OutgoingResponse|false} A response indicator (including `null`
    *   to indicate "not handled"), or `false` to indicate that no filtering was
@@ -145,7 +145,7 @@ export class BaseApplication extends BaseComponent {
   /**
    * Calls {@link #_impl_handleRequest}, and ensures a proper return value.
    *
-   * @param {IncomingRequest} request Request object.
+   * @param {IntfIncomingRequest} request Request object.
    * @param {DispatchInfo} dispatch Dispatch information.
    * @returns {?OutgoingResponse} Response to the request, if any.
    */

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -114,7 +114,7 @@ export class BaseApplication extends BaseComponent {
     if (maxPathLength !== null) {
       // TODO!!!!! FIXME!!! Change how dispatch path stringifies so that there
       // is not necessarily a leading slash on extra. Check what happens with
-      // path bindings `/` vs `/x` vs `/x/` vs `/x/*`.
+      // path bindings `/` vs `/*` vs `/x` vs `/x/` vs `/x/*`.
       const extraString = dispatch.extra.toUriPathString();
       if (extraString.length > maxPathLength) {
         return null;

--- a/src/sys-framework/export/ControlContext.js
+++ b/src/sys-framework/export/ControlContext.js
@@ -53,9 +53,10 @@ export class ControlContext {
    *   instance.
    * @param {?BaseControllable} parent Parent of `associate`, or `null` if this
    *   instance is to represent the root instance.
-   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
+   * @param {?IntfLogger} [logger] Logger to use, or `null` to not do any
+   *   logging.
    */
-  constructor(associate, parent, logger) {
+  constructor(associate, parent, logger = null) {
     this.#logger = logger;
 
     if (associate === 'root') {


### PR DESCRIPTION
This PR changes how paths can be filtered in `BaseApplication`, and it also introduces the first unit tests for applications. The latter is still a bit messy, but it's a good first step.