### PR TITLE
Connection setup fixes and tweakage

### DIFF
--- a/src/built-ins/private/RateLimitedStream.js
+++ b/src/built-ins/private/RateLimitedStream.js
@@ -427,7 +427,7 @@ export class RateLimitedStream {
         } else {
           // The wrapper hasn't yet been closed, so recapitulate the expected
           // behavior from `Socket`, namely to `end()` the stream and then
-          // `destroy()` it.
+          // `destroy()` it once pending data has been flushed.
           this.end(() => {
             this.destroy();
           });
@@ -470,6 +470,11 @@ export class RateLimitedStream {
     constructor(outerThis) {
       super();
       this.#outerThis = outerThis;
+    }
+
+    /** @override */
+    _destroy(...args) {
+      this.#outerThis.#destroy(...args);
     }
 
     /** @override */

--- a/src/built-ins/private/RateLimitedStream.js
+++ b/src/built-ins/private/RateLimitedStream.js
@@ -182,8 +182,16 @@ export class RateLimitedStream {
    *   finished.
    */
   #destroy(error, callback) {
-    this.#innerStream.destroy(error);
-    callback();
+    // Note: We don't propagate the error to `#innerStream`, because it would
+    // just end up re-emerging as a redundant `error` event and confusing the
+    // innards of this class as well.
+    this.#innerStream.destroy();
+
+    if (error) {
+      callback(error);
+    } else {
+      callback();
+    }
   }
 
   /**

--- a/src/built-ins/private/RateLimitedStream.js
+++ b/src/built-ins/private/RateLimitedStream.js
@@ -298,10 +298,12 @@ export class RateLimitedStream {
       at += grantResult.grant;
     }
 
-    if (this.#error) {
-      setImmediate(callback, this.#error);
-    } else {
-      setImmediate(callback);
+    if (callback) {
+      if (this.#error) {
+        setImmediate(callback, this.#error);
+      } else {
+        setImmediate(callback);
+      }
     }
   }
 

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -1,7 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as timers from 'node:timers/promises';
 import { Socket } from 'node:net';
 
 import { Condition, PromiseUtil, Threadlet } from '@this/async';
@@ -145,7 +144,7 @@ export class TcpWrangler extends ProtocolWrangler {
     // without forcing the other side to close too.
     socket.once('end', async () => {
       connLogger?.remoteClosed();
-      await timers.setTimeout(TcpWrangler.#SOCKET_WAIT_TIME_AFTER_HALF_CLOSE_MSEC);
+      await WallClock.waitForMsec(TcpWrangler.#SOCKET_WAIT_TIME_AFTER_HALF_CLOSE_MSEC);
 
       // "Soon" means "after all pending data has been written and flushed."
       socket.destroySoon();

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -101,8 +101,7 @@ export class TcpWrangler extends ProtocolWrangler {
       return;
     }
 
-    const connLogger    = this.logger?.conn.$newId ?? null;
-    const connectionCtx = WranglerContext.forConnection(this, socket, connLogger);
+    const connLogger = this.logger?.conn.$newId ?? null;
 
     this.logger?.newConnection(connLogger.$meta.lastContext);
 
@@ -132,8 +131,11 @@ export class TcpWrangler extends ProtocolWrangler {
       }
 
       socket = this.#rateLimiter.wrapWriter(socket, connLogger);
-      connectionCtx.bind(socket);
     }
+
+    // We can only set up the connection context once the rate-limiter wrapping
+    // is done (if that was configured).
+    const connectionCtx = WranglerContext.forConnection(this, socket, connLogger);
 
     this.#sockets.add(socket);
     this.#anySockets.value = true;

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -121,8 +121,8 @@ export class TcpWrangler extends ProtocolWrangler {
     // is done (if that was configured). That is, `socket` at this point is
     // either the original one that came as an argument to this method _or_ the
     // rate-limiter wrapper that was just constructed.
-    const connectionCtx = WranglerContext.forConnection(this, socket, connLogger);
-    connectionCtx.emitInContext(this._impl_server(), 'connection', socket);
+    WranglerContext.forConnection(this, socket, connLogger)
+      .emitInContext(this._impl_server(), 'connection', socket);
 
     // Note: Doing a socket timeout is a good idea in general. But beyond that,
     // as of this writing, there's a bug in Node which causes it to consistently


### PR DESCRIPTION
This PR fixes a handful of problems that were discovered when working in the same areas of the code over the last few days. Notably, we used to get occasional errors during connection shutdown when the connection got closed from the remote side, which turned out to be because our (higher level) code was reäcting to the shutdown before the TLS code had a chance to shut itself down gracefully. I don't think this caused any problems in practice _except_ for spurious error reports in our logs.