### PR TITLE
Doc comment reflow

### DIFF
--- a/scripts/lib/bashy-node/node-project/reflow-jsdoc
+++ b/scripts/lib/bashy-node/node-project/reflow-jsdoc
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+# Copyright 2022-2024 the Bashy-lib Authors (Dan Bornstein et alia).
 # SPDX-License-Identifier: Apache-2.0
 
 . "$(dirname "$(readlink -f "$0")")/_init.sh" || exit "$?"
@@ -52,6 +52,12 @@ inCodeQuote {
   next;
 }
 
+# End of doc comment block.
+inDoc && /^ *[*]\/$/ {
+  autoflowLines();
+  inDoc = 0;
+}
+
 # Paragraph separator.
 inDoc && /^ *[*]$/ {
   autoflowLines();
@@ -59,14 +65,8 @@ inDoc && /^ *[*]$/ {
   next;
 }
 
-# Start of a tag. (Should be handled, but not yet implemented.)
+# Start of a block tag. (Should be handled, but not yet implemented.)
 inDoc && /^ *[*] *@/ {
-  autoflowLines();
-  inDoc = 0;
-}
-
-# End of doc comment block.
-inDoc && /^ *[*]\/$/ {
   autoflowLines();
   inDoc = 0;
 }

--- a/scripts/lib/bashy-node/node-project/reflow-jsdoc
+++ b/scripts/lib/bashy-node/node-project/reflow-jsdoc
@@ -107,7 +107,7 @@ function calcIndent(firstIndent, _locals_, result) {
 }
 
 # Emit one paragraph of comment.
-function autoflowLines(_locals_, i, line, text) {
+function autoflowLines(_locals_, curIndent, i, line, text) {
   if (count == 0) return;
 
   #print "INDENTS: <" firstIndent "> <" indent ">";
@@ -120,11 +120,13 @@ function autoflowLines(_locals_, i, line, text) {
     else text = text " " line;
   }
 
+  curIndent = firstIndent;
+
   while (text != "") {
-    if (length(text) + length(indent) <= 80) {
+    if (length(text) + length(curIndent) <= 80) {
       i = length(text);
     } else {
-      for (i = 81 - length(indent); i > 0; i--) {
+      for (i = 81 - length(curIndent); i > 0; i--) {
         if (substr(text, i, 1) == " ") break;
       }
       if (i == 0) {
@@ -137,18 +139,15 @@ function autoflowLines(_locals_, i, line, text) {
     line = substr(text, 1, i);
     sub(/^ */, "", line);
     sub(/ *$/, "", line);
-    if (firstIndent != "") {
-      print firstIndent line;
-      firstIndent = "";
-    } else {
-      print indent line;
-    }
+    print curIndent line;
+    curIndent = indent;
 
     text = substr(text, i + 1);
   }
 
   count = 0;
   indent = "";
+  firstIndent = "";
 }
 '
 

--- a/scripts/lib/bashy-node/node-project/reflow-jsdoc
+++ b/scripts/lib/bashy-node/node-project/reflow-jsdoc
@@ -74,27 +74,30 @@ inDoc && /^ *[*] *@/ {
 # Additional line in current paragraph, or possibly start of new paragraph (if
 # indentation changes; not perfect but good enough for a follow-on human pass).
 inDoc {
-  if (indent == "") {
-    indent = $0;
-    match(indent, /^[ *]* /);
-    firstIndent = substr(indent, RSTART, RLENGTH);
+  thisIndent = matchIndent($0);
+  if ((indent == "") || (indent != thisIndent)) {
+    autoflowLines();
+    firstIndent = thisIndent;
     indent = calcIndent(firstIndent);
+    indentLength = length(firstIndent);
   } else {
-    newIndent = $0;
-    match(newIndent, /^[ *]* /);
-    newIndent = substr(newIndent, RSTART, RLENGTH);
-    if (indent != newIndent) {
-      autoflowLines();
-      firstIndent = newIndent;
-      indent = calcIndent(firstIndent);
-    }
+    # Expected the-rest-indent.
+    indentLength = length(indent);
   }
-  lines[count] = $0;
+
+  lines[count] = substr($0, indentLength + 1);
   count++;
   next;
 }
 
 { print; }
+
+# Matches any of the allowed "indent" patterns (which also includes `@tag`s for
+# block tags).
+function matchIndent(line) {
+  match(line, /^[ ]* ([ *]+|@[a-zA-Z]+) +/);
+  return substr(line, RSTART, RLENGTH);
+}
 
 # Convert a first-indent into a the-rest-indent.
 function calcIndent(firstIndent, _locals_, result) {
@@ -115,7 +118,7 @@ function autoflowLines(_locals_, curIndent, i, line, text) {
   text = "";
   for (i = 0; i < count; i++) {
     line = lines[i];
-    sub(/^[ *]* /, "", line);
+    sub(/^ */, "", line);
     if (i == 0) text = line;
     else text = text " " line;
   }

--- a/scripts/lib/bashy-node/node-project/reflow-jsdoc
+++ b/scripts/lib/bashy-node/node-project/reflow-jsdoc
@@ -65,14 +65,8 @@ inDoc && /^ *[*]$/ {
   next;
 }
 
-# Start of a block tag. (Should be handled, but not yet implemented.)
-inDoc && /^ *[*] *@/ {
-  autoflowLines();
-  inDoc = 0;
-}
-
-# Additional line in current paragraph, or possibly start of new paragraph (if
-# indentation changes; not perfect but good enough for a follow-on human pass).
+# Additional line in current paragraph, or start of new paragraph (if
+# indentation changes).
 inDoc {
   thisIndent = matchIndent($0);
   if ((indent == "") || (indent != thisIndent)) {
@@ -95,7 +89,7 @@ inDoc {
 # Matches any of the allowed "indent" patterns (which also includes `@tag`s for
 # block tags).
 function matchIndent(line) {
-  match(line, /^[ ]* ([ *]+|@[a-zA-Z]+) +/);
+  match(line, /^ *[*] ([ *]*|@[a-zA-Z]+ +)/);
   return substr(line, RSTART, RLENGTH);
 }
 
@@ -105,15 +99,12 @@ function calcIndent(firstIndent, _locals_, result) {
   match(result, /^ *[*] /);
   result = substr(result, RSTART, RLENGTH);
   while (length(result) < length(firstIndent)) result = result " ";
-  #print "FIRST <" firstIndent "> REST <" result ">";
   return result;
 }
 
 # Emit one paragraph of comment.
 function autoflowLines(_locals_, curIndent, i, line, text) {
   if (count == 0) return;
-
-  #print "INDENTS: <" firstIndent "> <" indent ">";
 
   text = "";
   for (i = 0; i < count; i++) {

--- a/scripts/lib/bashy-node/node-project/reflow-jsdoc
+++ b/scripts/lib/bashy-node/node-project/reflow-jsdoc
@@ -127,7 +127,11 @@ function autoflowLines(_locals_, i, line, text) {
       for (i = 81 - length(indent); i > 0; i--) {
         if (substr(text, i, 1) == " ") break;
       }
-      if (i == 0) i = 80 - length(indent);
+      if (i == 0) {
+        # Very long word. Just emit it on its own line.
+        match(text, /^[^ ]+/);
+        i = RLENGTH;
+      }
     }
 
     line = substr(text, 1, i);

--- a/scripts/lib/bashy-node/node-project/reflow-jsdoc
+++ b/scripts/lib/bashy-node/node-project/reflow-jsdoc
@@ -1,0 +1,173 @@
+#!/bin/bash
+#
+# Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+# SPDX-License-Identifier: Apache-2.0
+
+. "$(dirname "$(readlink -f "$0")")/_init.sh" || exit "$?"
+
+
+#
+# Argument parsing
+#
+
+define-usage --with-help $'
+    ${name} [<opt> ...] <version>
+
+    Reflows all JSDoc comments in the source, in a way that is imperfect yet
+    sufficiently decent to be reasonably human-vetted.
+'
+
+process-args "$@" || exit "$?"
+
+
+#
+# Helper functions
+#
+
+# Awk script which performs reflowing on a single file.
+REFLOW_SCRIPT='
+# Start of doc comment block.
+/^ *\/[*][*]$/ {
+  inDoc = 1;
+  count = 0;
+  indent = "";
+  firstIndent = "";
+  print;
+  next;
+}
+
+# Paragraph separator.
+inDoc && /^ *[*]$/ {
+  autoflowLines();
+  print;
+  next;
+}
+
+# Start of a tag. (Should be handled, but not yet implemented.)
+inDoc && /^ *[*] *@/ {
+  autoflowLines();
+  inDoc = 0;
+}
+
+# End of doc comment block.
+inDoc && /^ *[*]\/$/ {
+  autoflowLines();
+  inDoc = 0;
+}
+
+# Additional line in current paragraph, or possibly start of new paragraph (if
+# indentation changes; not perfect but good enough for a follow-on human pass).
+inDoc {
+  if (indent == "") {
+    indent = $0;
+    match(indent, /^[ *]* /);
+    firstIndent = substr(indent, RSTART, RLENGTH);
+    indent = calcIndent(firstIndent);
+  } else {
+    newIndent = $0;
+    match(newIndent, /^[ *]* /);
+    newIndent = substr(newIndent, RSTART, RLENGTH);
+    if (indent != newIndent) {
+      autoflowLines();
+      firstIndent = newIndent;
+      indent = calcIndent(firstIndent);
+    }
+  }
+  lines[count] = $0;
+  count++;
+  next;
+}
+
+{ print; }
+
+# Convert a first-indent into a the-rest-indent.
+function calcIndent(firstIndent, _locals_, result) {
+  result = firstIndent;
+  match(result, /^ *[*] /);
+  result = substr(result, RSTART, RLENGTH);
+  while (length(result) < length(firstIndent)) result = result " ";
+  #print "FIRST <" firstIndent "> REST <" result ">";
+  return result;
+}
+
+# Emit one paragraph of comment.
+function autoflowLines(_locals_, i, line, text) {
+  if (count == 0) return;
+
+  #print "INDENTS: <" firstIndent "> <" indent ">";
+
+  text = "";
+  for (i = 0; i < count; i++) {
+    line = lines[i];
+    sub(/^[ *]* /, "", line);
+    if (i == 0) text = line;
+    else text = text " " line;
+  }
+
+  while (text != "") {
+    if (length(text) + length(indent) <= 80) {
+      i = length(text);
+    } else {
+      for (i = 81 - length(indent); i > 0; i--) {
+        if (substr(text, i, 1) == " ") break;
+      }
+      if (i == 0) i = 80 - length(indent);
+    }
+
+    line = substr(text, 1, i);
+    sub(/^ */, "", line);
+    sub(/ *$/, "", line);
+    if (firstIndent != "") {
+      print firstIndent line;
+      firstIndent = "";
+    } else {
+      print indent line;
+    }
+
+    text = substr(text, i + 1);
+  }
+
+  count = 0;
+  indent = "";
+}
+'
+
+# Processes a single file.
+function process-file {
+    local path="$1"
+
+    local origText && origText="$(cat "${path}")" \
+    || return "$?"
+
+    local fixedText && fixedText="$(awk <<<"${origText}" "${REFLOW_SCRIPT}")" \
+    || return "$?"
+
+    cat <<<"${fixedText}" >"${path}" \
+    || return "$?"
+}
+
+
+#
+# Main script
+#
+
+baseDir="$(base-dir)"
+
+sourceArray="$(
+    lib buildy ls-files --output=array --full-paths --include='\.(js|mjs|cjs)'
+)" \
+|| exit "$?"
+
+jset-array --raw sources "${sourceArray}" \
+|| exit "$?"
+
+for file in "${sources[@]}"; do
+    progress-msg "${file}..."
+    process-file "${file}" \
+    || {
+        error-msg "Trouble processing file: ${file}"
+        exit 1
+    }
+done
+
+progress-msg 'Done!'

--- a/scripts/lib/bashy-node/node-project/reflow-jsdoc
+++ b/scripts/lib/bashy-node/node-project/reflow-jsdoc
@@ -36,6 +36,22 @@ REFLOW_SCRIPT='
   next;
 }
 
+# Code quote block: Suppress!
+inDoc && /^ *[*] ```/ {
+  if (inCodeQuote) {
+    inCodeQuote = 0;
+    print;
+    next;
+  } else {
+    autoflowLines();
+    inCodeQuote = 1;
+  }
+}
+inCodeQuote {
+  print;
+  next;
+}
+
 # Paragraph separator.
 inDoc && /^ *[*]$/ {
   autoflowLines();

--- a/src/async/export/Condition.js
+++ b/src/async/export/Condition.js
@@ -75,9 +75,9 @@ export class Condition {
   }
 
   /**
-   * Instantaneously switches the condition to `true` and then immediately
-   * back to `false`. This will cause all promises to resolve, no matter which
-   * state they were waiting for.
+   * Instantaneously switches the condition to `true` and then immediately back
+   * to `false`. This will cause all promises to resolve, no matter which state
+   * they were waiting for.
    */
   onOff() {
     this.value = true;

--- a/src/async/export/EventSink.js
+++ b/src/async/export/EventSink.js
@@ -9,11 +9,11 @@ import { Threadlet } from '#x/Threadlet';
 
 
 /**
- * Event sink for {@link LinkedEvent}. Instances of this class "consume"
- * events, calling on a specified processing function for each. Instances can be
- * started and stopped (this class is a sublcass of {@link Threadlet}), and
- * while running they are always either processing existing events or waiting
- * for new events to be emitted on the chain they track.
+ * Event sink for {@link LinkedEvent}. Instances of this class "consume" events,
+ * calling on a specified processing function for each. Instances can be started
+ * and stopped (this class is a sublcass of {@link Threadlet}), and while
+ * running they are always either processing existing events or waiting for new
+ * events to be emitted on the chain they track.
  */
 export class EventSink extends Threadlet {
   /**
@@ -24,16 +24,15 @@ export class EventSink extends Threadlet {
   #processor;
 
   /**
-   * Head of the event chain, representing the earliest
-   * event which has not yet been processed.
+   * Head of the event chain, representing the earliest event which has not yet
+   * been processed.
    *
    * @type {EventOrPromise}
    */
   #head;
 
   /**
-   * Is this instance eagerly "draining" all synchronously-known
-   * events?
+   * Is this instance eagerly "draining" all synchronously-known events?
    *
    * @type {boolean}
    */

--- a/src/async/export/EventSource.js
+++ b/src/async/export/EventSource.js
@@ -8,8 +8,8 @@ import { LinkedEvent } from '#x/LinkedEvent';
 
 
 /**
- * Event source for a chain of {@link LinkedEvent} instances. It is instances
- * of this class which are generally set up to manage and add new events to a
+ * Event source for a chain of {@link LinkedEvent} instances. It is instances of
+ * this class which are generally set up to manage and add new events to a
  * chain, that is, this class represents the authority to emit events on a
  * particular chain (as opposed to it being functionality exposed on
  * `LinkedEvent` itself).
@@ -35,9 +35,9 @@ import { LinkedEvent } from '#x/LinkedEvent';
  */
 export class EventSource {
   /**
-   * The number of already-emitted events to keep track of,
-   * not including the one referenced by {@link #currentEvent}. If infinite,
-   * then this instance keeps the entire event chain.
+   * The number of already-emitted events to keep track of, not including the
+   * one referenced by {@link #currentEvent}. If infinite, then this instance
+   * keeps the entire event chain.
    *
    * @type {number}
    */
@@ -51,29 +51,28 @@ export class EventSource {
   #emittedCount = 0;
 
   /**
-   * Earliest (furthest in the past) event emitted by this
-   * instance which is intentionally being kept by this instance. If this
-   * instance has never emitted, then -- as with {@link #currentEvent} -- this
-   * is the kickoff event. If this instance isn't keeping any history, then this
-   * is always going to be the same as {@link #currentEvent}.
+   * Earliest (furthest in the past) event emitted by this instance which is
+   * intentionally being kept by this instance. If this instance has never
+   * emitted, then -- as with {@link #currentEvent} -- this is the kickoff
+   * event. If this instance isn't keeping any history, then this is always
+   * going to be the same as {@link #currentEvent}.
    *
    * @type {LinkedEvent}
    */
   #earliestEvent;
 
   /**
-   * Current (Latest / most recent) event emitted by this
-   * instance. If this instance has never emitted, this is an initial "kickoff
-   * event" which is suitable for `await`ing in {@link #currentEvent}. (This
-   * arrangement makes the logic in {@link #emit} particularly simple.)
+   * Current (Latest / most recent) event emitted by this instance. If this
+   * instance has never emitted, this is an initial "kickoff event" which is
+   * suitable for `await`ing in {@link #currentEvent}. (This arrangement makes
+   * the logic in {@link #emit} particularly simple.)
    *
    * @type {LinkedEvent}
    */
   #currentEvent;
 
   /**
-   * Function to call in order to emit the next event on the
-   * chain.
+   * Function to call in order to emit the next event on the chain.
    *
    * @type {function(*)}
    */

--- a/src/async/export/EventSource.js
+++ b/src/async/export/EventSource.js
@@ -83,8 +83,8 @@ export class EventSource {
    *
    * @param {?object} [options] Construction options.
    * @param {number} [options.keepCount] Number of past events to keep
-   *   (remember), not including the current (most-recently emitted) event.
-   *   Must be a whole number or positive infinity.
+   *   (remember), not including the current (most-recently emitted) event. Must
+   *   be a whole number or positive infinity.
    * @param {?LinkedEvent} [options.kickoffEvent] "Kickoff" event, or
    *   `null` to use `options.kickoffPayload` (below). It is not valid to
    *   specify both this and `kickoffPayload`.

--- a/src/async/export/EventTracker.js
+++ b/src/async/export/EventTracker.js
@@ -46,9 +46,8 @@ import { TypeEventPredicate } from '#x/TypeEventPredicate';
  */
 export class EventTracker {
   /**
-   * Head of (the first event on) the chain. This also
-   * represents an instance of this class being broken by itself being in a
-   * "rejected" state.
+   * Head of (the first event on) the chain. This also represents an instance of
+   * this class being broken by itself being in a "rejected" state.
    *
    * @type {EventOrPromise}
    */
@@ -96,8 +95,8 @@ export class EventTracker {
    *
    * Though this method is `async`, if the request can be satisfied
    * synchronously, it will. In such cases, the return value will still be a
-   * promise (as it must be given this method is declared `async`), but
-   * {@link #headNow} will synchronously reflect the updated state of affairs.
+   * promise (as it must be given this method is declared `async`), but {@link
+   * #headNow} will synchronously reflect the updated state of affairs.
    *
    * **Note:** If the predicate throws an error -- even synchronously -- the
    * error becomes manifest by the state of the instance becoming broken.
@@ -335,24 +334,22 @@ export class EventTracker {
  */
 class AdvanceAction {
   /**
-   * Event chain head from the perspective of the
-   * in-progress operation.
+   * Event chain head from the perspective of the in-progress operation.
    *
    * @type {EventOrPromise}
    */
   #head;
 
   /**
-   * Predicate which an event needs to
-   * satisfy, for the operation to be considered complete.
+   * Predicate which an event needs to satisfy, for the operation to be
+   * considered complete.
    *
    * @type {function(LinkedEvent): boolean}
    */
   #predicate;
 
   /**
-   * Ultimate result of this operation, if indeed it has
-   * completed.
+   * Ultimate result of this operation, if indeed it has completed.
    *
    * @type {?EventOrPromise}
    */

--- a/src/async/export/LinkedEvent.js
+++ b/src/async/export/LinkedEvent.js
@@ -35,8 +35,8 @@ export class LinkedEvent {
   #payload;
 
   /**
-   * Next event in the chain, if there is in fact either
-   * a concrete next event or promise for same.
+   * Next event in the chain, if there is in fact either a concrete next event
+   * or promise for same.
    *
    * @type {?EventOrPromise}
    */
@@ -50,9 +50,9 @@ export class LinkedEvent {
   #hasEmitter;
 
   /**
-   * Function which can be called to resolve the (promise
-   * inside the) value of {@link #next}. `null` if {@link #next} is itself
-   * `null` _or_ if the resolver got used.
+   * Function which can be called to resolve the (promise inside the) value of
+   * {@link #next}. `null` if {@link #next} is itself `null` _or_ if the
+   * resolver got used.
    *
    * @type {?function(*)}
    */

--- a/src/async/export/ManualPromise.js
+++ b/src/async/export/ManualPromise.js
@@ -90,8 +90,8 @@ export class ManualPromise {
   }
 
   /**
-   * Gets an indicator of whether or not the underlying promise has been
-   * settled as fulfilled.
+   * Gets an indicator of whether or not the underlying promise has been settled
+   * as fulfilled.
    *
    * @returns {boolean} Whenter (`true`) or not (`false`) the underlying
    *   promise is settled as fulfilled.
@@ -101,8 +101,8 @@ export class ManualPromise {
   }
 
   /**
-   * Gets an indicator of whether or not the underlying promise has been
-   * settled as rejected.
+   * Gets an indicator of whether or not the underlying promise has been settled
+   * as rejected.
    *
    * @returns {boolean} Whenter (`true`) or not (`false`) the underlying
    *   promise is settled as rejected.
@@ -112,8 +112,8 @@ export class ManualPromise {
   }
 
   /**
-   * Gets an indicator of whether or not the underlying promise has been
-   * settled (either as fulfilled or rejected).
+   * Gets an indicator of whether or not the underlying promise has been settled
+   * (either as fulfilled or rejected).
    *
    * @returns {boolean} Whenter (`true`) or not (`false`) the underlying
    *   promise is settled.

--- a/src/async/export/Mutex.js
+++ b/src/async/export/Mutex.js
@@ -13,18 +13,17 @@ import { ManualPromise } from '#x/ManualPromise';
  */
 export class Mutex {
   /**
-   * Unique symbol representing the current lock holder, or
-   * `null` if the lock is not currently held. This symbol serves as the "key"
-   * for unlocking, such that only the current lock holder can unlock the
-   * instance.
+   * Unique symbol representing the current lock holder, or `null` if the lock
+   * is not currently held. This symbol serves as the "key" for unlocking, such
+   * that only the current lock holder can unlock the instance.
    *
    * @type {?symbol}
    */
   #lockedBy = null;
 
   /**
-   * Array of "release" functions, each of which
-   * represents a waiters for lock acquisition, in FIFO order.
+   * Array of "release" functions, each of which represents a waiters for lock
+   * acquisition, in FIFO order.
    *
    * @type {Array<function()>}
    */

--- a/src/async/export/PromiseUtil.js
+++ b/src/async/export/PromiseUtil.js
@@ -9,11 +9,11 @@ import { MustBe } from '@this/typey';
  */
 export class PromiseUtil {
   /**
-   * Weak map, which links contenders passed to {@link #race} to all
-   * the races those contenders are involved in, along with a `settled` flag
-   * indicating the promise state of the contender. (Note: When an
-   * already-settled contender is first added to the map, its `settled` flag
-   * will be incorrect until the immediately-subsequent `await`.)
+   * Weak map, which links contenders passed to {@link #race} to all the races
+   * those contenders are involved in, along with a `settled` flag indicating
+   * the promise state of the contender. (Note: When an already-settled
+   * contender is first added to the map, its `settled` flag will be incorrect
+   * until the immediately-subsequent `await`.)
    *
    * @type {WeakMap<Promise, {races: Set<{resolve, reject}>, settled: boolean}>}
    */

--- a/src/async/export/Threadlet.js
+++ b/src/async/export/Threadlet.js
@@ -32,34 +32,33 @@ export class Threadlet {
   #mainFunction;
 
   /**
-   * Intended current state of whether or not this instance is
-   * running.
+   * Intended current state of whether or not this instance is running.
    *
    * @type {Condition}
    */
   #runCondition = new Condition();
 
   /**
-   * Promised result of the currently-executing {@link #run},
-   * if the instance is currently running.
+   * Promised result of the currently-executing {@link #run}, if the instance is
+   * currently running.
    *
    * @type {?Promise}
    */
   #runResult = null;
 
   /**
-   * Promised result of calling {@link #start}, if the instance
-   * is currently running (at all, not just in the start function). `null` if
-   * not running or if the instance doesn't have a start function.
+   * Promised result of calling {@link #start}, if the instance is currently
+   * running (at all, not just in the start function). `null` if not running or
+   * if the instance doesn't have a start function.
    *
    * @type {?Promise}
    */
   #startResult = null;
 
   /**
-   * Has the current {@link #runResult} been returned "publicly"
-   * from this instance? This is used to figure out whether to force a failed
-   * run to become an unhandled promise rejection.
+   * Has the current {@link #runResult} been returned "publicly" from this
+   * instance? This is used to figure out whether to force a failed run to
+   * become an unhandled promise rejection.
    *
    * @type {boolean}
    */
@@ -204,13 +203,12 @@ export class Threadlet {
   }
 
   /**
-   * Gets a promise that becomes settled when this instance is running and
-   * after its start function has completed. It becomes _fulfilled_ with the
-   * result of calling the start function, if the start function returned
-   * without error. It becomes _rejected_ with the same reason as whatever the
-   * start function threw, if the start function indeed threw an error. If
-   * `isRunning() === false` when this method is called, it async-returns
-   * `null` promptly.
+   * Gets a promise that becomes settled when this instance is running and after
+   * its start function has completed. It becomes _fulfilled_ with the result of
+   * calling the start function, if the start function returned without error.
+   * It becomes _rejected_ with the same reason as whatever the start function
+   * threw, if the start function indeed threw an error. If `isRunning() ===
+   * false` when this method is called, it async-returns `null` promptly.
    *
    * @returns {*} Whatever was returned by the start function, with exceptions
    *   as noted above.
@@ -237,8 +235,8 @@ export class Threadlet {
   }
 
   /**
-   * Properly wraps a function so it can be called with no arguments in
-   * {@link #run}.
+   * Properly wraps a function so it can be called with no arguments in {@link
+   * #run}.
    *
    * @param {function(*)} func Function to wrap.
    * @returns {function(*)} Wrapped version.

--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -28,8 +28,8 @@ import { Threadlet } from '#x/Threadlet';
  */
 export class TokenBucket {
   /**
-   * Maximum allowed instantaneous burst, in tokens. This is the
-   * "bucket capacity" in the "leaky bucket as meter" metaphor.
+   * Maximum allowed instantaneous burst, in tokens. This is the "bucket
+   * capacity" in the "leaky bucket as meter" metaphor.
    *
    * @type {number}
    */
@@ -50,9 +50,9 @@ export class TokenBucket {
   #maxQueueGrantSize;
 
   /**
-   * The maximum allowed wait queue size, in tokens. That is,
-   * this is the sum of all grants to be made from waiters in the queue.
-   * `Number.POSITIVE_INFINITY` is used represent "no limit."
+   * The maximum allowed wait queue size, in tokens. That is, this is the sum of
+   * all grants to be made from waiters in the queue. `Number.POSITIVE_INFINITY`
+   * is used represent "no limit."
    *
    * @type {number}
    */
@@ -234,8 +234,8 @@ export class TokenBucket {
    *   is, the quantity of tokens currently in the bucket.
    * * `{number} availableQueueSize` -- The currently-available queue size, that
    *   is, the quantity of tokens that could potentially be reserved for new
-   *   grant waiters. If this instance has no limit on the queue size, then
-   *   this is `Number.POSITIVE_INFINITY`.
+   *   grant waiters. If this instance has no limit on the queue size, then this
+   *   is `Number.POSITIVE_INFINITY`.
    * * `{Moment} now` -- The time as of the snapshot, according to this
    *   instance's time source.
    * * `{number} waiterCount` -- The number of queued (awaited) grant requests.
@@ -268,8 +268,8 @@ export class TokenBucket {
    * * `{number} maxInclusive` -- Maximum quantity of tokens to be granted.
    *   Defaults to `0`. Invalid if negative, and clamped to `minInclusive` as a
    *   minimum. If this instance was constructed with `partialTokens === false`,
-   *   then it is rounded down (`Math.floor()`) when not a whole number. This
-   *   is allowed to be larger than `maxBurstSize`, but this method will never
+   *   then it is rounded down (`Math.floor()`) when not a whole number. This is
+   *   allowed to be larger than `maxBurstSize`, but this method will never
    *   actually grant more than that.
    *
    * The actual granting of tokens proceeds as follows (in order):
@@ -277,20 +277,20 @@ export class TokenBucket {
    * * If there is no contention (no queued waiters) and the available burst
    *   size can accommodate a grant of at least `minInclusive` tokens, then this
    *   method promptly succeeds with the maximum-possible requested grant.
-   * * If `minInclusive` is `0`, then this method promptly succeeds with a
-   *   grant of `0` tokens.
+   * * If `minInclusive` is `0`, then this method promptly succeeds with a grant
+   *   of `0` tokens.
    * * If there is insufficient available waiter queue size to accommodate a
    *   grant of at least `minInclusive`, then this method promptly fails, with
    *   `done === false` and a grant of `0` tokens.
-   * * The request is queued up as an awaited grant. When the request is
-   *   finally dequeued, the grant will be for the smaller of `maxInclusive` or
+   * * The request is queued up as an awaited grant. When the request is finally
+   *   dequeued, the grant will be for the smaller of `maxInclusive` or
    *   `maxQueueGrantSize` tokens (even if the available burst size happens to
    *   be larger at the moment of granting).
    *
    * This method returns an object with bindings as follows:
    *
-   * * `{boolean} done` -- `true` if the grant was actually made. This can be
-   *   be `true` even if `grant === 0`, in the case where the minimum requested
+   * * `{boolean} done` -- `true` if the grant was actually made. This can be be
+   *   `true` even if `grant === 0`, in the case where the minimum requested
    *   grant is in fact `0`.
    * * `{number} grant` -- The quantity of tokens granted to the caller. This is
    *   `0` if `done === false`, and can also be a successful grant of `0`, if
@@ -371,8 +371,8 @@ export class TokenBucket {
    * * `{number} maxInclusive` -- Maximum quantity of tokens to be granted.
    *   Defaults to `0`. Invalid if negative, and clamped to `minInclusive` as a
    *   minimum. If this instance was constructed with `partialTokens === false`,
-   *   then it is rounded down (`Math.floor()`) when not a whole number. This
-   *   is allowed to be larger than `maxBurstSize`, but this method will never
+   *   then it is rounded down (`Math.floor()`) when not a whole number. This is
+   *   allowed to be larger than `maxBurstSize`, but this method will never
    *   actually grant more than that.
    *
    * This method returns an object with bindings as follows:
@@ -382,11 +382,11 @@ export class TokenBucket {
    *   grant is in fact `0`.
    * * `{number} grant` -- The quantity of tokens granted to the caller. This is
    *   `0` if the minimum requested grant cannot be made.
-   * * `{Moment} waitUntil` -- The time to `waitUntil()` on this instance's
-   *   time source until the request would be expected to be granted, if this
-   *   were an asynchronously-requested grant, as if by {@link #requestGrant}
-   *   (see which). If `done === true`, then this will be a time at or before
-   *   the time source's `now()`.
+   * * `{Moment} waitUntil` -- The time to `waitUntil()` on this instance's time
+   *   source until the request would be expected to be granted, if this were an
+   *   asynchronously-requested grant, as if by {@link #requestGrant} (see
+   *   which). If `done === true`, then this will be a time at or before the
+   *   time source's `now()`.
    *
    * If the `minInclusive` request is non-zero, then this method will only ever
    * return `done === true` if there is no immediate contention for tokens

--- a/src/async/private/EventOrPromise.js
+++ b/src/async/private/EventOrPromise.js
@@ -19,17 +19,16 @@ export class EventOrPromise {
   #eventNow;
 
   /**
-   * Promise for {@link #eventNow}, when that
-   * property isn't synchronously known _or_ when it's known but something has
-   * asked for the promise anyway.
+   * Promise for {@link #eventNow}, when that property isn't synchronously known
+   * _or_ when it's known but something has asked for the promise anyway.
    *
    * @type {?Promise<LinkedEvent>}
    */
   #eventPromise;
 
   /**
-   * The reason why {@link #eventPromise} was rejected, if it was
-   * indeed rejected.
+   * The reason why {@link #eventPromise} was rejected, if it was indeed
+   * rejected.
    *
    * @type {?Error}
    */
@@ -200,8 +199,7 @@ export class EventOrPromise {
 
   /**
    * Checks an alleged event instance to see if it is (a) actually an instance
-   * of `LinkedEvent` and optionally an instance of a specific subclass
-   * thereof.
+   * of `LinkedEvent` and optionally an instance of a specific subclass thereof.
    *
    * @param {LinkedEvent} event The event in question.
    * @param {?function(new:LinkedEvent)} subclass Class to check for, or `null`

--- a/src/async/private/EventOrPromise.js
+++ b/src/async/private/EventOrPromise.js
@@ -83,8 +83,8 @@ export class EventOrPromise {
    * cases _except_ when this instance was constructed with a promise and that
    * promise has yet to settle. This class guarantees that, if this promise is
    * fulfilled (not rejected), then it will indeed be an instance of {@link
-   * LinkedEvent}. This class also guarantees that, if this promise is
-   * rejected, then {@link #rejectedReason} is non-`null`.
+   * LinkedEvent}. This class also guarantees that, if this promise is rejected,
+   * then {@link #rejectedReason} is non-`null`.
    */
   get eventPromise() {
     if (this.#eventPromise === null) {

--- a/src/built-ins/export/HostRouter.js
+++ b/src/built-ins/export/HostRouter.js
@@ -14,9 +14,9 @@ import { MustBe } from '@this/typey';
  */
 export class HostRouter extends BaseApplication {
   /**
-   * Map which goes from a host prefix
-   * to a handler (typically a {@link BaseApplication}) which should handle that
-   * prefix. Gets set in {@link #_impl_start}.
+   * Map which goes from a host prefix to a handler (typically a {@link
+   * BaseApplication}) which should handle that prefix. Gets set in {@link
+   * #_impl_start}.
    *
    * @type {?TreePathMap<IntfRequestHandler>}
    */
@@ -90,8 +90,8 @@ export class HostRouter extends BaseApplication {
    */
   static #Config = class Config extends BaseApplication.FilterConfig {
     /**
-     * Like the outer `routeTree` except with names
-     * instead of handler instances.
+     * Like the outer `routeTree` except with names instead of handler
+     * instances.
      *
      * @type {TreePathMap<string>}
      */

--- a/src/built-ins/export/MemoryMonitor.js
+++ b/src/built-ins/export/MemoryMonitor.js
@@ -27,8 +27,8 @@ export class MemoryMonitor extends BaseService {
   #runner = new Threadlet(() => this.#run());
 
   /**
-   * Most recent memory snapshot (along with timing info),
-   * or `null` if a snapshot has not yet been taken.
+   * Most recent memory snapshot (along with timing info), or `null` if a
+   * snapshot has not yet been taken.
    *
    * @type {?{ heap: number, rss: number, at: Moment, troubleAt: ?Duration,
    * actionAt: ?Moment }}
@@ -143,16 +143,16 @@ export class MemoryMonitor extends BaseService {
   //
 
   /**
-   * Minimum amount of time in msec between checks, when dealing
-   * with an "over limit" situation.
+   * Minimum amount of time in msec between checks, when dealing with an "over
+   * limit" situation.
    *
    * @type {number}
    */
   static #MIN_TROUBLE_CHECK_MSEC = 1000;
 
   /**
-   * Fraction of time between "now" and when action needs to
-   * happen, when the next check should take place in an "over limit" situation.
+   * Fraction of time between "now" and when action needs to happen, when the
+   * next check should take place in an "over limit" situation.
    *
    * @type {number}
    */

--- a/src/built-ins/export/PathRouter.js
+++ b/src/built-ins/export/PathRouter.js
@@ -15,9 +15,9 @@ import { MustBe } from '@this/typey';
  */
 export class PathRouter extends BaseApplication {
   /**
-   * Map which goes from a path prefix
-   * to a handler (typically a {@link BaseApplication}) which should handle that
-   * prefix. Gets set in {@link #_impl_start}.
+   * Map which goes from a path prefix to a handler (typically a {@link
+   * BaseApplication}) which should handle that prefix. Gets set in {@link
+   * #_impl_start}.
    *
    * @type {?TreePathMap<IntfRequestHandler>}
    */
@@ -96,8 +96,8 @@ export class PathRouter extends BaseApplication {
    */
   static #Config = class Config extends BaseApplication.FilterConfig {
     /**
-     * Like the outer `routeTree` except with names
-     * instead of handler instances.
+     * Like the outer `routeTree` except with names instead of handler
+     * instances.
      *
      * @type {TreePathMap<string>}
      */

--- a/src/built-ins/export/ProcessIdFile.js
+++ b/src/built-ins/export/ProcessIdFile.js
@@ -230,8 +230,7 @@ export class ProcessIdFile extends BaseFileService {
     #multiprocess;
 
     /**
-     * How often to update the info file, or `null` to not
-     * perform updates.
+     * How often to update the info file, or `null` to not perform updates.
      *
      * @type {?Duration}
      */

--- a/src/built-ins/export/ProcessInfoFile.js
+++ b/src/built-ins/export/ProcessInfoFile.js
@@ -304,8 +304,7 @@ export class ProcessInfoFile extends BaseFileService {
    */
   static #Config = class Config extends FileServiceConfig {
     /**
-     * How often to update the info file, or `null` to not
-     * perform updates.
+     * How often to update the info file, or `null` to not perform updates.
      *
      * @type {?Duration}
      */

--- a/src/built-ins/export/Redirector.js
+++ b/src/built-ins/export/Redirector.js
@@ -27,8 +27,7 @@ export class Redirector extends BaseApplication {
   #target;
 
   /**
-   * `cache-control` header to automatically include, or
-   * `null` not to do that.
+   * `cache-control` header to automatically include, or `null` not to do that.
    *
    * @type {?string}
    */
@@ -105,8 +104,8 @@ export class Redirector extends BaseApplication {
     #target;
 
     /**
-     * `cache-control` header to automatically include, or
-     * `null` not to do that.
+     * `cache-control` header to automatically include, or `null` not to do
+     * that.
      *
      * @type {?string}
      */

--- a/src/built-ins/export/SerialRouter.js
+++ b/src/built-ins/export/SerialRouter.js
@@ -14,8 +14,8 @@ import { MustBe } from '@this/typey';
  */
 export class SerialRouter extends BaseApplication {
   /**
-   * List of handlers (typically instances of
-   * {@link BaseApplication}) to route to. Gets set in {@link #_impl_start}.
+   * List of handlers (typically instances of {@link BaseApplication}) to route
+   * to. Gets set in {@link #_impl_start}.
    *
    * @type {Array<IntfRequestHandler>}
    */
@@ -81,8 +81,8 @@ export class SerialRouter extends BaseApplication {
    */
   static #Config = class Config extends BaseApplication.FilterConfig {
     /**
-     * Like the outer `routeList` except with names
-     * instead of application instances.
+     * Like the outer `routeList` except with names instead of application
+     * instances.
      *
      * @type {Array<string>}
      */

--- a/src/built-ins/export/SimpleResponse.js
+++ b/src/built-ins/export/SimpleResponse.js
@@ -23,8 +23,7 @@ export class SimpleResponse extends BaseApplication {
   #allowAdjustment = true;
 
   /**
-   * Response template to clone for all actual
-   * responses.
+   * Response template to clone for all actual responses.
    *
    * @type {OutgoingResponse}
    */
@@ -123,32 +122,31 @@ export class SimpleResponse extends BaseApplication {
    */
   static #Config = class Config extends BaseApplication.FilterConfig {
     /**
-     * Predefined status code of the response, or `null` to use
-     * the most appropriate "success" status code (most typically `200`).
+     * Predefined status code of the response, or `null` to use the most
+     * appropriate "success" status code (most typically `200`).
      *
      * @type {?number}
      */
     #statusCode = null;
 
     /**
-     * Content type of the response, or `null` to infer it from
-     * {@link #filePath}.
+     * Content type of the response, or `null` to infer it from {@link
+     * #filePath}.
      *
      * @type {?string}
      */
     #contentType = null;
 
     /**
-     * Body contents of the response, or `null` to
-     * use {@link #filePath}.
+     * Body contents of the response, or `null` to use {@link #filePath}.
      *
      * @type {?(string|Buffer)}
      */
     #body = null;
 
     /**
-     * `cache-control` header to automatically include, or
-     * `null` not to do that.
+     * `cache-control` header to automatically include, or `null` not to do
+     * that.
      *
      * @type {?string}
      */
@@ -162,8 +160,8 @@ export class SimpleResponse extends BaseApplication {
     #etagOptions = null;
 
     /**
-     * Absolute path to a file for the body contents, or `null`
-     * if {@link #body} is supplied directly.
+     * Absolute path to a file for the body contents, or `null` if {@link #body}
+     * is supplied directly.
      *
      * @type {?string}
      */
@@ -278,8 +276,8 @@ export class SimpleResponse extends BaseApplication {
     }
 
     /**
-     * Predefined status code of the response, or `null` to use
-     * the most appropriate "success" status code (most typically `200`).
+     * Predefined status code of the response, or `null` to use the most
+     * appropriate "success" status code (most typically `200`).
      *
      * @type {?number}
      */

--- a/src/built-ins/export/StaticFiles.js
+++ b/src/built-ins/export/StaticFiles.js
@@ -16,8 +16,8 @@ import { BaseApplication } from '@this/sys-framework';
  */
 export class StaticFiles extends BaseApplication {
   /**
-   * Path to the file to serve for a not-found result, or
-   * `null` if not-found handling shouldn't be done.
+   * Path to the file to serve for a not-found result, or `null` if not-found
+   * handling shouldn't be done.
    *
    * @type {?string}
    */
@@ -31,8 +31,7 @@ export class StaticFiles extends BaseApplication {
   #siteDirectory;
 
   /**
-   * `cache-control` header to automatically include, or
-   * `null` not to do that.
+   * `cache-control` header to automatically include, or `null` not to do that.
    *
    * @type {?string}
    */
@@ -46,8 +45,8 @@ export class StaticFiles extends BaseApplication {
   #etagGenerator = null;
 
   /**
-   * Not-found response to issue, or `null` if either
-   * not yet calculated or if this instance isn't handling not-found errors.
+   * Not-found response to issue, or `null` if either not yet calculated or if
+   * this instance isn't handling not-found errors.
    *
    * @type {?OutgoingResponse}
    */
@@ -271,8 +270,8 @@ export class StaticFiles extends BaseApplication {
    */
   static #Config = class Config extends BaseApplication.FilterConfig {
     /**
-     * Path to the file to serve for a not-found result, or
-     * `null` if not-found handling shouldn't be done.
+     * Path to the file to serve for a not-found result, or `null` if not-found
+     * handling shouldn't be done.
      *
      * @type {?string}
      */
@@ -286,16 +285,15 @@ export class StaticFiles extends BaseApplication {
     #siteDirectory;
 
     /**
-     * `cache-control` header to automatically include, or
-     * `null` not to do that.
+     * `cache-control` header to automatically include, or `null` not to do
+     * that.
      *
      * @type {?string}
      */
     #cacheControl = null;
 
     /**
-     * Etag configuration options, or `null` not to generate
-     * etags.
+     * Etag configuration options, or `null` not to generate etags.
      *
      * @type {?object}
      */

--- a/src/built-ins/export/SystemLogger.js
+++ b/src/built-ins/export/SystemLogger.js
@@ -23,8 +23,7 @@ export class SystemLogger extends BaseFileService {
   #rotator = null;
 
   /**
-   * Event sink which does the actual writing, or `null`
-   * if not yet set up.
+   * Event sink which does the actual writing, or `null` if not yet set up.
    *
    * @type {?TextFileSink}
    */
@@ -86,10 +85,10 @@ export class SystemLogger extends BaseFileService {
   }
 
   /**
-   * Figures out which event to actually write out first. When a system is
-   * first starting up, this will be the actual earliest recored event. However,
-   * in the case of a same-process restart, this method attempts to find the
-   * event just after the last one expected to have been logged by a predecessor
+   * Figures out which event to actually write out first. When a system is first
+   * starting up, this will be the actual earliest recored event. However, in
+   * the case of a same-process restart, this method attempts to find the event
+   * just after the last one expected to have been logged by a predecessor
    * instance.
    *
    * @returns {LinkedEvent|Promise<LinkedEvent>} First event to log.

--- a/src/built-ins/private/RateLimitedStream.js
+++ b/src/built-ins/private/RateLimitedStream.js
@@ -53,8 +53,8 @@ export class RateLimitedStream {
   #bytesWritten = 0;
 
   /**
-   * Error received via `error` event from {@link #innerStream}
-   * or produced internally, if any.
+   * Error received via `error` event from {@link #innerStream} or produced
+   * internally, if any.
    *
    * @type {?Error}
    */
@@ -244,8 +244,8 @@ export class RateLimitedStream {
   }
 
   /**
-   * Handles the `end` event from the inner stream, which is an indication
-   * that the reading side has closed.
+   * Handles the `end` event from the inner stream, which is an indication that
+   * the reading side has closed.
    */
   #readableOnEnd() {
     // `push(null)` is the spec-defined way to indicate to a `Readable` wrapper
@@ -263,8 +263,8 @@ export class RateLimitedStream {
   }
 
   /**
-   * Handles the `close` event from the inner stream, which indicates that
-   * (for any number of reasons) the writing side of the stream has closed.
+   * Handles the `close` event from the inner stream, which indicates that (for
+   * any number of reasons) the writing side of the stream has closed.
    */
   #writableOnClose() {
     this.#logger?.writableClose();

--- a/src/clocks/export/StdTimeSource.js
+++ b/src/clocks/export/StdTimeSource.js
@@ -6,8 +6,8 @@ import { WallClock } from '#x/WallClock';
 
 
 /**
- * Standard implementation of {@link #IntfTimeSource}, which uses
- * {@link WallClock} as the underlying source of time.
+ * Standard implementation of {@link #IntfTimeSource}, which uses {@link
+ * WallClock} as the underlying source of time.
  */
 export class StdTimeSource extends IntfTimeSource {
   // Note: The default constructor is fine.

--- a/src/clocks/export/WallClock.js
+++ b/src/clocks/export/WallClock.js
@@ -40,8 +40,8 @@ export class WallClock {
   static #lastHrtimeNsec = -1n;
 
   /**
-   * Last "now" measured by {@link #now}, as a `bigint`
-   * representing a nanosecond-based Unix Epoch time.
+   * Last "now" measured by {@link #now}, as a `bigint` representing a
+   * nanosecond-based Unix Epoch time.
    *
    * @type {bigint}
    */

--- a/src/collections/export/TreePathKey.js
+++ b/src/collections/export/TreePathKey.js
@@ -29,8 +29,7 @@ export class TreePathKey {
   #wildcard;
 
   /**
-   * The result of {@link #charLength}, or `null` if not yet
-   * calculated.
+   * The result of {@link #charLength}, or `null` if not yet calculated.
    *
    * @type {?number}
    */
@@ -100,10 +99,10 @@ export class TreePathKey {
   }
 
   /**
-   * Concatenates any number of components, arrays of components, or other
-   * keys' paths onto this one, returning a new instance with the same
-   * wildcard value as this one. If all of the given arguments are empty, this
-   * method returns `this`.
+   * Concatenates any number of components, arrays of components, or other keys'
+   * paths onto this one, returning a new instance with the same wildcard value
+   * as this one. If all of the given arguments are empty, this method returns
+   * `this`.
    *
    * @param {Array<string|Array<string>|TreePathKey>} others Values to
    *   concatenate to `this`.

--- a/src/collections/export/TreePathMap.js
+++ b/src/collections/export/TreePathMap.js
@@ -26,17 +26,16 @@ export class TreePathMap {
   #rootNode = new TreePathNode();
 
   /**
-   * Total number of bindings. This defined here instead of on
-   * {@link TreePathNode}, because internal nodes don't need to keep track of
-   * their overall size.
+   * Total number of bindings. This defined here instead of on {@link
+   * TreePathNode}, because internal nodes don't need to keep track of their
+   * overall size.
    *
    * @type {number}
    */
   #size = 0;
 
   /**
-   * Function which renders keys into
-   * strings.
+   * Function which renders keys into strings.
    *
    * @type {function(TreePathKey): string}
    */

--- a/src/data-values/export/Converter.js
+++ b/src/data-values/export/Converter.js
@@ -17,8 +17,8 @@ import { Ref } from '#x/Ref';
 // arrays, as opposed to using `Object.entries()` and the like.
 
 /**
- * Primary concrete implementation of the {@link BaseConverter} protocol.
- * See the module `README.md` for a bit more detail.
+ * Primary concrete implementation of the {@link BaseConverter} protocol. See
+ * the module `README.md` for a bit more detail.
  */
 export class Converter extends BaseConverter {
   /**
@@ -146,8 +146,8 @@ export class Converter extends BaseConverter {
   }
 
   /**
-   * Helper for {@link #encode0}, which performs conversion of arrays and
-   * plain objects.
+   * Helper for {@link #encode0}, which performs conversion of arrays and plain
+   * objects.
    *
    * @param {*} orig Value to convert.
    * @param {boolean} isArray Is `orig` an array?
@@ -201,8 +201,8 @@ export class Converter extends BaseConverter {
   }
 
   /**
-   * Helper for {@link #encode0}, which performs a replacement action as
-   * defined by one of the configured actions.
+   * Helper for {@link #encode0}, which performs a replacement action as defined
+   * by one of the configured actions.
    *
    * @param {*} orig Value to convert.
    * @param {string|function(*): *} action The action option value to use.

--- a/src/data-values/export/ConverterConfig.js
+++ b/src/data-values/export/ConverterConfig.js
@@ -24,9 +24,9 @@ import { Struct } from '#x/Struct';
  *    a non-empty string, or with `<no-name>` if it is unbound or anything else.
  *    This is most useful for functions (both regular and constructors).
  * * `omit` -- Omit the value in question. If the value would be returned
- *   directly, instead `undefined` is returned. If the value would be
- *   incluided in a plain object or array, the key it would be bound to is
- *   omitted (possibly causing an array to be sparse).
+ *   directly, instead `undefined` is returned. If the value would be incluided
+ *   in a plain object or array, the key it would be bound to is omitted
+ *   (possibly causing an array to be sparse).
  * * `unhandled` -- Treat the value conversion as "unhandled." The return value
  *   from `encode()` will in fact be {@link BaseConverter#UNHANDLED}.
  * * `wrap` -- Wrap the value in question inside an instance of {@link Ref}, a
@@ -37,8 +37,7 @@ import { Struct } from '#x/Struct';
  */
 export class ConverterConfig {
   /**
-   * Classes whose instances are treated as data
-   * values.
+   * Classes whose instances are treated as data values.
    *
    * @type {Array<function(new:*)>}
    */
@@ -52,8 +51,7 @@ export class ConverterConfig {
   #freeze;
 
   /**
-   * Action to take when asked to encode a
-   * function.
+   * Action to take when asked to encode a function.
    *
    * @type {string|(function(*): *)}
    */
@@ -67,9 +65,8 @@ export class ConverterConfig {
   #honorEncodeMethod;
 
   /**
-   * Action to take when asked to encode an
-   * instance (object with a class) which is not otherwise covered by other
-   * configuration options.
+   * Action to take when asked to encode an instance (object with a class) which
+   * is not otherwise covered by other configuration options.
    *
    * @type {string|(function(*): *)}
    */
@@ -82,8 +79,8 @@ export class ConverterConfig {
   #specialCases;
 
   /**
-   * Action to take when encountering a symbol-keyed object or
-   * array property. Allowed to be either `error` or `omit`.
+   * Action to take when encountering a symbol-keyed object or array property.
+   * Allowed to be either `error` or `omit`.
    *
    * @type {string}
    */

--- a/src/data-values/export/ConverterConfig.js
+++ b/src/data-values/export/ConverterConfig.js
@@ -178,8 +178,8 @@ export class ConverterConfig {
    * precedence over other configuration options, or `null` if there are no
    * special cases.
    *
-   * Default value if not passed during construction:
-   * {@link SpecialConverters#STANDARD}.
+   * Default value if not passed during construction: {@link
+   * SpecialConverters#STANDARD}.
    */
   get specialCases() {
     return this.#specialCases;

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -91,8 +91,7 @@ export class Duration extends UnitQuantity {
   static ZERO = new Duration(0);
 
   /**
-   * Multipliers for each named unit to convert to
-   * seconds.
+   * Multipliers for each named unit to convert to seconds.
    *
    * @type {Map<string, number>}
    */

--- a/src/data-values/export/Frequency.js
+++ b/src/data-values/export/Frequency.js
@@ -50,8 +50,7 @@ export class Frequency extends UnitQuantity {
   static ZERO = new Frequency(0);
 
   /**
-   * Multipliers for each named unit to convert to
-   * hertz.
+   * Multipliers for each named unit to convert to hertz.
    *
    * @type {Map<string, number>}
    */

--- a/src/data-values/export/Moment.js
+++ b/src/data-values/export/Moment.js
@@ -23,8 +23,7 @@ import { Struct } from '#x/Struct';
  */
 export class Moment {
   /**
-   * The moment being represented, in the form of seconds since
-   * the Unix Epoch.
+   * The moment being represented, in the form of seconds since the Unix Epoch.
    *
    * @type {number}
    */
@@ -138,8 +137,8 @@ export class Moment {
   }
 
   /**
-   * Makes a string representing this instance, in the standard HTTP format.
-   * See {@link #httpStringFromSec} for more details.
+   * Makes a string representing this instance, in the standard HTTP format. See
+   * {@link #httpStringFromSec} for more details.
    *
    * @returns {string} The HTTP standard form.
    */

--- a/src/data-values/export/SpecialConverters.js
+++ b/src/data-values/export/SpecialConverters.js
@@ -13,8 +13,8 @@ import { StandardConverters } from '#p/StandardConverters';
  */
 export class SpecialConverters extends BaseConverter {
   /**
-   * Map from each
-   * specially-handled class to the converter to use on that class.
+   * Map from each specially-handled class to the converter to use on that
+   * class.
    *
    * @type {Map<function(new:object, ...*), BaseConverter>}
    */

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -118,9 +118,9 @@ export class UnitQuantity {
   }
 
   /**
-   * Adds the value of this instance to another, returning a new instance of
-   * the same (possibly sub-) class as this. The other instance must have the
-   * same units as this one.
+   * Adds the value of this instance to another, returning a new instance of the
+   * same (possibly sub-) class as this. The other instance must have the same
+   * units as this one.
    *
    * @param {UnitQuantity} other Other instance to add.
    * @returns {UnitQuantity} Summed result.

--- a/src/fs-util/export/StatsBase.js
+++ b/src/fs-util/export/StatsBase.js
@@ -5,10 +5,10 @@ import * as fs from 'node:fs';
 
 
 /**
- * The base class of {@link fs.Stats} and {@link
- * fs.BigIntStats}. Neither this class nor either of the concrete subclasses
- * are directly exposed by Node, because (arguably bad) reasons, but we can at
- * least extract it and then use it for type checks.
+ * The base class of {@link fs.Stats} and {@link fs.BigIntStats}. Neither this
+ * class nor either of the concrete subclasses are directly exposed by Node,
+ * because (arguably bad) reasons, but we can at least extract it and then use
+ * it for type checks.
  *
  * @type {function(new: object)}
  */

--- a/src/host/export/KeepRunning.js
+++ b/src/host/export/KeepRunning.js
@@ -10,10 +10,10 @@ import { ThisModule } from '#p/ThisModule';
 
 
 /**
- * Utility to guarantee that this process doesn't stop running. By default,
- * Node proactively exits when the event loop quiesces and there do not seem
- * to be any pending actions. However, some systems still want to be able to
- * keep the process up, for whatever reason.
+ * Utility to guarantee that this process doesn't stop running. By default, Node
+ * proactively exits when the event loop quiesces and there do not seem to be
+ * any pending actions. However, some systems still want to be able to keep the
+ * process up, for whatever reason.
  */
 export class KeepRunning {
   /**
@@ -24,8 +24,7 @@ export class KeepRunning {
   #thread;
 
   /**
-   * Logger for this class, or `null` not to do any
-   * logging.
+   * Logger for this class, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */

--- a/src/host/private/HeapDump.js
+++ b/src/host/private/HeapDump.js
@@ -34,8 +34,8 @@ export class HeapDump {
    * Performs a heap dump.
    *
    * @param {string} fileName Where to write the dump to. If given a simple
-   *   name, the system will try several reasonable directories to write to.
-   *   If not already suffixed with `.heapsnapshot` (which is required for
+   *   name, the system will try several reasonable directories to write to. If
+   *   not already suffixed with `.heapsnapshot` (which is required for
    *   recognition by downstream tooling), it will be appended along with a
    *   timestamp.
    */

--- a/src/host/private/HeapDump.js
+++ b/src/host/private/HeapDump.js
@@ -24,8 +24,7 @@ export class HeapDump {
   static #REPORT_INTERVAL_BYTES = 4_000_000;
 
   /**
-   * Logger for this class, or `null` not to do any
-   * logging.
+   * Logger for this class, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */

--- a/src/host/private/ShutdownHandler.js
+++ b/src/host/private/ShutdownHandler.js
@@ -19,25 +19,24 @@ import { TopErrorHandler } from '#p/TopErrorHandler';
  */
 export class ShutdownHandler {
   /**
-   * Maximum amount of time to wait for callbacks to complete,
-   * while shutting down.
+   * Maximum amount of time to wait for callbacks to complete, while shutting
+   * down.
    *
    * @type {number}
    */
   static #MAX_SHUTDOWN_MSEC = 10 * 1000;
 
   /**
-   * Amount of time to wait just before calling `process.exit()`,
-   * intended to allow shutdown-time log messages to get flushed before the
-   * process actually goes away.
+   * Amount of time to wait just before calling `process.exit()`, intended to
+   * allow shutdown-time log messages to get flushed before the process actually
+   * goes away.
    *
    * @type {number}
    */
   static #PRE_EXIT_DELAY_MSEC = 250;
 
   /**
-   * Logger for this class, or `null` not to do any
-   * logging.
+   * Logger for this class, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */

--- a/src/host/private/SignalHandler.js
+++ b/src/host/private/SignalHandler.js
@@ -17,16 +17,15 @@ import { ThisModule } from '#p/ThisModule';
  */
 export class SignalHandler {
   /**
-   * Maximum amount of time to wait for callbacks to complete,
-   * while reloading the system.
+   * Maximum amount of time to wait for callbacks to complete, while reloading
+   * the system.
    *
    * @type {number}
    */
   static #MAX_RELOAD_MSEC = 10 * 1000;
 
   /**
-   * Logger for this class, or `null` not to do any
-   * logging.
+   * Logger for this class, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */
@@ -47,9 +46,9 @@ export class SignalHandler {
   static #reloadCallbacks = new CallbackList('reload', this.#MAX_RELOAD_MSEC);
 
   /**
-   * Number of times the exit signal has been received. Used to
-   * force a non-clean exit when the (human) user seems to be adamant about
-   * shutting things down.
+   * Number of times the exit signal has been received. Used to force a
+   * non-clean exit when the (human) user seems to be adamant about shutting
+   * things down.
    *
    * @type {number}
    */

--- a/src/host/private/ThisModule.js
+++ b/src/host/private/ThisModule.js
@@ -10,8 +10,7 @@ import { IntfLogger } from '@this/loggy-intf';
  */
 export class ThisModule {
   /**
-   * Logger for this module, or `null` not to do any
-   * logging.
+   * Logger for this module, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */

--- a/src/host/private/TopErrorHandler.js
+++ b/src/host/private/TopErrorHandler.js
@@ -15,22 +15,20 @@ import { ThisModule } from '#p/ThisModule';
 /**
  * Top-level error handling. This is what handles errors (thrown exceptions and
  * rejected promises) that percolate to the main event loop without having been
- * handled. It also handles warnings (which always just get emitted directly,
- * no percolation required).
+ * handled. It also handles warnings (which always just get emitted directly, no
+ * percolation required).
  */
 export class TopErrorHandler {
   /**
-   * How many ticks to wait after receiving an
-   * `unhandledRejection` event before considering a promise rejection
-   * _actually_ unhandled.
+   * How many ticks to wait after receiving an `unhandledRejection` event before
+   * considering a promise rejection _actually_ unhandled.
    *
    * @type {number}
    */
   static #PROMISE_REJECTION_GRACE_PERIOD_TICKS = 10;
 
   /**
-   * Logger for this class, or `null` not to do any
-   * logging.
+   * Logger for this class, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -55,8 +55,8 @@ export class LogPayload extends EventPayload {
    * @param {LogTag} tag Tag for the instance, that is, component name and
    *   optional context.
    * @param {string} type "Type" of the instance, e.g. think of this as
-   *   something like a constructor class name if log records could be
-   *   "invoked" (which... they kinda might be able to be at some point).
+   *   something like a constructor class name if log records could be "invoked"
+   *   (which... they kinda might be able to be at some point).
    * @param {...*} args Arbitrary arguments of the instance, whose meaning
    *   depends on the type.
    */

--- a/src/loggy-intf/export/LogTag.js
+++ b/src/loggy-intf/export/LogTag.js
@@ -17,8 +17,8 @@ const chalk = Chalk.ON;
  * Structured "tag" information for log records. Each instance consists of a
  * main tag and zero or more additional "context" strings. The main tag is
  * typically a high-level system component of some sort, e.g. and typically a
- * module. The context strings, if any, are specific to the main tag (defined
- * by the component being so represented).
+ * module. The context strings, if any, are specific to the main tag (defined by
+ * the component being so represented).
  */
 export class LogTag {
   /**
@@ -82,8 +82,8 @@ export class LogTag {
   }
 
   /**
-   * Compares this instance to another for equality, that is, whether the
-   * main tag and context are all the same.
+   * Compares this instance to another for equality, that is, whether the main
+   * tag and context are all the same.
    *
    * @param {*} other Instance to compare to.
    * @returns {boolean} `true` iff `other` is an instance of this class with the

--- a/src/loggy/export/TextFileSink.js
+++ b/src/loggy/export/TextFileSink.js
@@ -23,8 +23,7 @@ export class TextFileSink extends EventSink {
   #filePath;
 
   /**
-   * Function to convert an event
-   * into writable form.
+   * Function to convert an event into writable form.
    *
    * @type {function(LogPayload): Buffer|string}
    */
@@ -99,8 +98,8 @@ export class TextFileSink extends EventSink {
   //
 
   /**
-   * Data converter to use for encoding payload arguments,
-   * specifically for the `json` format.
+   * Data converter to use for encoding payload arguments, specifically for the
+   * `json` format.
    *
    * @type {Converter}
    */
@@ -108,8 +107,7 @@ export class TextFileSink extends EventSink {
     new Converter(ConverterConfig.makeLoggingInstance({ freeze: false }));
 
   /**
-   * Map from names to
-   * corresponding formatter methods.
+   * Map from names to corresponding formatter methods.
    *
    * @type {Map<string, function(LogPayload): Buffer|string>}
    */

--- a/src/loggy/private/LogProxyHandler.js
+++ b/src/loggy/private/LogProxyHandler.js
@@ -22,8 +22,8 @@ export class LogProxyHandler extends PropertyCacheProxyHandler {
   #tag;
 
   /**
-   * Type to use when emitting events, or the tag to append to
-   * the context, for the next layer of proxy.
+   * Type to use when emitting events, or the tag to append to the context, for
+   * the next layer of proxy.
    *
    * @type {?string}
    */
@@ -37,8 +37,8 @@ export class LogProxyHandler extends PropertyCacheProxyHandler {
   #environment;
 
   /**
-   * The tag to use for instances directly "under" this one, if
-   * already computed.
+   * The tag to use for instances directly "under" this one, if already
+   * computed.
    *
    * @type {?LogTag}
    */

--- a/src/main-lactoserv/private/Debugging.js
+++ b/src/main-lactoserv/private/Debugging.js
@@ -18,8 +18,7 @@ import { UsualSystem } from '#p/UsualSystem';
  */
 export class Debugging {
   /**
-   * Logger for this class, or `null` not to do any
-   * logging.
+   * Logger for this class, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */

--- a/src/main-lactoserv/private/MainArgs.js
+++ b/src/main-lactoserv/private/MainArgs.js
@@ -31,8 +31,7 @@ export class MainArgs {
   #parsedArgs = null;
 
   /**
-   * Warehouse maker, based on the passed configuration
-   * URL.
+   * Warehouse maker, based on the passed configuration URL.
    *
    * @type {?WarehouseMaker}
    */
@@ -64,8 +63,7 @@ export class MainArgs {
   }
 
   /**
-   * Warehouse maker, based on the passed configuration
-   * location.
+   * Warehouse maker, based on the passed configuration location.
    *
    * @type {WarehouseMaker}
    */

--- a/src/main-lactoserv/private/ThisModule.js
+++ b/src/main-lactoserv/private/ThisModule.js
@@ -10,8 +10,7 @@ import { IntfLogger } from '@this/loggy-intf';
  */
 export class ThisModule {
   /**
-   * Logger for this module, or `null` not to do any
-   * logging.
+   * Logger for this module, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */

--- a/src/main-lactoserv/private/WarehouseMaker.js
+++ b/src/main-lactoserv/private/WarehouseMaker.js
@@ -26,8 +26,7 @@ export class WarehouseMaker {
   #configUrl = null;
 
   /**
-   * Logger for this instance, or `null` not to do any
-   * logging.
+   * Logger for this instance, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */
@@ -101,9 +100,9 @@ export class WarehouseMaker {
   }
 
   /**
-   * Helper for {@link #loadConfig}, which handles the case of a syntax error
-   * in the config file (or something it in turn loads). This uses `fork()` to
-   * try loading the configuration in a subprocess and then captures stdout and
+   * Helper for {@link #loadConfig}, which handles the case of a syntax error in
+   * the config file (or something it in turn loads). This uses `fork()` to try
+   * loading the configuration in a subprocess and then captures stdout and
    * stderr to replay to the main process (for the presumed user reading the
    * logs or what-have-you). This all is done because -- as of this writing --
    * Node doesn't provide line/column information about where a syntax error

--- a/src/metacomp/export/BaseProxyHandler.js
+++ b/src/metacomp/export/BaseProxyHandler.js
@@ -4,12 +4,12 @@
 /**
  * Base class for proxy handlers, which implements all methods in the most
  * "no-oppy" way possible. By default, if a proxy handler doesn't implement a
- * method, the equivalent operation is attempted on the proxy target. This
- * class explicitly implements _all_ proxy handler methods, so subclasses can be
- * sure that the target is only accessed if code in the subclass explicitly
- * allows it. The _one_ exception is that {@link #getPrototypeOf} per spec needs
- * to return the prototype of the target when {@link #isExtensible} returns
- * `false` (which it does on this class), so that's what's implemented.
+ * method, the equivalent operation is attempted on the proxy target. This class
+ * explicitly implements _all_ proxy handler methods, so subclasses can be sure
+ * that the target is only accessed if code in the subclass explicitly allows
+ * it. The _one_ exception is that {@link #getPrototypeOf} per spec needs to
+ * return the prototype of the target when {@link #isExtensible} returns `false`
+ * (which it does on this class), so that's what's implemented.
  *
  * In addition, this class provides a static method {@link #makeProxy} for
  * convenient proxy construction.
@@ -180,9 +180,9 @@ export class BaseProxyHandler {
   //
 
   /**
-   * Constructs and returns a proxy which wraps an instance of this class,
-   * and with a frozen no-op function as the target. The instance of this class
-   * is constructed with whatever arguments get passed to this method.
+   * Constructs and returns a proxy which wraps an instance of this class, and
+   * with a frozen no-op function as the target. The instance of this class is
+   * constructed with whatever arguments get passed to this method.
    *
    * @param {...*} args Construction arguments to pass to this class's
    *   constructor.
@@ -197,8 +197,8 @@ export class BaseProxyHandler {
   }
 
   /**
-   * Constructs and returns a proxy which wraps an instance of this class,
-   * and with a frozen pseudo-instance of the given class as the target which is
+   * Constructs and returns a proxy which wraps an instance of this class, and
+   * with a frozen pseudo-instance of the given class as the target which is
    * also considered to be a callable function. The instance of this class is
    * constructed with whatever arguments get passed to this method.
    *
@@ -221,8 +221,8 @@ export class BaseProxyHandler {
   }
 
   /**
-   * Constructs and returns a proxy which wraps an instance of this class,
-   * and with a frozen pseudo-instance of the given class as the target. The
+   * Constructs and returns a proxy which wraps an instance of this class, and
+   * with a frozen pseudo-instance of the given class as the target. The
    * instance of this class is constructed with whatever arguments get passed to
    * this method.
    *
@@ -242,9 +242,9 @@ export class BaseProxyHandler {
   }
 
   /**
-   * Constructs and returns a proxy which wraps an instance of this class,
-   * and with a frozen empty object as the target. The instance of this class
-   * is constructed with whatever arguments get passed to this method.
+   * Constructs and returns a proxy which wraps an instance of this class, and
+   * with a frozen empty object as the target. The instance of this class is
+   * constructed with whatever arguments get passed to this method.
    *
    * @param {...*} args Construction arguments to pass to this class's
    *   constructor.

--- a/src/metacomp/export/LimitedLoader.js
+++ b/src/metacomp/export/LimitedLoader.js
@@ -9,12 +9,12 @@ import { IntfLogger } from '@this/loggy-intf';
 
 
 /**
- * "Limited loader" which enables the loading/importing of files as modules in
- * a module loading environment which limits what's available in terms of
- * further `import`s and which maintains its own independent cache of what's
- * been loaded. The environment can either use any VM "context" including the
- * default (i.e., usual Node globals), one shared with other loaders, or an
- * entirely separate one.
+ * "Limited loader" which enables the loading/importing of files as modules in a
+ * module loading environment which limits what's available in terms of further
+ * `import`s and which maintains its own independent cache of what's been
+ * loaded. The environment can either use any VM "context" including the default
+ * (i.e., usual Node globals), one shared with other loaders, or an entirely
+ * separate one.
  *
  * About "contexts:" See the Node and V8 documentation about details, but TLDR:
  * If you want to run in a non-default context but have the system behave at
@@ -30,8 +30,7 @@ import { IntfLogger } from '@this/loggy-intf';
  */
 export class LimitedLoader {
   /**
-   * "Contextified" object which is bound as `global` in loaded
-   * modules.
+   * "Contextified" object which is bound as `global` in loaded modules.
    *
    * @type {?object}
    */
@@ -45,16 +44,15 @@ export class LimitedLoader {
   #logger;
 
   /**
-   * Map from each specifier that has been loaded to
-   * the resulting module instance.
+   * Map from each specifier that has been loaded to the resulting module
+   * instance.
    *
    * @type {Map<string, Module>}
    */
   #cache = new Map();
 
   /**
-   * Linker function, passed to
-   * `module.link()`.
+   * Linker function, passed to `module.link()`.
    *
    * @type {function(string, Module, object)}
    */
@@ -230,8 +228,8 @@ export class LimitedLoader {
 
   /**
    * Helper for {@link #importModule}, which performs a dynamic `import` from
-   * _this_ class, and produces a usable `SyntheticModule` as required by
-   * Node's internals.
+   * _this_ class, and produces a usable `SyntheticModule` as required by Node's
+   * internals.
    *
    * @param {string} specifier The `import` specifier.
    * @returns {SyntheticModule} The module to be bound in the loadee's

--- a/src/metacomp/export/PropertyCacheProxyHandler.js
+++ b/src/metacomp/export/PropertyCacheProxyHandler.js
@@ -35,8 +35,7 @@ import { BaseProxyHandler } from '#x/BaseProxyHandler';
  */
 export class PropertyCacheProxyHandler extends BaseProxyHandler {
   /**
-   * Cached property values, as a map from name to
-   * handler.
+   * Cached property values, as a map from name to handler.
    *
    * @type {Map<string, *>}
    */

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -40,18 +40,16 @@ export class ProtocolWrangler {
   #logger = null;
 
   /**
-   * Logger to use for {@link IncomingRequest}s, or `null`
-   * to not do any logging. This is passed into the {@link IncomingRequest}
-   * constructor, which will end up making a sub-logger with a generated request
-   * ID.
+   * Logger to use for {@link IncomingRequest}s, or `null` to not do any
+   * logging. This is passed into the {@link IncomingRequest} constructor, which
+   * will end up making a sub-logger with a generated request ID.
    *
    * @type {?IntfLogger}
    */
   #requestLogger = null;
 
   /**
-   * Optional host manager; only needed for some
-   * protocols.
+   * Optional host manager; only needed for some protocols.
    *
    * @type {?IntfHostManager}
    */
@@ -72,8 +70,7 @@ export class ProtocolWrangler {
   #requestHandler;
 
   /**
-   * Helper for HTTP-ish request logging, or `null`
-   * to not do any such logging.
+   * Helper for HTTP-ish request logging, or `null` to not do any such logging.
    *
    * @type {?RequestLogHelper}
    */
@@ -101,8 +98,7 @@ export class ProtocolWrangler {
   #runner = new Threadlet(() => this.#startNetwork(), () => this.#runNetwork());
 
   /**
-   * Is a system reload in progress (either during start or
-   * stop)?
+   * Is a system reload in progress (either during start or stop)?
    *
    * @type {boolean}
    */
@@ -199,8 +195,8 @@ export class ProtocolWrangler {
   }
 
   /**
-   * Starts this instance listening for connections and dispatching them to
-   * the high-level application. This method async-returns once the instance has
+   * Starts this instance listening for connections and dispatching them to the
+   * high-level application. This method async-returns once the instance has
    * actually gotten started.
    *
    * @param {boolean} isReload Is this action due to an in-process reload?
@@ -216,10 +212,9 @@ export class ProtocolWrangler {
 
   /**
    * Stops this instance from listening for any more connections. This method
-   * async-returns once the instance has actually stopped. If there was an
-   * error thrown while running, that error in turn gets thrown by this method.
-   * If this instance wasn't running in the first place, this method does
-   * nothing.
+   * async-returns once the instance has actually stopped. If there was an error
+   * thrown while running, that error in turn gets thrown by this method. If
+   * this instance wasn't running in the first place, this method does nothing.
    *
    * @param {boolean} willReload Is this action due to an in-process reload
    *   being requested?
@@ -241,9 +236,8 @@ export class ProtocolWrangler {
   }
 
   /**
-   * Initializes the instance. After this is called and (asynchronously)
-   * returns without throwing, {@link #_impl_server} is expected to work without
-   * error.
+   * Initializes the instance. After this is called and (asynchronously) returns
+   * without throwing, {@link #_impl_server} is expected to work without error.
    *
    * @abstract
    */
@@ -536,8 +530,8 @@ export class ProtocolWrangler {
   }
 
   /**
-   * Runs the "network stack." This is called as the main function of the
-   * {@link #runner}.
+   * Runs the "network stack." This is called as the main function of the {@link
+   * #runner}.
    */
   async #runNetwork() {
     // As things stand, there isn't actually anything to do other than wait for

--- a/src/net-protocol/export/ProtocolWranglers.js
+++ b/src/net-protocol/export/ProtocolWranglers.js
@@ -12,8 +12,7 @@ import { ProtocolWrangler } from '#x/ProtocolWrangler';
  */
 export class ProtocolWranglers {
   /**
-   * Map from each protocol name to
-   * the wrangler subclass that handles it.
+   * Map from each protocol name to the wrangler subclass that handles it.
    *
    * @type {Map<string, function(new:*, ...*)>}
    */

--- a/src/net-protocol/private/AsyncServerSocket.js
+++ b/src/net-protocol/private/AsyncServerSocket.js
@@ -38,16 +38,14 @@ export class AsyncServerSocket {
   #protocol;
 
   /**
-   * The underlying server socket instance (Node library class),
-   * if constructed.
+   * The underlying server socket instance (Node library class), if constructed.
    *
    * @type {?Server}
    */
   #serverSocket = null;
 
   /**
-   * Function to call to remove all of the listeners on
-   * {@link #serverSocket}.
+   * Function to call to remove all of the listeners on {@link #serverSocket}.
    *
    * @type {function()}
    */
@@ -61,8 +59,7 @@ export class AsyncServerSocket {
   #eventSource = new EventSource();
 
   /**
-   * Promise for the next event which will need
-   * action.
+   * Promise for the next event which will need action.
    *
    * @type {Promise<LinkedEvent>}
    */
@@ -308,8 +305,8 @@ export class AsyncServerSocket {
   //
 
   /**
-   * "Prototype" of server socket creation options. See
-   * `ProtocolWrangler` class doc for details.
+   * "Prototype" of server socket creation options. See `ProtocolWrangler` class
+   * doc for details.
    *
    * @type {object}
    */
@@ -322,8 +319,8 @@ export class AsyncServerSocket {
   });
 
   /**
-   * "Prototype" of server listen options. See `ProtocolWrangler`
-   * class doc for details.
+   * "Prototype" of server listen options. See `ProtocolWrangler` class doc for
+   * details.
    *
    * @type {object}
    */
@@ -336,17 +333,15 @@ export class AsyncServerSocket {
   });
 
   /**
-   * How long in msec to allow a stashed instance to remain
-   * stashed.
+   * How long in msec to allow a stashed instance to remain stashed.
    *
    * @type {number}
    */
   static #STASH_TIMEOUT_MSEC = 5 * 1000;
 
   /**
-   * Set of stashed instances, for use during a
-   * reload. Such instances were left open and listening during a previous
-   * call to {@link #stop}.
+   * Set of stashed instances, for use during a reload. Such instances were left
+   * open and listening during a previous call to {@link #stop}.
    *
    * @type {Set<AsyncServerSocket>}
    */
@@ -375,8 +370,8 @@ export class AsyncServerSocket {
   }
 
   /**
-   * Trims down and "fixes" `options` using the given prototype. This is used
-   * to convert from our incoming `interface` form to what's expected by Node's
+   * Trims down and "fixes" `options` using the given prototype. This is used to
+   * convert from our incoming `interface` form to what's expected by Node's
    * `Server` construction and `listen()` methods.
    *
    * @param {object} options Original options.

--- a/src/net-protocol/private/Http2Wrangler.js
+++ b/src/net-protocol/private/Http2Wrangler.js
@@ -44,8 +44,8 @@ export class Http2Wrangler extends TcpWrangler {
   #runner = new Threadlet(() => this.#run());
 
   /**
-   * Per-connection storage, used to plumb connection
-   * context through to the various objects that use the connection.
+   * Per-connection storage, used to plumb connection context through to the
+   * various objects that use the connection.
    *
    * @type {AsyncLocalStorage}
    */
@@ -263,16 +263,16 @@ export class Http2Wrangler extends TcpWrangler {
   //
 
   /**
-   * How long in msec to wait when stopping, after telling
-   * sessions to close before closing with more extreme prejudice.
+   * How long in msec to wait when stopping, after telling sessions to close
+   * before closing with more extreme prejudice.
    *
    * @type {number}
    */
   static #STOP_GRACE_PERIOD_MSEC = 250;
 
   /**
-   * How long in msec to wait for a session to have activity
-   * before considering it "timed out" and telling it to close.
+   * How long in msec to wait for a session to have activity before considering
+   * it "timed out" and telling it to close.
    *
    * @type {number}
    */

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -27,16 +27,15 @@ export class TcpWrangler extends ProtocolWrangler {
   #rateLimiter;
 
   /**
-   * Arguments to pass to the {@link AsyncServerSocket}
-   * constructor.
+   * Arguments to pass to the {@link AsyncServerSocket} constructor.
    *
    * @type {Array<*>}
    */
   #asyncServerArgs;
 
   /**
-   * Underlying server socket, wrapped for `async`
-   * friendliness. Set in {@link #init}.
+   * Underlying server socket, wrapped for `async` friendliness. Set in {@link
+   * #init}.
    *
    * @type {?AsyncServerSocket}
    */
@@ -317,8 +316,8 @@ export class TcpWrangler extends ProtocolWrangler {
   }
 
   /**
-   * Runs the low-level stack. This is called as the main function of the
-   * {@link #runner}.
+   * Runs the low-level stack. This is called as the main function of the {@link
+   * #runner}.
    */
   async #run() {
     while (!this.#runner.shouldStop()) {
@@ -347,26 +346,26 @@ export class TcpWrangler extends ProtocolWrangler {
   //
 
   /**
-   * How long in msec to wait before considering a connected
-   * socket (a/o/t a server socket doing a `listen()`) to be "timed out." When
-   * timed out, a socket is closed proactively.
+   * How long in msec to wait before considering a connected socket (a/o/t a
+   * server socket doing a `listen()`) to be "timed out." When timed out, a
+   * socket is closed proactively.
    *
    * @type {number}
    */
   static #SOCKET_TIMEOUT_MSEC = 3 * 60 * 1000; // Three minutes.
 
   /**
-   * Grace period in msec after trying to close a socket due to
-   * timeout, before doing it more forcefully.
+   * Grace period in msec after trying to close a socket due to timeout, before
+   * doing it more forcefully.
    *
    * @type {number}
    */
   static #SOCKET_TIMEOUT_CLOSE_GRACE_PERIOD_MSEC = 250; // Quarter of a second.
 
   /**
-   * Grace period in msec after receiving an `end` event from
-   * a raw socket (which indicates that the readable side was closed), before
-   * reacting by closing the writable side.
+   * Grace period in msec after receiving an `end` event from a raw socket
+   * (which indicates that the readable side was closed), before reacting by
+   * closing the writable side.
    *
    * @type {number}
    */

--- a/src/net-protocol/private/WranglerContext.js
+++ b/src/net-protocol/private/WranglerContext.js
@@ -60,8 +60,7 @@ export class WranglerContext {
   #sessionLogger = null;
 
   /**
-   * Result of {@link #remoteInfo}, or `null` if not yet
-   * calculated.
+   * Result of {@link #remoteInfo}, or `null` if not yet calculated.
    *
    * @type {?object}
    */
@@ -184,8 +183,8 @@ export class WranglerContext {
    * The layers of protocol implementation inside Node "conspire" to hide the
    * original socket of a `connection` event from the request and response
    * objects that ultimately get emitted as part of a `request` event, but we
-   * want to actually be able to track a request back to the connection. This
-   * is used in a few ways, including for recovering local-listener information
+   * want to actually be able to track a request back to the connection. This is
+   * used in a few ways, including for recovering local-listener information
    * (see `IncomingRequest.host`) and logging. Node makes some effort to expose
    * "safe" socket operations through all the wrapped layers, but at least in
    * our use case (maybe because we ourselves wrap the raw socket, and that
@@ -216,17 +215,16 @@ export class WranglerContext {
   //
 
   /**
-   * Weak map from the "various
-   * objects" to instances of this class.
+   * Weak map from the "various objects" to instances of this class.
    *
    * @type {WeakMap<object, WranglerContext>}
    */
   static #CONTEXT_MAP = new WeakMap();
 
   /**
-   * Async storage that can be bound to instances of
-   * this class, to enable plumbing contexts through event chains that don't
-   * otherwise bear enough information to recover the contexts.
+   * Async storage that can be bound to instances of this class, to enable
+   * plumbing contexts through event chains that don't otherwise bear enough
+   * information to recover the contexts.
    *
    * @type {AsyncLocalStorage}
    */

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -13,9 +13,8 @@ import { MustBe } from '@this/typey';
  */
 export class Cookies {
   /**
-   * Map from each cookie name to its attributes,
-   * including attributes per se for use as `Set-Cookie` headers, but also
-   * properties `name` and `value`.
+   * Map from each cookie name to its attributes, including attributes per se
+   * for use as `Set-Cookie` headers, but also properties `name` and `value`.
    *
    * @type {Map<string, object>}
    */
@@ -186,18 +185,17 @@ export class Cookies {
   //
 
   /**
-   * Regex which matches a cookie name. This is derived from the
-   * definition of `cookie-name` in RFC6265, which is in terms of the definition
-   * of `token` in RFC2616.
+   * Regex which matches a cookie name. This is derived from the definition of
+   * `cookie-name` in RFC6265, which is in terms of the definition of `token` in
+   * RFC2616.
    *
    * @type {RegExp}
    */
   static #NAME_REGEX;
 
   /**
-   * Regex which matches a cookie value, either with or without
-   * surrounding quotes. This is derived from the definition of `cookie-value`
-   * in RFC6265.
+   * Regex which matches a cookie value, either with or without surrounding
+   * quotes. This is derived from the definition of `cookie-value` in RFC6265.
    *
    * @type {RegExp}
    */

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -12,10 +12,10 @@ import { UriUtil } from '#x/UriUtil';
 /**
  * Dispatch information related to an {@link IncomingRequest}.
  *
- * The idea here is that {@link IncomingRequest} objects are treated in a
- * way that's as immutable as possible (even if we don't quite achieve it), so
- * we need somewhere -- that is, instances of this class -- to hold the ephemera
- * of the request dispatch process.
+ * The idea here is that {@link IncomingRequest} objects are treated in a way
+ * that's as immutable as possible (even if we don't quite achieve it), so we
+ * need somewhere -- that is, instances of this class -- to hold the ephemera of
+ * the request dispatch process.
  */
 export class DispatchInfo {
   /**
@@ -119,11 +119,11 @@ export class DispatchInfo {
   }
 
   /**
-   * Gets a relative redirect path which refers to {@link #extra} as a
-   * file. This property is always `../<last>` where `<last>` is the last
-   * file component of the full path, _except_ if the full path is entirely
-   * empty, in which case it is `/`, which is about as good as we can do (even
-   * though it is in directory form).
+   * Gets a relative redirect path which refers to {@link #extra} as a file.
+   * This property is always `../<last>` where `<last>` is the last file
+   * component of the full path, _except_ if the full path is entirely empty, in
+   * which case it is `/`, which is about as good as we can do (even though it
+   * is in directory form).
    *
    * @returns {string} The relative redirect string, as described above.
    */

--- a/src/net-util/export/EtagGenerator.js
+++ b/src/net-util/export/EtagGenerator.js
@@ -54,8 +54,8 @@ export class EtagGenerator {
    *   defaults.
    * @param {boolean} [options.dataOnly] Only ever hash based on entity data,
    *   not metadata such as path and modification time. If `true`, this disables
-   *   {@link #etagFromFileStats} and makes {@link #etagFromFile} use
-   *   {@link #etagFromFileData}. Defaults to `false`.
+   *   {@link #etagFromFileStats} and makes {@link #etagFromFile} use {@link
+   *   #etagFromFileData}. Defaults to `false`.
    * @param {?string} [options.hashAlgorithm] Algorithm to use to generate
    *   hashes. Allowed to be `sha1`, `sha256`, or `sha512`. Defaults to
    *  `sha256`.

--- a/src/net-util/export/EtagGenerator.js
+++ b/src/net-util/export/EtagGenerator.js
@@ -27,16 +27,14 @@ export class EtagGenerator {
   #hashAlgorithm;
 
   /**
-   * The number of characters to use from the hash for strong
-   * etags.
+   * The number of characters to use from the hash for strong etags.
    *
    * @type {?number}
    */
   #hashLengthStrong;
 
   /**
-   * The number of characters to use from the hash for weak
-   * etags.
+   * The number of characters to use from the hash for weak etags.
    *
    * @type {?number}
    */

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -34,8 +34,7 @@ export class HostInfo {
   #portString = null;
 
   /**
-   * Is the hostname actually an IP address? `null` if not yet
-   * calculated.
+   * Is the hostname actually an IP address? `null` if not yet calculated.
    *
    * @type {?boolean}
    */
@@ -51,8 +50,8 @@ export class HostInfo {
   /**
    * Constructs an instance.
    *
-   * **Note:** You are probably better off constructing an instance using one
-   * of the static methods on this class.
+   * **Note:** You are probably better off constructing an instance using one of
+   * the static methods on this class.
    *
    * @param {string} nameString The name string.
    * @param {string|number} portNumber The port number, as either a number per
@@ -163,10 +162,10 @@ export class HostInfo {
   }
 
   /**
-   * Constructs an instance of this class by parsing a string in the format
-   * used by the `Host` header of an HTTP(ish) request. The local port number,
-   * if provided, is used when there is no explicit port number in `hostString`;
-   * if needed and not provided, it is treated as if it is `0`.
+   * Constructs an instance of this class by parsing a string in the format used
+   * by the `Host` header of an HTTP(ish) request. The local port number, if
+   * provided, is used when there is no explicit port number in `hostString`; if
+   * needed and not provided, it is treated as if it is `0`.
    *
    * @param {string} hostString The `Host` header string to parse.
    * @param {?number} [localPort] Local port being listened on, if known.

--- a/src/net-util/export/HttpConditional.js
+++ b/src/net-util/export/HttpConditional.js
@@ -13,8 +13,8 @@ import { HttpUtil } from '#x/HttpUtil';
  */
 export class HttpConditional {
   /**
-   * Regex which matches a `cache-control` header that specifies
-   * `no-cache` somewhere in it.
+   * Regex which matches a `cache-control` header that specifies `no-cache`
+   * somewhere in it.
    *
    * @type {RegExp}
    */

--- a/src/net-util/export/HttpHeaders.js
+++ b/src/net-util/export/HttpHeaders.js
@@ -126,9 +126,8 @@ export class HttpHeaders extends Headers {
 
   /**
    * Extracts a subset of the headers. Names which aren't found are not listed
-   * in the result, and don't cause an error. Extracted values are always
-   * simple (pre-combined) strings, except for `Set-Cookies`, which is always
-   * an array.
+   * in the result, and don't cause an error. Extracted values are always simple
+   * (pre-combined) strings, except for `Set-Cookies`, which is always an array.
    *
    * @param {...string} names Names of headers to extract.
    * @returns {object} The extracted subset, as a mapping from the given `names`

--- a/src/net-util/export/HttpUtil.js
+++ b/src/net-util/export/HttpUtil.js
@@ -13,18 +13,17 @@ import { MustBe } from '@this/typey';
  */
 export class HttpUtil {
   /**
-   * Mapping from arbitrarily-cased header names to
-   * their modern (downcased) versions. Seeded proactively and then lazily
-   * accumulated.
+   * Mapping from arbitrarily-cased header names to their modern (downcased)
+   * versions. Seeded proactively and then lazily accumulated.
    *
    * @type {Map<string, string>}
    */
   static #ANY_TO_MODERN = new Map();
 
   /**
-   * Mapping from arbitrarily-cased header names to
-   * their classic version (mostly capitalized though with some exceptions).
-   * Seeded proactively and then lazily accumulated.
+   * Mapping from arbitrarily-cased header names to their classic version
+   * (mostly capitalized though with some exceptions). Seeded proactively and
+   * then lazily accumulated.
    *
    * @type {Map<string, string>}
    */

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -130,8 +130,7 @@ export class IncomingRequest {
    *   will be one that includes an additional subtag representing a new
    *   unique(ish) ID for the request.
    * @param {string} config.protocolName The protocol name. This is expected
-   *   to be a lowercase name followed by a dash and a version, e.g.
-   *   `http-1.1`.
+   *   to be a lowercase name followed by a dash and a version, e.g. `http-1.1`.
    * @param {HttpHeaders} config.pseudoHeaders HTTP-2-ish "pseudo-headers"
    *   that came with the request or were synthesized based on an HTTP-1-ish
    *   request, with keys stripped of their colon (`:`) prefixes.
@@ -328,12 +327,11 @@ export class IncomingRequest {
 
   /**
    * @returns {string} The name of the protocol which this instance is using.
-   * This is generally a string starting with `http-` and ending with the
-   * dotted version. This corresponds to the (unencrypted) protocol being used
-   * over the (possibly encrypted) transport, and has nothing to do _per se_
-   * with the port number which the remote side of this request connected to in
-   * order to send the request. That is, `https*` won't be the value of this
-   * property.
+   * This is generally a string starting with `http-` and ending with the dotted
+   * version. This corresponds to the (unencrypted) protocol being used over the
+   * (possibly encrypted) transport, and has nothing to do _per se_ with the
+   * port number which the remote side of this request connected to in order to
+   * send the request. That is, `https*` won't be the value of this property.
    */
   get protocolName() {
     return this.#protocolName;
@@ -364,9 +362,9 @@ export class IncomingRequest {
    *
    * For example, for the requested URL
    * `https://example.com:123/foo/bar?baz=10`, this would be `/foo/bar?baz=10`.
-   * This property name corresponds to the standard Node field
-   * {@link IncomingMessage#url}, even though it's not actually a URL per se. We
-   * chose to diverge from Node for the sake of clarity.
+   * This property name corresponds to the standard Node field {@link
+   * IncomingMessage#url}, even though it's not actually a URL per se. We chose
+   * to diverge from Node for the sake of clarity.
    */
   get targetString() {
     return this.#parsedTarget.targetString;

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -29,8 +29,8 @@ import { RequestContext } from '#x/RequestContext';
  */
 export class IncomingRequest {
   /**
-   * Logger to use for this instance, or `null` if the
-   * instance is not doing logging.
+   * Logger to use for this instance, or `null` if the instance is not doing
+   * logging.
    *
    * @type {?IntfLogger}
    */
@@ -44,8 +44,7 @@ export class IncomingRequest {
   #id = null;
 
   /**
-   * Information about the incoming "context" of a
-   * request.
+   * Information about the incoming "context" of a request.
    *
    * @type {RequestContext}
    */
@@ -66,9 +65,9 @@ export class IncomingRequest {
   #protocolName;
 
   /**
-   * HTTP-2-ish "pseudo-headers" that came with the request
-   * or were synthesized from an HTTP-1-ish request, with keys stripped of their
-   * colon (`:`) prefixes.
+   * HTTP-2-ish "pseudo-headers" that came with the request or were synthesized
+   * from an HTTP-1-ish request, with keys stripped of their colon (`:`)
+   * prefixes.
    *
    * @type {HttpHeaders}
    */
@@ -89,8 +88,7 @@ export class IncomingRequest {
   #cookies = null;
 
   /**
-   * The host (a/k/a "authority") info, or `null` if not yet
-   * figured out.
+   * The host (a/k/a "authority") info, or `null` if not yet figured out.
    *
    * @type {HostInfo}
    */
@@ -105,16 +103,14 @@ export class IncomingRequest {
   #parsedTargetObject = null;
 
   /**
-   * The result of {@link #infoForLog}, or `null` if not yet
-   * calculated.
+   * The result of {@link #infoForLog}, or `null` if not yet calculated.
    *
    * @type {?object}
    */
   #infoForLog = null;
 
   /**
-   * The value of {@link #urlForLog}, or `null` if not yet
-   * calculated.
+   * The value of {@link #urlForLog}, or `null` if not yet calculated.
    *
    * @type {?string}
    */

--- a/src/net-util/export/OutgoingResponse.js
+++ b/src/net-util/export/OutgoingResponse.js
@@ -58,8 +58,8 @@ export class OutgoingResponse {
   #body = null;
 
   /**
-   * `cache-control` header to automatically use when
-   * appropriate, or `null` not to do that.
+   * `cache-control` header to automatically use when appropriate, or `null` not
+   * to do that.
    *
    * @type {?string}
    */
@@ -105,12 +105,12 @@ export class OutgoingResponse {
   }
 
   /**
-   * A `cache-control` header to include in any response whose
-   * status code indicates that a response is possibly cacheable, using a
-   * request method that also allows for caching, or `null` not to do automatic
-   * `cache-control` header insertion. (See {@link
-   * HttpUtil#responseIsCacheableFor}.) If this is non-`null`, then it is an
-   * error to include `cache-control` in {@link #headers}.
+   * A `cache-control` header to include in any response whose status code
+   * indicates that a response is possibly cacheable, using a request method
+   * that also allows for caching, or `null` not to do automatic `cache-control`
+   * header insertion. (See {@link HttpUtil#responseIsCacheableFor}.) If this is
+   * non-`null`, then it is an error to include `cache-control` in {@link
+   * #headers}.
    *
    * @type {?string}
    */
@@ -780,8 +780,8 @@ export class OutgoingResponse {
   //
 
   /**
-   * Array of header names associated with content (that
-   * is, non-empty bodies that represent high-level application content).
+   * Array of header names associated with content (that is, non-empty bodies
+   * that represent high-level application content).
    *
    * @type {Array<string>}
    */
@@ -806,25 +806,24 @@ export class OutgoingResponse {
   });
 
   /**
-   * Chunk size to use when reading a file and writing it as a
-   * response.
+   * Chunk size to use when reading a file and writing it as a response.
    *
    * @type {number}
    */
   static #READ_CHUNK_SIZE = 64 * 1024; // 64k
 
   /**
-   * Key to use on response objects to hold a result from
-   * {@link #whenResponseDone}. See comment at use site for more explanation.
+   * Key to use on response objects to hold a result from {@link
+   * #whenResponseDone}. See comment at use site for more explanation.
    *
    * @type {symbol}
    */
   static #RESPONSE_DONE_SYMBOL = Symbol('OutgoingResponse.HttpResponseDone');
 
   /**
-   * Key to use on response objects to hold a "secret" copy of
-   * its `.socket`. Set by {@link #whenResponseDone}, see comment in which for
-   * for more explanation.
+   * Key to use on response objects to hold a "secret" copy of its `.socket`.
+   * Set by {@link #whenResponseDone}, see comment in which for for more
+   * explanation.
    *
    * @type {symbol}
    */
@@ -836,10 +835,10 @@ export class OutgoingResponse {
    * in the response, this method aims to report the error-ish info via a normal
    * return (not by `throw`ing).
    *
-   * **Note:** The `headers` in the result omits anything that is redundant
-   * with respect to other parts of the return value. (E.g., the
-   * `content-length` header is always omitted, and the `:status` pseudo-header
-   * is omitted from HTTP2 response headers.)
+   * **Note:** The `headers` in the result omits anything that is redundant with
+   * respect to other parts of the return value. (E.g., the `content-length`
+   * header is always omitted, and the `:status` pseudo-header is omitted from
+   * HTTP2 response headers.)
    *
    * @param {ServerResponse|Http2ServerResponse} res The response object.
    * @param {Duplex} connectionSocket The underlying socket for the connection.
@@ -1019,9 +1018,9 @@ export class OutgoingResponse {
   }
 
   /**
-   * Returns when an underlying response has been closed successfully (after
-   * all of the response is believed to be sent) or has errored. Returns `true`
-   * for a normal close, or throws whatever error the response reports.
+   * Returns when an underlying response has been closed successfully (after all
+   * of the response is believed to be sent) or has errored. Returns `true` for
+   * a normal close, or throws whatever error the response reports.
    *
    * @param {ServerResponse|Http2ServerResponse} res The response object in
    *   question.

--- a/src/sys-config/export/EndpointConfig.js
+++ b/src/sys-config/export/EndpointConfig.js
@@ -32,8 +32,8 @@ export class EndpointConfig extends NamedConfig {
   #hostnames;
 
   /**
-   * Physical interface to listen on; this is the result of a
-   * call to {@link UriUtil#parseInterface}.
+   * Physical interface to listen on; this is the result of a call to {@link
+   * UriUtil#parseInterface}.
    *
    * @type {object}
    */

--- a/src/sys-config/export/HostConfig.js
+++ b/src/sys-config/export/HostConfig.js
@@ -10,8 +10,8 @@ import { Util } from '#x/Util';
 
 
 /**
- * Configuration representation for a "host" item, that is, a thing that
- * defines the mapping from one or more names to a certificate / key pair.
+ * Configuration representation for a "host" item, that is, a thing that defines
+ * the mapping from one or more names to a certificate / key pair.
  *
  * Accepted configuration bindings (in the constructor).
  *

--- a/src/sys-config/export/SaveConfig.js
+++ b/src/sys-config/export/SaveConfig.js
@@ -28,8 +28,7 @@ import { FileServiceConfig } from '#x/FileServiceConfig';
  */
 export class SaveConfig extends BaseConfig {
   /**
-   * The maximum number of old-file bytes to allow, if so
-   * limited.
+   * The maximum number of old-file bytes to allow, if so limited.
    *
    * @type {?number}
    */

--- a/src/sys-config/export/ServiceConfig.js
+++ b/src/sys-config/export/ServiceConfig.js
@@ -5,8 +5,8 @@ import { ClassedConfig } from '#x/ClassedConfig';
 
 
 /**
- * Class for configuration of services. Accepted configuration bindings (in
- * the constructor) are entirely as defined by the superclass, {@link
+ * Class for configuration of services. Accepted configuration bindings (in the
+ * constructor) are entirely as defined by the superclass, {@link
  * ClassedConfig}.
  */
 export class ServiceConfig extends ClassedConfig {

--- a/src/sys-config/export/ServiceUseConfig.js
+++ b/src/sys-config/export/ServiceUseConfig.js
@@ -8,8 +8,8 @@ import { Names } from '#x/Names';
 
 /**
  * Class for indicating a mapping from service roles (by name) to corresponding
- * services (also by name) that are to be used for those roles. (See
- * {@link EndpointConfig}.)
+ * services (also by name) that are to be used for those roles. (See {@link
+ * EndpointConfig}.)
  *
  * Accepted configuration (in the constructor) is an object with role names for
  * keys and service names for values. Only specific recognized role names are

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -16,8 +16,8 @@ import { BaseComponent } from '#x/BaseComponent';
  */
 export class BaseApplication extends BaseComponent {
   /**
-   * Config instance, if it is an instance
-   * of this class's config class, or `null` if not.
+   * Config instance, if it is an instance of this class's config class, or
+   * `null` if not.
    *
    * @type {?BaseApplication.FilterConfig}
    */
@@ -213,32 +213,31 @@ export class BaseApplication extends BaseComponent {
    */
   static FilterConfig = class FilterConfig extends ApplicationConfig {
     /**
-     * Set of request methods (e.g. `post`) that the
-     * application accepts.
+     * Set of request methods (e.g. `post`) that the application accepts.
      *
      * @type {Set<string>}
      */
     #acceptMethods;
 
     /**
-     * Maximum allowed dispatch `extra` path length in
-     * slash-separated components (inclusive), or `null` if there is no limit.
+     * Maximum allowed dispatch `extra` path length in slash-separated
+     * components (inclusive), or `null` if there is no limit.
      *
      * @type {?number}
      */
     #maxPathDepth;
 
     /**
-     * Maximum allowed dispatch `extra` path length in octets
-     * (inclusive), or `null` if there is no limit.
+     * Maximum allowed dispatch `extra` path length in octets (inclusive), or
+     * `null` if there is no limit.
      *
      * @type {?number}
      */
     #maxPathLength;
 
     /**
-     * Maximum allowed query (search string) length in octets
-     * (inclusive), or `null` if there is no limit.
+     * Maximum allowed query (search string) length in octets (inclusive), or
+     * `null` if there is no limit.
      *
      * @type {?number}
      */
@@ -304,8 +303,8 @@ export class BaseApplication extends BaseComponent {
     }
 
     /**
-     * Maximum allowed dispatch `extra` path length in
-     * slash-separated components (inclusive), or `null` if there is no limit.
+     * Maximum allowed dispatch `extra` path length in slash-separated
+     * components (inclusive), or `null` if there is no limit.
      *
      * @type {?number}
      */
@@ -314,8 +313,8 @@ export class BaseApplication extends BaseComponent {
     }
 
     /**
-     * Maximum allowed dispatch `extra` path length in octets
-     * (inclusive), or `null` if there is no limit.
+     * Maximum allowed dispatch `extra` path length in octets (inclusive), or
+     * `null` if there is no limit.
      *
      * @type {?number}
      */
@@ -324,8 +323,8 @@ export class BaseApplication extends BaseComponent {
     }
 
     /**
-     * Maximum allowed query (search string) length in octets
-     * (inclusive), or `null` if there is no limit.
+     * Maximum allowed query (search string) length in octets (inclusive), or
+     * `null` if there is no limit.
      *
      * @type {?number}
      */

--- a/src/sys-framework/export/BaseControllable.js
+++ b/src/sys-framework/export/BaseControllable.js
@@ -174,8 +174,7 @@ export class BaseControllable {
   }
 
   /**
-   * Logs a message about an item (component, etc.) starting an `init()`
-   * action.
+   * Logs a message about an item (component, etc.) starting an `init()` action.
    *
    * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    * @param {boolean} isReload Is this a system reload (vs. first-time init)?

--- a/src/sys-framework/export/ComponentManager.js
+++ b/src/sys-framework/export/ComponentManager.js
@@ -18,32 +18,30 @@ import { ControlContext } from '#x/ControlContext';
  */
 export class ComponentManager extends BaseControllable {
   /**
-   * Base class of all components to be
-   * managed by this instance.
+   * Base class of all components to be managed by this instance.
    *
    * @type {function(new:BaseComponent)}
    */
   #baseClass;
 
   /**
-   * Base class of all component
-   * configuration classes to be used by this instance.
+   * Base class of all component configuration classes to be used by this
+   * instance.
    *
    * @type {function(new:ClassedConfig)}
    */
   #configBaseClass;
 
   /**
-   * Base sublogger to use for instantiated components, or
-   * `null` not to do any logging.
+   * Base sublogger to use for instantiated components, or `null` not to do any
+   * logging.
    *
    * @type {?IntfLogger}
    */
   #baseSublogger;
 
   /**
-   * Map from each bound name to the
-   * corresponding instance.
+   * Map from each bound name to the corresponding instance.
    *
    * @type {Map<string, BaseComponent>}
    */

--- a/src/sys-framework/export/ControlContext.js
+++ b/src/sys-framework/export/ControlContext.js
@@ -31,26 +31,24 @@ export class ControlContext {
   #logger;
 
   /**
-   * Associated controllable instance. Is only ever
-   * `null` for the context of the root instance itself, and only briefly while
-   * it gets bootstrapped.
+   * Associated controllable instance. Is only ever `null` for the context of
+   * the root instance itself, and only briefly while it gets bootstrapped.
    *
    * @type {?BaseControllable}
    */
   #associate;
 
   /**
-   * Instance which represents the parent (container)
-   * of this instance's associated controllable, or `null` if this instance has
-   * no parent (that is, is the root of the containership hierarchy).
+   * Instance which represents the parent (container) of this instance's
+   * associated controllable, or `null` if this instance has no parent (that is,
+   * is the root of the containership hierarchy).
    *
    * @type {?ControlContext}
    */
   #parent;
 
   /**
-   * Instance which represents the root of the
-   * containership hierarchy.
+   * Instance which represents the root of the containership hierarchy.
    *
    * @type {RootControlContext}
    */

--- a/src/sys-framework/export/EndpointManager.js
+++ b/src/sys-framework/export/EndpointManager.js
@@ -24,8 +24,8 @@ export class EndpointManager extends BaseControllable {
   #warehouse;
 
   /**
-   * Map from each endpoint name to the
-   * {@link NetworkEndpoint} object with that name.
+   * Map from each endpoint name to the {@link NetworkEndpoint} object with that
+   * name.
    *
    * @type {Map<string, NetworkEndpoint>}
    */

--- a/src/sys-framework/export/HostManager.js
+++ b/src/sys-framework/export/HostManager.js
@@ -23,16 +23,15 @@ import { ThisModule } from '#p/ThisModule';
  */
 export class HostManager {
   /**
-   * Map from each componentized hostname to
-   * the {@link HostItem} that should be used for it.
+   * Map from each componentized hostname to the {@link HostItem} that should be
+   * used for it.
    *
    * @type {TreePathMap<HostItem>}
    */
   #items = new TreePathMap(HostUtil.hostnameStringFrom);
 
   /**
-   * Logger for this class, or `null` not to do any
-   * logging.
+   * Logger for this class, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */
@@ -77,8 +76,8 @@ export class HostManager {
   }
 
   /**
-   * Makes an instance with the given subset of bindings. Wildcard hostnames
-   * in `names` are matched as wildcards with the existing bindings, so, for
+   * Makes an instance with the given subset of bindings. Wildcard hostnames in
+   * `names` are matched as wildcards with the existing bindings, so, for
    * example, passing a complete wildcard hostname will produce a clone of this
    * instance.
    *
@@ -113,7 +112,8 @@ export class HostManager {
    * `SNICallback` configured in the options of a call to (something like)
    * `http2.createSecureServer()`.
    *
-   * See <https://nodejs.org/dist/latest-v18.x/docs/api/tls.html#tlscreateserveroptions-secureconnectionlistener>
+   * See
+   * <https://nodejs.org/dist/latest-v18.x/docs/api/tls.html#tlscreateserveroptions-secureconnectionlistener>
    * for details.
    *
    * @param {string} serverName Name of the host to find, or `*` to

--- a/src/sys-framework/export/NetworkEndpoint.js
+++ b/src/sys-framework/export/NetworkEndpoint.js
@@ -26,8 +26,8 @@ import { HostManager } from '#x/HostManager';
  */
 export class NetworkEndpoint extends BaseComponent {
   /**
-   * Application to send requests to. Becomes
-   * non-`null` during {@link #_impl_start()}.
+   * Application to send requests to. Becomes non-`null` during {@link
+   * #_impl_start()}.
    *
    * @type {?BaseApplication}
    */

--- a/src/sys-framework/export/RootControlContext.js
+++ b/src/sys-framework/export/RootControlContext.js
@@ -15,9 +15,9 @@ import { ThisModule } from '#p/ThisModule';
  */
 export class RootControlContext extends ControlContext {
   /**
-   * For each context which represents a
-   * component (all of which have `name`s), a mapping from its name to the
-   * context. This represents a subset of all descendants.
+   * For each context which represents a component (all of which have `name`s),
+   * a mapping from its name to the context. This represents a subset of all
+   * descendants.
    *
    * @type {Map<string, ControlContext>}
    */

--- a/src/sys-framework/export/Warehouse.js
+++ b/src/sys-framework/export/Warehouse.js
@@ -156,18 +156,18 @@ export class Warehouse extends BaseControllable {
   //
 
   /**
-   * Grace period after asking all applications to stop before
-   * asking services to shut down. (If the applications stop more promptly, then
-   * the system will immediately move on.)
+   * Grace period after asking all applications to stop before asking services
+   * to shut down. (If the applications stop more promptly, then the system will
+   * immediately move on.)
    *
    * @type {number}
    */
   static #APPLICATION_STOP_GRACE_PERIOD_MSEC = 250;
 
   /**
-   * Grace period after asking all endpoints to stop before
-   * asking applications and services to shut down. (If the endpoints stop more
-   * promptly, then the system will immediately move on.)
+   * Grace period after asking all endpoints to stop before asking applications
+   * and services to shut down. (If the endpoints stop more promptly, then the
+   * system will immediately move on.)
    *
    * @type {number}
    */

--- a/src/sys-framework/private/ThisModule.js
+++ b/src/sys-framework/private/ThisModule.js
@@ -11,16 +11,14 @@ import { MustBe } from '@this/typey';
  */
 export class ThisModule {
   /**
-   * Map of all loggers returned from {@link
-   * #loggerFor}.
+   * Map of all loggers returned from {@link #loggerFor}.
    *
    * @type {Map<string, IntfLogger>}
    */
   static #loggers = new Map();
 
   /**
-   * Base logger for this module's subsystems, or `null` not
-   * to do any logging.
+   * Base logger for this module's subsystems, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */
@@ -41,8 +39,8 @@ export class ThisModule {
   static SYM_linkRoot = Symbol('sys-framework.linkRoot');
 
   /**
-   * Gets a logger for a particular cohort. A "cohort" is a set of similar
-   * items of some sort, e.g. "applications" or "services."
+   * Gets a logger for a particular cohort. A "cohort" is a set of similar items
+   * of some sort, e.g. "applications" or "services."
    *
    * @param {string} name Name of the cohort.
    * @returns {?IntfLogger} Logger for the cohort, or `null` if it is not to be
@@ -64,8 +62,8 @@ export class ThisModule {
   }
 
   /**
-   * Gets a logger for a particular subsystem or cohort. (A "cohort" is a set
-   * of loggers for similar items, e.g. "applications" or "services.")
+   * Gets a logger for a particular subsystem or cohort. (A "cohort" is a set of
+   * loggers for similar items, e.g. "applications" or "services.")
    *
    * @param {string} name Name of the subsystem or cohort.
    * @param {boolean} isCohort Is this a cohort?

--- a/src/sys-util/export/BaseSystem.js
+++ b/src/sys-util/export/BaseSystem.js
@@ -29,24 +29,22 @@ export class BaseSystem extends Threadlet {
   #reloadRequested = new Condition();
 
   /**
-   * Logger for this instance, or `null` not to do any
-   * logging.
+   * Logger for this instance, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
    */
   #logger = null;
 
   /**
-   * Value returned from {@link #_impl_init} which is currently being
-   * used.
+   * Value returned from {@link #_impl_init} which is currently being used.
    *
    * @type {*}
    */
   #initValue = null;
 
   /**
-   * Value returned from {@link #_impl_init} which is to be used on
-   * the next start (including a restart).
+   * Value returned from {@link #_impl_init} which is to be used on the next
+   * start (including a restart).
    *
    * @type {*}
    */

--- a/src/sys-util/export/Rotator.js
+++ b/src/sys-util/export/Rotator.js
@@ -23,8 +23,8 @@ export class Rotator extends BaseFilePreserver {
   #config;
 
   /**
-   * How long to wait between checks if timed checks are to be
-   * done, or `null` not to do such checks.
+   * How long to wait between checks if timed checks are to be done, or `null`
+   * not to do such checks.
    *
    * @type {?Duration}
    */

--- a/src/sys-util/private/BaseFilePreserver.js
+++ b/src/sys-util/private/BaseFilePreserver.js
@@ -41,8 +41,7 @@ export class BaseFilePreserver {
   #lastInfix = null;
 
   /**
-   * Count (in the infix) used for the most recently preserved
-   * file.
+   * Count (in the infix) used for the most recently preserved file.
    *
    * @type {?string}
    */
@@ -74,8 +73,7 @@ export class BaseFilePreserver {
   }
 
   /**
-   * Logger used by this instance. This is mostly for the
-   * benefit of subclasses.
+   * Logger used by this instance. This is mostly for the benefit of subclasses.
    *
    * @type {?IntfLogger}
    */

--- a/src/typey/export/AskIf.js
+++ b/src/typey/export/AskIf.js
@@ -6,8 +6,8 @@ import { MustBe } from '#x/MustBe';
 
 /**
  * Simple type checks. Each one is a predicate (boolean-returning function).
- * These are all similar to the name-named methods in {@link MustBe}, except
- * the latter are assertions.
+ * These are all similar to the name-named methods in {@link MustBe}, except the
+ * latter are assertions.
  *
  * **Note:** The intention is that this class and {@link MustBe} contain all the
  * same methods, except where a method in this class would be redundant with a
@@ -126,12 +126,12 @@ export class AskIf {
    * called (they can only be used as constructors).
    *
    * **Note:** Unfortunately, JavaScript (a) is loosey-goosey about what sorts
-   * of functions can be called, and (b) doesn't provide a way
-   * to distinguish the various cases _except_ to look at the string conversion
-   * of functions. This method errs on the side of over-acceptance.
+   * of functions can be called, and (b) doesn't provide a way to distinguish
+   * the various cases _except_ to look at the string conversion of functions.
+   * This method errs on the side of over-acceptance.
    *
-   * **Further note:** There is a TC39 proposal that would address this
-   * problem: <https://github.com/caitp/TC39-Proposals/blob/HEAD/tc39-reflect-isconstructor-iscallable.md>
+   * **Further note:** There is a TC39 proposal that would address this problem:
+   * <https://github.com/caitp/TC39-Proposals/blob/HEAD/tc39-reflect-isconstructor-iscallable.md>
    * Unfortunately it is not (as of this writing) close to being accepted.
    *
    * @param {*} value Arbitrary value.


### PR DESCRIPTION
More spring cleaning: The last PR — which was mostly script-driven edits — caused a bunch of doc comments to be jankily-flowed in that some doc paragraphs started off with too-short lines. Instead of spend half a day manually reflowing all of them, I spent half a day writing a jsdoc comment reflow tool, five seconds running it, and about 20 minutes reviewing what it did. Time well spent!
