### PR TITLE
`TreePathMap` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Breaking changes:
   * Removed net-related `TreePathKey` methods (rendering as URI paths and
     hostname strings).
   * Made `TreePathKey.toString()` less "net-centric" by default.
+  * Added new method `TreePathMap.findWithFallback()` to replace `find()` with
+    `wantNextChain == true`. Removed the second argument from `find()`.
 * `net-util`:
   * Major rework of `IncomingRequest`, so it no longer has to be constructed
     from a low-level Node request object.

--- a/src/built-ins/export/PathRouter.js
+++ b/src/built-ins/export/PathRouter.js
@@ -26,9 +26,7 @@ export class PathRouter extends BaseApplication {
   /** @override */
   async _impl_handleRequest(request, dispatch) {
     // Iterate from most- to least-specific mounted path.
-    for (let pathMatch = this.#routeTree.find(dispatch.extra, true);
-      pathMatch;
-      pathMatch = pathMatch.next) {
+    for (const pathMatch of this.#routeTree.findWithFallback(dispatch.extra)) {
       const application = pathMatch.value;
       const subDispatch = new DispatchInfo(
         dispatch.base.concat(pathMatch.key),

--- a/src/collections/export/TreePathMap.js
+++ b/src/collections/export/TreePathMap.js
@@ -109,7 +109,7 @@ export class TreePathMap {
    * getting the first result from {@link #findWithFallback} or `null` if there
    * are no matching bindings.
    *
-   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to look
+   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to search
    *   for.
    * @returns {?{key: TreePathKey, keyRemainder: TreePathKey, value: *}} The
    *   most specific match, or `null` if there was no match at all.
@@ -133,17 +133,15 @@ export class TreePathMap {
    * wildcard key with a non-empty path, then this method will only return
    * bindings with keys at or under that path.
    *
-   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to look
+   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to search
    *   up.
    * @returns {TreePathMap} Map of matched bindings.
    */
   findSubtree(key) {
-    // See the note in docs of `TreePathNode.findSubtree()` for an explanation
-    // about what's going on here.
-
     const result = new TreePathMap();
 
-    this.#rootNode.findSubtree(key, (k, v) => result.add(k, v));
+    this.#rootNode.addSubtree(key, result);
+
     return result;
   }
 

--- a/src/collections/export/TreePathMap.js
+++ b/src/collections/export/TreePathMap.js
@@ -138,7 +138,7 @@ export class TreePathMap {
    * @returns {TreePathMap} Map of matched bindings.
    */
   findSubtree(key) {
-    const result = new TreePathMap();
+    const result = new TreePathMap(this.#keyStringFunc);
 
     this.#rootNode.addSubtree(key, result);
 

--- a/src/collections/export/TreePathMap.js
+++ b/src/collections/export/TreePathMap.js
@@ -161,34 +161,6 @@ export class TreePathMap {
   }
 
   /**
-   * Gets a generator which produces bindings which match the given path, from
-   * most- to least-specific.
-   *
-   * Note that, given the same path, a non-wildcard binding is considered more
-   * specific than a wildcard binding.
-   *
-   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to look
-   *   up. If `.wildcard` is `true`, then this method will only find bindings
-   *   which are wildcards, though they might be more general than the `.path`
-   *   being looked for.
-   * @yields {{key: TreePathKey, keyRemainder: TreePathKey, value: *}} One
-   *   result of the search.
-   *   * `{TreePathKey} key` -- The key that was matched; this is a wildcard key
-   *     if the match was in fact a wildcard match, and likewise it is a
-   *     non-wildcard key for an exact match. Furthermore, this is an object
-   *     that was `add()`ed to this instance (and not, e.g., a "reconstructed"
-   *     key).
-   *   * `{TreePathKey} keyRemainder` -- The portion of the originally-given
-   *     `key.path` that was matched by a wildcard, if this was in fact a
-   *     wildcard match, in the form of a non-wildcard key. For non-wildcard
-   *     matches, this is always an empty-path key.
-   *   * `{*} value` -- The value bound to `key`.
-   */
-  *findWithFallback(key) {
-    yield* this.#rootNode.findWithFallback(key);
-  }
-
-  /**
    * Returns a new instance which is just like this one, except it will only
    * find keys which themselves match a given key. In the common case of passing
    * a wildcard key, this returns the subtree rooted at the given key, with the
@@ -215,6 +187,34 @@ export class TreePathMap {
 
     this.#rootNode.findSubtree(key, (k, v) => result.add(k, v));
     return result;
+  }
+
+  /**
+   * Gets a generator which produces bindings which match the given path, from
+   * most- to least-specific.
+   *
+   * Note that, given the same path, a non-wildcard binding is considered more
+   * specific than a wildcard binding.
+   *
+   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to look
+   *   up. If `.wildcard` is `true`, then this method will only find bindings
+   *   which are wildcards, though they might be more general than the `.path`
+   *   being looked for.
+   * @yields {{key: TreePathKey, keyRemainder: TreePathKey, value: *}} One
+   *   result of the search.
+   *   * `{TreePathKey} key` -- The key that was matched; this is a wildcard key
+   *     if the match was in fact a wildcard match, and likewise it is a
+   *     non-wildcard key for an exact match. Furthermore, this is an object
+   *     that was `add()`ed to this instance (and not, e.g., a "reconstructed"
+   *     key).
+   *   * `{TreePathKey} keyRemainder` -- The portion of the originally-given
+   *     `key.path` that was matched by a wildcard, if this was in fact a
+   *     wildcard match, in the form of a non-wildcard key. For non-wildcard
+   *     matches, this is always an empty-path key.
+   *   * `{*} value` -- The value bound to `key`.
+   */
+  *findWithFallback(key) {
+    yield* this.#rootNode.findWithFallback(key);
   }
 
   /**

--- a/src/collections/export/TreePathMap.js
+++ b/src/collections/export/TreePathMap.js
@@ -105,59 +105,17 @@ export class TreePathMap {
   }
 
   /**
-   * Finds the most-specific binding for the given path. Optionally produces
-   * a chain of `next` results for less-and-less-specific bindings.
-   *
-   * Note that, given the same path, a non-wildcard binding is considered more
-   * specific than a wildcard binding.
+   * Finds the most specific binding for the given path. This is equivalent to
+   * getting the first result from {@link #findWithFallback} or `null` if there
+   * are no matching bindings.
    *
    * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to look
-   *   up. If `.wildcard` is `true`, then this method will only find bindings
-   *   which are wildcards, though they might be more general than the `.path`
-   *   being looked for.
-   * @param {boolean} [wantNextChain] Should the return value have a
-   *   `next` binding indicating the next-most-specific binding? If so,
-   *   `next.next` will be similarly bound, and so on. The final element of the
-   *   chain will have no binding for `next` (not even `null`).
+   *   for.
    * @returns {?{key: TreePathKey, keyRemainder: TreePathKey, value: *}} The
-   *   found result, or `null` if there was no match.
-   *   * `{TreePathKey} key` -- The key that was matched; this is a wildcard key
-   *     if the match was in fact a wildcard match, and likewise it is a
-   *     non-wildcard key for an exact match. Furthermore, this is an object
-   *     that was `add()`ed to this instance (and not, e.g., a "reconstructed"
-   *     key).
-   *   * `{TreePathKey} keyRemainder` -- The portion of the originally-given
-   *     `key.path` that was matched by a wildcard, if this was in fact a
-   *     wildcard match, in the form of a non-wildcard key. For non-wildcard
-   *     matches, this is always an empty-path key.
-   *   * `{object} next` -- The next-most-specific result, with bindings as
-   *     described here. Only present if (a) `wantNextChain` was passed as
-   *     `true` _and_ (b) there is in fact a next-most-specific result.
-   *   * `{*} value` -- The value bound to `key`.
+   *   most specific match, or `null` if there was no match at all.
    */
-  find(key, wantNextChain = false) {
-    const found = this.#rootNode.findWithFallback(key);
-
-    if (!wantNextChain) {
-      const result = found.next();
-      return result.done ? null : result.value;
-    }
-
-    // TEMP: Implement the old behavior in terms of the new method.
-
-    let result = null;
-    let at     = null;
-    for (const r of found) {
-      if (!result) {
-        result = r;
-        at     = r;
-      } else {
-        at.next = r;
-        at = r;
-      }
-    }
-
-    return result;
+  find(key) {
+    return this.#rootNode.find(key);
   }
 
   /**
@@ -196,8 +154,8 @@ export class TreePathMap {
    * Note that, given the same path, a non-wildcard binding is considered more
    * specific than a wildcard binding.
    *
-   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to look
-   *   up. If `.wildcard` is `true`, then this method will only find bindings
+   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to search
+   *   for. If `.wildcard` is `true`, then this method will only find bindings
    *   which are wildcards, though they might be more general than the `.path`
    *   being looked for.
    * @yields {{key: TreePathKey, keyRemainder: TreePathKey, value: *}} One
@@ -208,9 +166,9 @@ export class TreePathMap {
    *     that was `add()`ed to this instance (and not, e.g., a "reconstructed"
    *     key).
    *   * `{TreePathKey} keyRemainder` -- The portion of the originally-given
-   *     `key.path` that was matched by a wildcard, if this was in fact a
-   *     wildcard match, in the form of a non-wildcard key. For non-wildcard
-   *     matches, this is always an empty-path key.
+   *     `key.path` that was matched by the wildcard portion of the key, if this
+   *     was in fact a wildcard match, in the form of a non-wildcard key. For
+   *     non-wildcard matches, this is always an empty-path key.
    *   * `{*} value` -- The value bound to `key`.
    */
   *findWithFallback(key) {

--- a/src/collections/export/TreePathMap.js
+++ b/src/collections/export/TreePathMap.js
@@ -21,9 +21,9 @@ export class TreePathMap {
   #rootNode = new TreePathNode();
 
   /**
-   * @type {number} Total number of bindings. This is only maintained on a
-   * root (publicly exposed) instance of this class (not on the instances that
-   * are used internally in {@link #subtrees}).
+   * @type {number} Total number of bindings. This defined here instead of on
+   * {@link TreePathNode}, because internal nodes don't need to keep track of
+   * their overall size.
    */
   #size = 0;
 

--- a/src/collections/private/TreePathNode.js
+++ b/src/collections/private/TreePathNode.js
@@ -114,13 +114,12 @@ export class TreePathNode {
    * Underlying implementation of `TreePathMap.findSubtree()`, see which for
    * detailed docs.
    *
-   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to look
+   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to search
    *   up.
-   * @param {function(TreePathKey, *)} add Function to call to add an entry to
-   *   the result. This is used instead of constructing a result instance
-   *   directly here, so as to avoid a circular dependency on `TreePathMap`.
+   * @param {object} result Result to add to. (It's a `TreePathMap`, but we
+   *   don't name the type here to avoid a circular dependency.)
    */
-  findSubtree(key, add) {
+  addSubtree(key, result) {
     const { path, wildcard } = key;
 
     if (!(key instanceof TreePathKey)) {
@@ -131,7 +130,7 @@ export class TreePathNode {
       // Non-wildcard is easy, because `find()` already does the right thing.
       const found = this.find(key);
       if (found !== null) {
-        add(key, found.value);
+        result.add(key, found.value);
       }
       return;
     }
@@ -151,7 +150,7 @@ export class TreePathNode {
     }
 
     for (const [k, v] of subtree.#iteratorAt(path)) {
-      add(k, v);
+      result.add(k, v);
     }
   }
 

--- a/src/collections/private/TreePathNode.js
+++ b/src/collections/private/TreePathNode.js
@@ -101,10 +101,10 @@ export class TreePathNode {
    * Underlying implementation of `TreePathMap.find()`, see which for detailed
    * docs.
    *
-   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to look
-   *   up.
+   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to search
+   *   for.
    * @returns {?{key: TreePathKey, keyRemainder: TreePathKey, value: *}} The
-   *   found result, or `null` if there was no match.
+   *   most specific match, or `null` if there was no match at all.
    */
   find(key) {
     return this.findWithFallback(key).next().value ?? null;
@@ -115,7 +115,7 @@ export class TreePathNode {
    * for detailed docs.
    *
    * @param {TreePathKey|{path: string[], wildcard: boolean}} keyToFind Key to
-   *   find (natch).
+   *   search for.
    * @yields {{key: TreePathKey, keyRemainder: TreePathKey, value: *}} One
    *   result.
    */

--- a/src/collections/private/TreePathNode.js
+++ b/src/collections/private/TreePathNode.js
@@ -88,29 +88,6 @@ export class TreePathNode {
   }
 
   /**
-   * Underlying implementation of `TreePathMap.entries()`, see which for
-   * detailed docs.
-   *
-   * @returns {object} Iterator over the entries of this instance.
-   */
-  entries() {
-    return this.#iteratorAt([]);
-  }
-
-  /**
-   * Underlying implementation of `TreePathMap.find()`, see which for detailed
-   * docs.
-   *
-   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to search
-   *   for.
-   * @returns {?{key: TreePathKey, keyRemainder: TreePathKey, value: *}} The
-   *   most specific match, or `null` if there was no match at all.
-   */
-  find(key) {
-    return this.findWithFallback(key).next().value ?? null;
-  }
-
-  /**
    * Underlying implementation of `TreePathMap.findSubtree()`, see which for
    * detailed docs.
    *
@@ -152,6 +129,29 @@ export class TreePathNode {
     for (const [k, v] of subtree.#iteratorAt(path)) {
       result.add(k, v);
     }
+  }
+
+  /**
+   * Underlying implementation of `TreePathMap.entries()`, see which for
+   * detailed docs.
+   *
+   * @returns {object} Iterator over the entries of this instance.
+   */
+  entries() {
+    return this.#iteratorAt([]);
+  }
+
+  /**
+   * Underlying implementation of `TreePathMap.find()`, see which for detailed
+   * docs.
+   *
+   * @param {TreePathKey|{path: string[], wildcard: boolean}} key Key to search
+   *   for.
+   * @returns {?{key: TreePathKey, keyRemainder: TreePathKey, value: *}} The
+   *   most specific match, or `null` if there was no match at all.
+   */
+  find(key) {
+    return this.findWithFallback(key).next().value ?? null;
   }
 
   /**

--- a/src/collections/tests/TreePathMap.test.js
+++ b/src/collections/tests/TreePathMap.test.js
@@ -281,387 +281,276 @@ describe('entries()', () => {
 });
 
 describe('find()', () => {
-  describe('without `wantNextChain` argument (that is, implied `false`)', () => {
-    describe('given a non-wildcard key', () => {
-      test('finds an already-added key, when an exact match is passed as a `TreePathKey`', () => {
-        const key   = new TreePathKey(['1', '2', '3'], false);
-        const value = ['florp'];
-        const map   = new TreePathMap();
+  describe('given a non-wildcard key', () => {
+    test('finds an already-added key, when an exact match is passed as a `TreePathKey`', () => {
+      const key   = new TreePathKey(['1', '2', '3'], false);
+      const value = ['florp'];
+      const map   = new TreePathMap();
 
-        map.add(key, value);
-        const result = map.find(key);
-        expect(result).not.toBeNull();
-        expect(result.key).toBe(key);
-        expect(result.keyRemainder).toBe(TreePathKey.EMPTY);
-        expect(result.value).toBe(value);
-      });
-
-      test('finds an already-added key, when an exact match passed as a key-like plain object', () => {
-        const key1  = new TreePathKey(['1', '2', '3'], false);
-        const key2  = { path: ['1', '2', '3'], wildcard: false };
-        const value = ['florp'];
-        const map   = new TreePathMap();
-
-        map.add(key1, value);
-        const result = map.find(key2);
-        expect(result).not.toBeNull();
-        expect(result.key).toBe(key1);
-        expect(result.keyRemainder).toBe(TreePathKey.EMPTY);
-        expect(result.value).toBe(value);
-      });
-
-      test('finds an already-added wildcard, when a matching non-wildcard key is passed', () => {
-        const key1  = new TreePathKey(['one', 'two'], true);
-        const key2  = new TreePathKey(['one', 'two'], false);
-        const key3  = new TreePathKey(['one', 'two', 'three'], false);
-        const value = ['boop'];
-        const map   = new TreePathMap();
-
-        map.add(key1, value);
-
-        const result1 = map.find(key2);
-        expect(result1).not.toBeNull();
-        expect(result1.key).toBe(key1);
-        expect(result1.keyRemainder).toBe(TreePathKey.EMPTY);
-        expect(result1.value).toBe(value);
-
-        const result2 = map.find(key3);
-        expect(result2).not.toBeNull();
-        expect(result2.key).toBe(key1);
-        expect(result2.keyRemainder.path).toStrictEqual(['three']);
-        expect(result2.keyRemainder.wildcard).toBeFalse();
-        expect(result2.value).toBe(value);
-      });
-
-      test('finds a wildcard binding at the exact key', () => {
-        const key1  = new TreePathKey(['i', 'love', 'muffins'], true);
-        const key2  = new TreePathKey(['i', 'love', 'muffins'], false);
-        const value = ['blueberry'];
-        const map   = new TreePathMap();
-
-        map.add(key1, value);
-
-        const result = map.find(key2);
-        expect(result).not.toBeNull();
-        expect(result.key).toBe(key1);
-        expect(result.keyRemainder.path).toStrictEqual([]);
-        expect(result.keyRemainder.wildcard).toBeFalse();
-        expect(result.value).toBe(value);
-      });
-
-      test('finds a wildcard binding "below" the key being looked up', () => {
-        const key1  = new TreePathKey(['top'], true);
-        const key2  = new TreePathKey(['top', 'middle'], false);
-        const key3  = new TreePathKey(['top', 'middle', 'bottom'], false);
-        const value = ['florp'];
-        const map   = new TreePathMap();
-
-        map.add(key1, value);
-        map.add(key2, 'y');
-
-        const result = map.find(key3);
-        expect(result).not.toBeNull();
-        expect(result.key).toBe(key1);
-        expect(result.keyRemainder.path).toStrictEqual(['middle', 'bottom']);
-        expect(result.keyRemainder.wildcard).toBeFalse();
-        expect(result.value).toBe(value);
-      });
-
-      test('finds the most specific wildcard binding "below" the key being looked up', () => {
-        const key1  = new TreePathKey(['top'], true);
-        const key2  = new TreePathKey(['top', 'middle'], true);
-        const key3  = new TreePathKey(['top', 'middle', 'bottom'], false);
-        const value = ['florp', 'like'];
-        const map   = new TreePathMap();
-
-        map.add(key1, 'x');
-        map.add(key2, value);
-
-        const result = map.find(key3);
-        expect(result).not.toBeNull();
-        expect(result.key).toBe(key2);
-        expect(result.keyRemainder.path).toStrictEqual(['bottom']);
-        expect(result.keyRemainder.wildcard).toBeFalse();
-        expect(result.value).toBe(value);
-      });
-
-      test('does not find a non-wildcard binding "below" the key being looked up', () => {
-        const key1 = new TreePathKey(['top'], false);
-        const key2 = new TreePathKey(['top', 'middle'], false);
-        const key3 = new TreePathKey(['top', 'middle', 'bottom'], false);
-        const map  = new TreePathMap();
-
-        map.add(key1, 'x');
-        map.add(key2, 'y');
-
-        const result = map.find(key3);
-        expect(result).toBeNull();
-      });
+      map.add(key, value);
+      const result = map.find(key);
+      expect(result).not.toBeNull();
+      expect(result.key).toBe(key);
+      expect(result.keyRemainder).toBe(TreePathKey.EMPTY);
+      expect(result.value).toBe(value);
     });
 
-    describe('given a wildcard key', () => {
-      test('finds an already-added wildcard, when a matching key is passed as a `TreePathKey`', () => {
-        const key1  = new TreePathKey(['one', 'two'], true);
-        const key2  = new TreePathKey(['one', 'two', 'three'], true);
-        const value = ['boop'];
-        const map   = new TreePathMap();
+    test('finds an already-added key, when an exact match passed as a key-like plain object', () => {
+      const key1  = new TreePathKey(['1', '2', '3'], false);
+      const key2  = { path: ['1', '2', '3'], wildcard: false };
+      const value = ['florp'];
+      const map   = new TreePathMap();
+
+      map.add(key1, value);
+      const result = map.find(key2);
+      expect(result).not.toBeNull();
+      expect(result.key).toBe(key1);
+      expect(result.keyRemainder).toBe(TreePathKey.EMPTY);
+      expect(result.value).toBe(value);
+    });
+
+    test('finds an already-added wildcard, when a matching non-wildcard key is passed', () => {
+      const key1  = new TreePathKey(['one', 'two'], true);
+      const key2  = new TreePathKey(['one', 'two'], false);
+      const key3  = new TreePathKey(['one', 'two', 'three'], false);
+      const value = ['boop'];
+      const map   = new TreePathMap();
+
+      map.add(key1, value);
+
+      const result1 = map.find(key2);
+      expect(result1).not.toBeNull();
+      expect(result1.key).toBe(key1);
+      expect(result1.keyRemainder).toBe(TreePathKey.EMPTY);
+      expect(result1.value).toBe(value);
+
+      const result2 = map.find(key3);
+      expect(result2).not.toBeNull();
+      expect(result2.key).toBe(key1);
+      expect(result2.keyRemainder.path).toStrictEqual(['three']);
+      expect(result2.keyRemainder.wildcard).toBeFalse();
+      expect(result2.value).toBe(value);
+    });
+
+    test('finds a wildcard binding at the exact key', () => {
+      const key1  = new TreePathKey(['i', 'love', 'muffins'], true);
+      const key2  = new TreePathKey(['i', 'love', 'muffins'], false);
+      const value = ['blueberry'];
+      const map   = new TreePathMap();
+
+      map.add(key1, value);
+
+      const result = map.find(key2);
+      expect(result).not.toBeNull();
+      expect(result.key).toBe(key1);
+      expect(result.keyRemainder.path).toStrictEqual([]);
+      expect(result.keyRemainder.wildcard).toBeFalse();
+      expect(result.value).toBe(value);
+    });
+
+    test('finds a wildcard binding "below" the key being looked up', () => {
+      const key1  = new TreePathKey(['top'], true);
+      const key2  = new TreePathKey(['top', 'middle'], false);
+      const key3  = new TreePathKey(['top', 'middle', 'bottom'], false);
+      const value = ['florp'];
+      const map   = new TreePathMap();
+
+      map.add(key1, value);
+      map.add(key2, 'y');
+
+      const result = map.find(key3);
+      expect(result).not.toBeNull();
+      expect(result.key).toBe(key1);
+      expect(result.keyRemainder.path).toStrictEqual(['middle', 'bottom']);
+      expect(result.keyRemainder.wildcard).toBeFalse();
+      expect(result.value).toBe(value);
+    });
+
+    test('finds the most specific wildcard binding "below" the key being looked up', () => {
+      const key1  = new TreePathKey(['top'], true);
+      const key2  = new TreePathKey(['top', 'middle'], true);
+      const key3  = new TreePathKey(['top', 'middle', 'bottom'], false);
+      const value = ['florp', 'like'];
+      const map   = new TreePathMap();
+
+      map.add(key1, 'x');
+      map.add(key2, value);
+
+      const result = map.find(key3);
+      expect(result).not.toBeNull();
+      expect(result.key).toBe(key2);
+      expect(result.keyRemainder.path).toStrictEqual(['bottom']);
+      expect(result.keyRemainder.wildcard).toBeFalse();
+      expect(result.value).toBe(value);
+    });
+
+    test('does not find a non-wildcard binding "below" the key being looked up', () => {
+      const key1 = new TreePathKey(['top'], false);
+      const key2 = new TreePathKey(['top', 'middle'], false);
+      const key3 = new TreePathKey(['top', 'middle', 'bottom'], false);
+      const map  = new TreePathMap();
+
+      map.add(key1, 'x');
+      map.add(key2, 'y');
+
+      const result = map.find(key3);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('given a wildcard key', () => {
+    test('finds an already-added wildcard, when a matching key is passed as a `TreePathKey`', () => {
+      const key1  = new TreePathKey(['one', 'two'], true);
+      const key2  = new TreePathKey(['one', 'two', 'three'], true);
+      const value = ['boop'];
+      const map   = new TreePathMap();
+
+      map.add(key1, value);
+
+      const result1 = map.find(key1);
+      expect(result1).not.toBeNull();
+      expect(result1.key).toBe(key1);
+      expect(result1.keyRemainder).toBe(TreePathKey.EMPTY);
+      expect(result1.value).toBe(value);
+
+      const result2 = map.find(key2);
+      expect(result2).not.toBeNull();
+      expect(result2.key).toBe(key1);
+      expect(result2.keyRemainder.path).toStrictEqual(['three']);
+      expect(result2.keyRemainder.wildcard).toBeFalse();
+      expect(result2.value).toBe(value);
+    });
+
+    test('finds an already-added wildcard, when a matching key is passed as a plain object', () => {
+      const key1  = new TreePathKey(['a', 'b', 'c'], true);
+      const value = ['boop'];
+      const map   = new TreePathMap();
+
+      map.add(key1, value);
+
+      const result = map.find({ path: ['a', 'b', 'c'], wildcard: true });
+      expect(result).not.toBeNull();
+      expect(result.key).toBe(key1);
+      expect(result.keyRemainder).toBe(TreePathKey.EMPTY);
+      expect(result.value).toBe(value);
+    });
+
+    test('does not find a non-wildcard binding "below" the key being looked up', () => {
+      const key1 = new TreePathKey(['top'], false);
+      const key2 = new TreePathKey(['top', 'middle'], false);
+      const key3 = new TreePathKey(['top', 'middle', 'bottom'], true);
+      const map  = new TreePathMap();
+
+      map.add(key1, 'x');
+      map.add(key2, 'y');
+
+      const result = map.find(key3);
+      expect(result).toBeNull();
+    });
+
+    test('finds a wildcard binding "below" the key being looked up', () => {
+      const key1  = new TreePathKey(['top'], true);
+      const key2  = new TreePathKey(['top', 'middle'], false);
+      const key3  = new TreePathKey(['top', 'middle', 'bottom'], true);
+      const value = { beep: 'boop' };
+      const map   = new TreePathMap();
+
+      map.add(key1, value);
+      map.add(key2, 'y');
+
+      const result = map.find(key3);
+      expect(result).not.toBeNull();
+      expect(result.key).toBe(key1);
+      expect(result.keyRemainder.path).toStrictEqual(['middle', 'bottom']);
+      expect(result.keyRemainder.wildcard).toBeFalse();
+      expect(result.value).toBe(value);
+    });
+
+    test('finds the most-specific wildcard binding "below" the key being looked up', () => {
+      const key1  = new TreePathKey(['top'], true);
+      const key2  = new TreePathKey(['top', 'middle'], true);
+      const key3  = new TreePathKey(['top', 'middle', 'bottom'], true);
+      const value = { zeep: 'zoop' };
+      const map   = new TreePathMap();
+
+      map.add(key1, 'x');
+      map.add(key2, value);
+
+      const result = map.find(key3);
+      expect(result).not.toBeNull();
+      expect(result.key).toBe(key2);
+      expect(result.keyRemainder.path).toStrictEqual(['bottom']);
+      expect(result.keyRemainder.wildcard).toBeFalse();
+      expect(result.value).toBe(value);
+    });
+
+    test('does not find a non-wildcard, when a would-match wildcard key is passed', () => {
+      const key1  = new TreePathKey(['one', 'two'], false);
+      const key2  = new TreePathKey(['one', 'two'], true);
+      const value = ['beep'];
+      const map   = new TreePathMap();
+
+      map.add(key1, value);
+      expect(map.find(key2)).toBeNull();
+    });
+  });
+
+  describe('nullish values', () => {
+    describe.each([
+      [undefined],
+      [null],
+      [false],
+      [0],
+      [''],
+      [[]],
+      [{}]
+    ])('for %p', (value) => {
+      const key1 = new TreePathKey(['a'], true);
+      const key2 = new TreePathKey(['a'], false);
+
+      test('finds it when bound to a wildcard', () => {
+        const map = new TreePathMap();
 
         map.add(key1, value);
 
         const result1 = map.find(key1);
         expect(result1).not.toBeNull();
-        expect(result1.key).toBe(key1);
-        expect(result1.keyRemainder).toBe(TreePathKey.EMPTY);
         expect(result1.value).toBe(value);
 
         const result2 = map.find(key2);
         expect(result2).not.toBeNull();
-        expect(result2.key).toBe(key1);
-        expect(result2.keyRemainder.path).toStrictEqual(['three']);
-        expect(result2.keyRemainder.wildcard).toBeFalse();
         expect(result2.value).toBe(value);
       });
 
-      test('finds an already-added wildcard, when a matching key is passed as a plain object', () => {
-        const key1  = new TreePathKey(['a', 'b', 'c'], true);
-        const value = ['boop'];
-        const map   = new TreePathMap();
+      test('finds it when bound to a non-wildcard', () => {
+        const map = new TreePathMap();
 
-        map.add(key1, value);
-
-        const result = map.find({ path: ['a', 'b', 'c'], wildcard: true });
-        expect(result).not.toBeNull();
-        expect(result.key).toBe(key1);
-        expect(result.keyRemainder).toBe(TreePathKey.EMPTY);
-        expect(result.value).toBe(value);
-      });
-
-      test('does not find a non-wildcard binding "below" the key being looked up', () => {
-        const key1 = new TreePathKey(['top'], false);
-        const key2 = new TreePathKey(['top', 'middle'], false);
-        const key3 = new TreePathKey(['top', 'middle', 'bottom'], true);
-        const map  = new TreePathMap();
-
-        map.add(key1, 'x');
-        map.add(key2, 'y');
-
-        const result = map.find(key3);
-        expect(result).toBeNull();
-      });
-
-      test('finds a wildcard binding "below" the key being looked up', () => {
-        const key1  = new TreePathKey(['top'], true);
-        const key2  = new TreePathKey(['top', 'middle'], false);
-        const key3  = new TreePathKey(['top', 'middle', 'bottom'], true);
-        const value = { beep: 'boop' };
-        const map   = new TreePathMap();
-
-        map.add(key1, value);
-        map.add(key2, 'y');
-
-        const result = map.find(key3);
-        expect(result).not.toBeNull();
-        expect(result.key).toBe(key1);
-        expect(result.keyRemainder.path).toStrictEqual(['middle', 'bottom']);
-        expect(result.keyRemainder.wildcard).toBeFalse();
-        expect(result.value).toBe(value);
-      });
-
-      test('finds the most-specific wildcard binding "below" the key being looked up', () => {
-        const key1  = new TreePathKey(['top'], true);
-        const key2  = new TreePathKey(['top', 'middle'], true);
-        const key3  = new TreePathKey(['top', 'middle', 'bottom'], true);
-        const value = { zeep: 'zoop' };
-        const map   = new TreePathMap();
-
-        map.add(key1, 'x');
         map.add(key2, value);
 
-        const result = map.find(key3);
-        expect(result).not.toBeNull();
-        expect(result.key).toBe(key2);
-        expect(result.keyRemainder.path).toStrictEqual(['bottom']);
-        expect(result.keyRemainder.wildcard).toBeFalse();
-        expect(result.value).toBe(value);
+        const result2 = map.find(key2);
+        expect(result2).not.toBeNull();
+        expect(result2.value).toBe(value);
       });
-
-      test('does not find a non-wildcard, when a would-match wildcard key is passed', () => {
-        const key1  = new TreePathKey(['one', 'two'], false);
-        const key2  = new TreePathKey(['one', 'two'], true);
-        const value = ['beep'];
-        const map   = new TreePathMap();
-
-        map.add(key1, value);
-        expect(map.find(key2)).toBeNull();
-      });
-    });
-
-    describe('nullish values', () => {
-      describe.each([
-        [undefined],
-        [null],
-        [false],
-        [0],
-        [''],
-        [[]],
-        [{}]
-      ])('for %p', (value) => {
-        const key1 = new TreePathKey(['a'], true);
-        const key2 = new TreePathKey(['a'], false);
-
-        test('finds it when bound to a wildcard', () => {
-          const map = new TreePathMap();
-
-          map.add(key1, value);
-
-          const result1 = map.find(key1);
-          expect(result1).not.toBeNull();
-          expect(result1.value).toBe(value);
-
-          const result2 = map.find(key2);
-          expect(result2).not.toBeNull();
-          expect(result2.value).toBe(value);
-        });
-
-        test('finds it when bound to a non-wildcard', () => {
-          const map = new TreePathMap();
-
-          map.add(key2, value);
-
-          const result2 = map.find(key2);
-          expect(result2).not.toBeNull();
-          expect(result2.value).toBe(value);
-        });
-      });
-    });
-
-    test('does not produce a `next` even with multiple matches', () => {
-      const key1 = new TreePathKey([], true);
-      const key2 = new TreePathKey(['x'], true);
-      const key3 = new TreePathKey(['x', 'y'], true);
-      const key4 = new TreePathKey(['x', 'y'], false);
-
-      const map = new TreePathMap();
-      map.add(key1, 'a');
-      map.add(key2, 'b');
-      map.add(key3, 'c');
-      map.add(key4, 'd');
-
-      const result = map.find(key4);
-      expect(result).not.toBeNull();
-      expect(result).not.toContainKey('next');
-      expect(result.key).toBe(key4);
-      expect(result.value).toBe('d');
     });
   });
 
-  describe('with `wantNextChain` passed as `false`', () => {
-    test('does not produce a `next` even with multiple matches', () => {
-      const key1 = new TreePathKey([], true);
-      const key2 = new TreePathKey(['x'], true);
-      const key3 = new TreePathKey(['x', 'y'], true);
-      const key4 = new TreePathKey(['x', 'y'], false);
+  test('does not produce a `next` even with multiple matches', () => {
+    const key1 = new TreePathKey([], true);
+    const key2 = new TreePathKey(['x'], true);
+    const key3 = new TreePathKey(['x', 'y'], true);
+    const key4 = new TreePathKey(['x', 'y'], false);
 
-      const map = new TreePathMap();
-      map.add(key1, 'a');
-      map.add(key2, 'b');
-      map.add(key3, 'c');
-      map.add(key4, 'd');
+    const map = new TreePathMap();
+    map.add(key1, 'a');
+    map.add(key2, 'b');
+    map.add(key3, 'c');
+    map.add(key4, 'd');
 
-      const result = map.find(key4, false);
-      expect(result).not.toBeNull();
-      expect(result).not.toContainKey('next');
-      expect(result.key).toBe(key4);
-      expect(result.value).toBe('d');
-    });
-  });
-
-  describe('with `wantNextChain` passed as `true`', () => {
-    test('produces a `next` chain, if there are multiple matches, in the expected order', () => {
-      const key1 = new TreePathKey([], true);
-      const key2 = new TreePathKey(['x'], true);
-      const key3 = new TreePathKey(['x', 'y'], true);
-      const key4 = new TreePathKey(['x', 'y'], false);
-
-      const map = new TreePathMap();
-      map.add(key1, 'a');
-      map.add(key2, 'b');
-      map.add(key3, 'c');
-      map.add(key4, 'd');
-
-      const result = map.find(key4, true);
-      expect(result).not.toBeNull();
-      expect(result.key).toBe(key4);
-      expect(result.value).toBe('d');
-
-      expect(result.next).not.toBeUndefined();
-      expect(result.next.key).toBe(key3);
-      expect(result.next.keyRemainder.path).toStrictEqual([]);
-
-      expect(result.next.next).not.toBeUndefined();
-      expect(result.next.next.key).toBe(key2);
-      expect(result.next.next.keyRemainder.path).toStrictEqual(['y']);
-
-      expect(result.next.next.next).not.toBeUndefined();
-      expect(result.next.next.next.key).toBe(key1);
-      expect(result.next.next.next.keyRemainder.path).toStrictEqual(['x', 'y']);
-
-      expect(result.next.next.next).not.toContainKey('next');
-    });
-
-    test('does not produce a `next` if there is only one match', () => {
-      const key1 = new TreePathKey([], false);
-      const key2 = new TreePathKey(['x'], false);
-      const key3 = new TreePathKey(['x', 'y'], false);
-      const key4 = new TreePathKey(['x', 'y', 'z'], false);
-
-      const map = new TreePathMap();
-      map.add(key1, 'a');
-      map.add(key2, 'b');
-      map.add(key3, 'c');
-      map.add(key4, 'd');
-
-      const result = map.find(key3, true);
-      expect(result).not.toBeNull();
-      expect(result.key).toBe(key3);
-      expect(result.value).toBe('c');
-      expect(result).not.toContainKey('next');
-    });
-
-    test('returns `null` if there is no match', () => {
-      const key1 = new TreePathKey([], false);
-      const key2 = new TreePathKey(['x'], false);
-      const key3 = new TreePathKey(['x', 'y'], false);
-
-      const map = new TreePathMap();
-      map.add(key1, 'a');
-      map.add(key2, 'b');
-
-      const result = map.find(key3, true);
-      expect(result).toBeNull();
-    });
-
-    test('does not find a non-wildcard prefix match', () => {
-      const key1 = new TreePathKey([], true);
-      const key2 = new TreePathKey(['x'], false);
-      const key3 = new TreePathKey(['x', 'y'], true);
-
-      const map = new TreePathMap();
-      map.add(key1, 'a');
-      map.add(key2, 'b');
-      map.add(key3, 'c');
-
-      const result = map.find(key3, true);
-      expect(result).not.toBeNull();
-      expect(result.key).toBe(key3);
-      expect(result.value).toBe('c');
-
-      expect(result.next).not.toBeUndefined();
-      expect(result.next.key).toBe(key1);
-      expect(result.next.keyRemainder.path).toStrictEqual(['x', 'y']);
-
-      expect(result.next.next).toBeUndefined();
-    });
+    const result = map.find(key4);
+    expect(result).not.toBeNull();
+    expect(result).not.toContainKey('next');
+    expect(result.key).toBe(key4);
+    expect(result.value).toBe('d');
   });
 });
 

--- a/src/collections/tests/TreePathMap.test.js
+++ b/src/collections/tests/TreePathMap.test.js
@@ -556,7 +556,7 @@ describe('find()', () => {
 
 describe('findSubtree()', () => {
   test('returns an instance with the same `keyStringFunc`.', () => {
-    const ksf    = (k) => 'florp';
+    const ksf    = () => 'florp';
     const key    = new TreePathKey(['x'], true);
     const map    = new TreePathMap(ksf);
     const result = map.findSubtree(key);

--- a/src/collections/tests/TreePathMap.test.js
+++ b/src/collections/tests/TreePathMap.test.js
@@ -555,6 +555,15 @@ describe('find()', () => {
 });
 
 describe('findSubtree()', () => {
+  test('returns an instance with the same `keyStringFunc`.', () => {
+    const ksf    = (k) => 'florp';
+    const key    = new TreePathKey(['x'], true);
+    const map    = new TreePathMap(ksf);
+    const result = map.findSubtree(key);
+
+    expect(result.stringFromKey(key)).toBe('florp');
+  });
+
   describe('given an empty-path wildcard key', () => {
     const key = new TreePathKey([], true);
 


### PR DESCRIPTION
This PR fixes up a handful of items in `TreePathMap`. Most notably, it reworks `find()` with `wantNextChain == true` to be a new method `findWithFallback()`, which has a much simpler contract.