### PR TITLE
Wrangle untangle!

### DIFF
--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -3,7 +3,6 @@
 
 import { IncomingMessage, ServerResponse } from 'node:http';
 import { Http2ServerRequest, Http2ServerResponse } from 'node:http2';
-import * as net from 'node:net';
 
 import { ManualPromise, Threadlet } from '@this/async';
 import { ProductInfo } from '@this/host';

--- a/src/net-protocol/private/Http2Wrangler.js
+++ b/src/net-protocol/private/Http2Wrangler.js
@@ -80,11 +80,8 @@ export class Http2Wrangler extends TcpWrangler {
     const connectionCtx    = WranglerContext.currentInstance;
     const connectionLogger = connectionCtx.connectionLogger;
     const sessionLogger    = this.logger?.sess.$newId;
-    const sessionCtx       = WranglerContext.forSession(connectionCtx, sessionLogger);
+    const sessionCtx       = WranglerContext.forSession(connectionCtx, session, sessionLogger);
     const sessions         = this.#sessions;
-
-    WranglerContext.bind(session, sessionCtx);
-    WranglerContext.bind(session.socket, sessionCtx);
 
     connectionLogger?.newSession(sessionCtx.sessionId);
     sessionLogger?.opened({

--- a/src/net-protocol/private/Http2Wrangler.js
+++ b/src/net-protocol/private/Http2Wrangler.js
@@ -77,7 +77,7 @@ export class Http2Wrangler extends TcpWrangler {
       return;
     }
 
-    const connectionCtx    = this._prot_connectionContext;
+    const connectionCtx    = WranglerContext.currentInstance;
     const connectionLogger = connectionCtx.connectionLogger;
     const sessionLogger    = this.logger?.sess.$newId;
     const sessionCtx       = WranglerContext.forSession(connectionCtx, sessionLogger);

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -103,7 +103,6 @@ export class TcpWrangler extends ProtocolWrangler {
 
     const connLogger    = this.logger?.conn.$newId ?? null;
     const connectionCtx = WranglerContext.forConnection(this, socket, connLogger);
-    WranglerContext.bind(socket, connectionCtx);
 
     this.logger?.newConnection(connLogger.$meta.lastContext);
 
@@ -130,6 +129,7 @@ export class TcpWrangler extends ProtocolWrangler {
       }
 
       socket = this.#rateLimiter.wrapWriter(socket, connLogger);
+      WranglerContext.bind(socket, connectionCtx);
     }
 
     this.#sockets.add(socket);
@@ -199,6 +199,8 @@ export class TcpWrangler extends ProtocolWrangler {
       logClose();
     });
 
+    // Note: The `socket` we use here might either be the original incoming one
+    // _or_ one wrapped in a rate limiter.
     connectionCtx.emitInContext(this._impl_server(), 'connection', socket);
   }
 

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -11,6 +11,7 @@ import { IntfLogger } from '@this/loggy-intf';
 import { AsyncServerSocket } from '#p/AsyncServerSocket';
 import { IntfRateLimiter } from '#x/IntfRateLimiter';
 import { ProtocolWrangler } from '#x/ProtocolWrangler';
+import { WranglerContext } from '#p/WranglerContext';
 
 
 /**
@@ -100,7 +101,9 @@ export class TcpWrangler extends ProtocolWrangler {
       return;
     }
 
-    const connLogger = this.logger?.conn.$newId ?? null;
+    const connLogger    = this.logger?.conn.$newId ?? null;
+    const connectionCtx = WranglerContext.forConnection(this, socket, connLogger);
+    WranglerContext.bind(socket, connectionCtx);
 
     this.logger?.newConnection(connLogger.$meta.lastContext);
 
@@ -196,7 +199,7 @@ export class TcpWrangler extends ProtocolWrangler {
       logClose();
     });
 
-    this._prot_newConnection(socket, connLogger);
+    connectionCtx.emitInContext(this._impl_server(), 'connection', socket);
   }
 
   /**

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -129,7 +129,7 @@ export class TcpWrangler extends ProtocolWrangler {
       }
 
       socket = this.#rateLimiter.wrapWriter(socket, connLogger);
-      WranglerContext.bind(socket, connectionCtx);
+      connectionCtx.bind(socket);
     }
 
     this.#sockets.add(socket);

--- a/src/net-protocol/private/WranglerContext.js
+++ b/src/net-protocol/private/WranglerContext.js
@@ -141,6 +141,15 @@ export class WranglerContext {
   }
 
   /**
+   * Binds the given object to this instance.
+   *
+   * @param {object} obj The object to bind from.
+   */
+  bind(obj) {
+    WranglerContext.#CONTEXT_MAP.set(obj, this);
+  }
+
+  /**
    * Emits an event with an {@link AsyncLocalStorage} instance bound to this
    * instance, which can be recovered in follow-on event handlers by {@link
    * #currentInstance}.
@@ -210,23 +219,12 @@ export class WranglerContext {
   }
 
   /**
-   * Binds an instance of this class to the given external related object.
-   *
-   * @param {object} obj The object to bind from.
-   * @param {WranglerContext} context Instance of this class with salient
-   *   context.
-   */
-  static bind(obj, context) {
-    this.#CONTEXT_MAP.set(obj, context);
-  }
-
-  /**
    * Binds an arbitrary external object to the {@link #currentInstance}.
    *
    * @param {object} obj The object to bind.
    */
   static bindCurrent(obj) {
-    this.bind(obj, this.currentInstance);
+    this.currentInstance.bind(obj);
   }
 
   /**
@@ -249,7 +247,7 @@ export class WranglerContext {
       ctx.#connectionId     = logger.$meta.lastContext;
     }
 
-    this.bind(socket, ctx);
+    ctx.bind(socket);
 
     return ctx;
   }
@@ -271,8 +269,8 @@ export class WranglerContext {
       ctx.#sessionId     = logger.$meta.lastContext;
     }
 
-    this.bind(session, ctx);
-    this.bind(session.socket, ctx);
+    ctx.bind(session);
+    ctx.bind(session.socket);
 
     return ctx;
   }

--- a/src/net-protocol/private/WranglerContext.js
+++ b/src/net-protocol/private/WranglerContext.js
@@ -3,7 +3,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { EventEmitter } from 'node:events';
-import { ServerHttp2Session } from 'node:http2';
+import * as http2 from 'node:http2';
 import * as net from 'node:net';
 import * as stream from 'node:stream';
 
@@ -258,7 +258,7 @@ export class WranglerContext {
    *
    * @param {?WranglerContext} outerContext Instance of this class which has
    *   outer context (for the connection), if any.
-   * @param {ServerHttp2Session} session The session.
+   * @param {http2.ServerHttp2Session} session The session.
    * @param {?IntfLogger} logger The request logger, if any.
    * @returns {WranglerContext} An appropriately-constructed instance.
    */

--- a/src/net-protocol/private/WranglerContext.js
+++ b/src/net-protocol/private/WranglerContext.js
@@ -3,6 +3,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { EventEmitter } from 'node:events';
+import { ServerHttp2Session } from 'node:http2';
 import * as net from 'node:net';
 import * as stream from 'node:stream';
 

--- a/src/net-protocol/private/WranglerContext.js
+++ b/src/net-protocol/private/WranglerContext.js
@@ -230,7 +230,7 @@ export class WranglerContext {
   }
 
   /**
-   * Makes a new instance of this class for a connection.
+   * Makes a new instance of this class for a connection and {@link #bind}s it.
    *
    * @param {ProtocolWrangler} wrangler The wrangler instance which is managing
    *   the `socket`.
@@ -248,6 +248,8 @@ export class WranglerContext {
       ctx.#connectionLogger = logger;
       ctx.#connectionId     = logger.$meta.lastContext;
     }
+
+    this.bind(socket, ctx);
 
     return ctx;
   }

--- a/src/net-protocol/private/WranglerContext.js
+++ b/src/net-protocol/private/WranglerContext.js
@@ -255,20 +255,24 @@ export class WranglerContext {
   }
 
   /**
-   * Makes a new instance of this class for a session.
+   * Makes a new instance of this class for a session, and {@link #bind}s it.
    *
    * @param {?WranglerContext} outerContext Instance of this class which has
    *   outer context (for the connection), if any.
+   * @param {ServerHttp2Session} session The session.
    * @param {?IntfLogger} logger The request logger, if any.
    * @returns {WranglerContext} An appropriately-constructed instance.
    */
-  static forSession(outerContext, logger) {
+  static forSession(outerContext, session, logger) {
     const ctx = new WranglerContext(outerContext);
 
     if (logger) {
       ctx.#sessionLogger = logger;
       ctx.#sessionId     = logger.$meta.lastContext;
     }
+
+    this.bind(session, ctx);
+    this.bind(session.socket, ctx);
 
     return ctx;
   }


### PR DESCRIPTION
This PR cleans up a bit around how `WranglerContext` instances get bound into their environment. There was a lot of ping-pong back-and-forth between the various layers, which was kinda confusing. It's probably still too confusing, but it's at least _less_ confusing now.