### PR TITLE
More config stuff

### DIFF
--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -10,6 +10,9 @@ sort-imports`, which you can run if you're ever in need of some automated help.
 The basic idea is that imports go from "general" to "specific" with an extra
 newline between each related section.
 
+And for documentation comments, `ubik node-project reflow-jsdoc` will help keep
+those comments neat and tidy.
+
 - - - - - - - - - -
 
 ### Canonical order of items in a class declaration
@@ -69,18 +72,21 @@ use the following comment in place of an intentionally omitted constructor:
 
 ### Class naming (and details)
 
-* `Base<Name>` -- An abstract base class. Method bodies should use
+* `Base<Name>` &mdash; An abstract base class. Method bodies should use
   `Methods.abstract(...)` to avoid accidental direct instantiation.
 
-* `Intf<Name>` -- An interface, just to be used with `@interface` and
+* `Intf<Name>` &mdash; An interface, just to be used with `@interface` and
   `@implements` annotations, and declared as the types of variables and
   properties. As with base classes, use `Methods.abstract(...)` to prevent
   accidental usage.
 
-* `Type<Name>` -- A `@typedef` declaration, just to be used to annotate method
-  arguments, class properties, etc.,
+* `Type<Name>` &mdash; A `@typedef` declaration, just to be used to annotate
+  method arguments, class properties, etc.
 
-### Method naming (and details)
+* `<Name>Util` &mdash; A "utility" class which is not meant to be instantiated,
+  and which only contains `static` methods.
+
+### Member naming (and details)
 
 * `_impl_<name>` -- Declared in base classes as abstract, and left for
   subclasses to fill in (as specified by the base class). _Not_ supposed to be
@@ -91,14 +97,19 @@ use the following comment in place of an intentionally omitted constructor:
   called by subclasses; _not_ supposed to be used outside of the class. These
   are more or less `protected final` methods defined by a base class.
 
+With very few exceptions, members _not_ marked with `_impl_` should be treated
+as effectively `final`, that is, not overridden.
+
 ### Ledger of arbitrary decisions
 
 Every enduring project of nontrivial size ends up having the results of myriad
 small and mostly inconsequential decisions embedded in it. This section is
 meant to record them, in order to keep track of them and maintain consistency.
 
-* Anything that is complained about by the linter.
-* The string `'utf-8'` to refer to the UTF-8 encoding. Context: Node
+* Anything that is complained about by the linter is a problem to be fixed
+  before merging to `main`.
+
+* The string `'utf-8'` is the way to refer to the UTF-8 encoding. Context: Node
   historically prefers `'utf8'`, but web standards seem to prefer `'utf-8'`.
   Node generally accepts both, and so we go with the latter.
 

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -58,6 +58,15 @@ export class Florp {
 }
 ```
 
+#### Default constructors
+
+In order to make it clear that the omission of a constructor is intentional,
+use the following comment in place of an intentionally omitted constructor:
+
+```js
+  // @defaultConstructor
+```
+
 ### Class naming (and details)
 
 * `Base<Name>` -- An abstract base class. Method bodies should use

--- a/src/async/export/Mutex.js
+++ b/src/async/export/Mutex.js
@@ -29,7 +29,7 @@ export class Mutex {
    */
   #waiters = [];
 
-  // Note: The default constructor is fine for this class.
+  // @defaultConstructor
 
   /**
    * Acquires the mutual exclusion lock. This method returns only after the lock

--- a/src/built-ins/export/HostRouter.js
+++ b/src/built-ins/export/HostRouter.js
@@ -100,12 +100,12 @@ export class HostRouter extends BaseApplication {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
-      super(config);
+    constructor(rawConfig) {
+      super(rawConfig);
 
-      const { hosts } = config;
+      const { hosts } = rawConfig;
 
       MustBe.plainObject(hosts);
 

--- a/src/built-ins/export/HostRouter.js
+++ b/src/built-ins/export/HostRouter.js
@@ -22,7 +22,7 @@ export class HostRouter extends BaseApplication {
    */
   #routeTree = null;
 
-  // Note: The default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   async _impl_handleRequest(request, dispatch) {

--- a/src/built-ins/export/MemoryMonitor.js
+++ b/src/built-ins/export/MemoryMonitor.js
@@ -198,17 +198,17 @@ export class MemoryMonitor extends BaseService {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
-      super(config);
+    constructor(rawConfig) {
+      super(rawConfig);
 
       const {
         checkPeriod  = null,
         gracePeriod  = null,
         maxHeapBytes = null,
         maxRssBytes  = null
-      } = config;
+      } = rawConfig;
 
       this.#checkPeriod = Duration.parse(checkPeriod ?? '5 min', { minInclusive: 1 });
       if (!this.#checkPeriod) {

--- a/src/built-ins/export/MemoryMonitor.js
+++ b/src/built-ins/export/MemoryMonitor.js
@@ -35,7 +35,7 @@ export class MemoryMonitor extends BaseService {
    */
   #lastSnapshot = null;
 
-  // Note: Default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   async _impl_init(isReload_unused) {

--- a/src/built-ins/export/PathRouter.js
+++ b/src/built-ins/export/PathRouter.js
@@ -23,7 +23,7 @@ export class PathRouter extends BaseApplication {
    */
   #routeTree = null;
 
-  // Note: The default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   async _impl_handleRequest(request, dispatch) {

--- a/src/built-ins/export/PathRouter.js
+++ b/src/built-ins/export/PathRouter.js
@@ -106,12 +106,12 @@ export class PathRouter extends BaseApplication {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
-      super(config);
+    constructor(rawConfig) {
+      super(rawConfig);
 
-      const { paths } = config;
+      const { paths } = rawConfig;
 
       MustBe.plainObject(paths);
 

--- a/src/built-ins/export/ProcessIdFile.js
+++ b/src/built-ins/export/ProcessIdFile.js
@@ -32,7 +32,7 @@ export class ProcessIdFile extends BaseFileService {
    */
   #runner = new Threadlet(() => this.#run());
 
-  // Note: Default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   async _impl_init(isReload_unused) {

--- a/src/built-ins/export/ProcessIdFile.js
+++ b/src/built-ins/export/ProcessIdFile.js
@@ -239,12 +239,12 @@ export class ProcessIdFile extends BaseFileService {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
-      super(config);
+    constructor(rawConfig) {
+      super(rawConfig);
 
-      const { multiprocess = null, updatePeriod = null } = config;
+      const { multiprocess = null, updatePeriod = null } = rawConfig;
 
       this.#multiprocess = (typeof multiprocess === 'boolean')
         ? multiprocess

--- a/src/built-ins/export/ProcessInfoFile.js
+++ b/src/built-ins/export/ProcessInfoFile.js
@@ -44,14 +44,7 @@ export class ProcessInfoFile extends BaseFileService {
    */
   #runner = new Threadlet(() => this.#start(), () => this.#run());
 
-  /**
-   * Constructs an instance.
-   *
-   * @param {FileServiceConfig} config Configuration for this service.
-   */
-  constructor(config) {
-    super(config);
-  }
+  // Note: The default constructor is fine for this class.
 
   /** @override */
   async _impl_init(isReload_unused) {

--- a/src/built-ins/export/ProcessInfoFile.js
+++ b/src/built-ins/export/ProcessInfoFile.js
@@ -44,7 +44,7 @@ export class ProcessInfoFile extends BaseFileService {
    */
   #runner = new Threadlet(() => this.#start(), () => this.#run());
 
-  // Note: The default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   async _impl_init(isReload_unused) {

--- a/src/built-ins/export/ProcessInfoFile.js
+++ b/src/built-ins/export/ProcessInfoFile.js
@@ -313,12 +313,12 @@ export class ProcessInfoFile extends BaseFileService {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
-      super(config);
+    constructor(rawConfig) {
+      super(rawConfig);
 
-      const { updatePeriod = null } = config;
+      const { updatePeriod = null } = rawConfig;
 
       if (updatePeriod) {
         this.#updatePeriod = Duration.parse(updatePeriod, { minInclusive: 1 });

--- a/src/built-ins/export/RateLimiter.js
+++ b/src/built-ins/export/RateLimiter.js
@@ -170,12 +170,12 @@ export class RateLimiter extends BaseService {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
-      super(config);
+    constructor(rawConfig) {
+      super(rawConfig);
 
-      const { connections, data, requests } = config;
+      const { connections, data, requests } = rawConfig;
 
       this.#connections = Config.#parseOneBucket(connections);
       this.#data        = Config.#parseOneBucket(data);

--- a/src/built-ins/export/RateLimiter.js
+++ b/src/built-ins/export/RateLimiter.js
@@ -44,12 +44,12 @@ export class RateLimiter extends BaseService {
   /**
    * Constructs an instance.
    *
-   * @param {ServiceConfig} config Configuration for this service.
+   * @param {object} rawConfig Raw configuration object.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
-    const { connections, data, requests } = config;
+    const { connections, data, requests } = this.config;
 
     this.#connections = RateLimiter.#makeBucket(connections);
     this.#data        = RateLimiter.#makeBucket(data);

--- a/src/built-ins/export/Redirector.js
+++ b/src/built-ins/export/Redirector.js
@@ -36,17 +36,19 @@ export class Redirector extends BaseApplication {
   /**
    * Constructs an instance.
    *
-   * @param {ApplicationConfig} config Configuration for this application.
+   * @param {object} rawConfig Raw configuration object.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
-    this.#cacheControl = config.cacheControl;
-    this.#statusCode   = config.statusCode;
+    const { cacheControl, statusCode, target } = this.config;
+
+    this.#cacheControl = cacheControl;
+    this.#statusCode   = statusCode;
 
     // Drop the final slash from `target`, because we'll always be appending a
     // path that _starts_ with a slash.
-    this.#target = config.target.match(/^(?<target>.*)[/]$/).groups.target;
+    this.#target = target.match(/^(?<target>.*)[/]$/).groups.target;
   }
 
   /** @override */

--- a/src/built-ins/export/Redirector.js
+++ b/src/built-ins/export/Redirector.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { HttpUtil, OutgoingResponse, UriUtil } from '@this/net-util';
-import { ApplicationConfig } from '@this/sys-config';
 import { BaseApplication } from '@this/sys-framework';
 import { MustBe } from '@this/typey';
 

--- a/src/built-ins/export/Redirector.js
+++ b/src/built-ins/export/Redirector.js
@@ -114,19 +114,19 @@ export class Redirector extends BaseApplication {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
+    constructor(rawConfig) {
       super({
         acceptMethods: ['delete', 'get', 'head', 'patch', 'post', 'put'],
-        ...config
+        ...rawConfig
       });
 
       const {
         cacheControl = null,
         statusCode = null,
         target
-      } = config;
+      } = rawConfig;
 
       this.#statusCode = statusCode
         ? MustBe.number(statusCode, { minInclusive: 300, maxInclusive: 399 })

--- a/src/built-ins/export/RequestLogger.js
+++ b/src/built-ins/export/RequestLogger.js
@@ -27,23 +27,7 @@ export class RequestLogger extends BaseFileService {
    */
   #rotator = null;
 
-  /**
-   * Also log to the system log?
-   *
-   * @type {boolean}
-   */
-  #doSyslog;
-
-  /**
-   * Constructs an instance.
-   *
-   * @param {FileServiceConfig} config Configuration for this service.
-   */
-  constructor(config) {
-    super(config);
-
-    this.#doSyslog = config.doSyslog;
-  }
+  // Note: The default constructor is fine for this class.
 
   /** @override */
   async logCompletedRequest(line) {
@@ -57,7 +41,7 @@ export class RequestLogger extends BaseFileService {
 
   /** @override */
   async requestStarted(networkInfo_unused, timingInfo_unused, request) {
-    if (this.#doSyslog) {
+    if (this.config.doSyslog) {
       request.logger?.request(request.infoForLog);
     }
   }
@@ -70,7 +54,7 @@ export class RequestLogger extends BaseFileService {
     const responseInfo =
       await OutgoingResponse.getInfoForLog(nodeResponse, connectionSocket);
 
-    if (this.#doSyslog) {
+    if (this.config.doSyslog) {
       request.logger?.response(responseInfo);
       request.logger?.timing(timingInfo);
     }

--- a/src/built-ins/export/RequestLogger.js
+++ b/src/built-ins/export/RequestLogger.js
@@ -27,7 +27,7 @@ export class RequestLogger extends BaseFileService {
    */
   #rotator = null;
 
-  // Note: The default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   now() {

--- a/src/built-ins/export/RequestLogger.js
+++ b/src/built-ins/export/RequestLogger.js
@@ -30,11 +30,6 @@ export class RequestLogger extends BaseFileService {
   // Note: The default constructor is fine for this class.
 
   /** @override */
-  async logCompletedRequest(line) {
-    await this.#logLine(line);
-  }
-
-  /** @override */
   now() {
     return WallClock.now();
   }

--- a/src/built-ins/export/RequestLogger.js
+++ b/src/built-ins/export/RequestLogger.js
@@ -150,12 +150,12 @@ export class RequestLogger extends BaseFileService {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
-      super(config);
+    constructor(rawConfig) {
+      super(rawConfig);
 
-      const { sendToSystemLog = false } = config;
+      const { sendToSystemLog = false } = rawConfig;
 
       this.#doSyslog = MustBe.boolean(sendToSystemLog);
     }

--- a/src/built-ins/export/RequestSyslogger.js
+++ b/src/built-ins/export/RequestSyslogger.js
@@ -19,11 +19,6 @@ export class RequestSyslogger extends BaseService {
   // Note: The default constructor is fine for this class.
 
   /** @override */
-  async logCompletedRequest(line_unused) {
-    // TODO: Remove this method.
-  }
-
-  /** @override */
   now() {
     return WallClock.now();
   }

--- a/src/built-ins/export/RequestSyslogger.js
+++ b/src/built-ins/export/RequestSyslogger.js
@@ -16,7 +16,7 @@ import { BaseService } from '@this/sys-framework';
  * @implements {IntfRequestLogger}
  */
 export class RequestSyslogger extends BaseService {
-  // Note: The default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   now() {

--- a/src/built-ins/export/SerialRouter.js
+++ b/src/built-ins/export/SerialRouter.js
@@ -21,7 +21,7 @@ export class SerialRouter extends BaseApplication {
    */
   #routeList = null;
 
-  // Note: The default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   async _impl_handleRequest(request, dispatch) {

--- a/src/built-ins/export/SerialRouter.js
+++ b/src/built-ins/export/SerialRouter.js
@@ -91,12 +91,12 @@ export class SerialRouter extends BaseApplication {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
-      super(config);
+    constructor(rawConfig) {
+      super(rawConfig);
 
-      const { applications } = config;
+      const { applications } = rawConfig;
 
       MustBe.arrayOfString(applications);
 

--- a/src/built-ins/export/SimpleResponse.js
+++ b/src/built-ins/export/SimpleResponse.js
@@ -170,12 +170,12 @@ export class SimpleResponse extends BaseApplication {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
+    constructor(rawConfig) {
       super({
         acceptMethods: ['get', 'head'],
-        ...config
+        ...rawConfig
       });
 
       const {
@@ -185,7 +185,7 @@ export class SimpleResponse extends BaseApplication {
         etag         = null,
         filePath     = null,
         statusCode   = null
-      } = config;
+      } = rawConfig;
 
       if (body !== null) {
         if (!(body instanceof Buffer)) {

--- a/src/built-ins/export/StaticFiles.js
+++ b/src/built-ins/export/StaticFiles.js
@@ -6,7 +6,6 @@ import fs from 'node:fs/promises';
 import { Paths, Statter } from '@this/fs-util';
 import { DispatchInfo, EtagGenerator, HttpUtil, MimeTypes, OutgoingResponse }
   from '@this/net-util';
-import { ApplicationConfig } from '@this/sys-config';
 import { BaseApplication } from '@this/sys-framework';
 
 
@@ -55,12 +54,12 @@ export class StaticFiles extends BaseApplication {
   /**
    * Constructs an instance.
    *
-   * @param {ApplicationConfig} config Configuration for this application.
+   * @param {object} rawConfig Raw configuration object.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
-    const { cacheControl, etagOptions, notFoundPath, siteDirectory } = config;
+    const { cacheControl, etagOptions, notFoundPath, siteDirectory } = this.config;
 
     this.#notFoundPath  = notFoundPath;
     this.#siteDirectory = siteDirectory;

--- a/src/built-ins/export/StaticFiles.js
+++ b/src/built-ins/export/StaticFiles.js
@@ -302,12 +302,12 @@ export class StaticFiles extends BaseApplication {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
+    constructor(rawConfig) {
       super({
         acceptMethods: ['get', 'head'],
-        ...config,
+        ...rawConfig,
 
         // These are always disabled. See configuration docs for explanation.
         redirectDirectories: false,
@@ -319,7 +319,7 @@ export class StaticFiles extends BaseApplication {
         etag         = null,
         notFoundPath = null,
         siteDirectory
-      } = config;
+      } = rawConfig;
 
       this.#notFoundPath = (notFoundPath === null)
         ? null

--- a/src/built-ins/export/SystemLogger.js
+++ b/src/built-ins/export/SystemLogger.js
@@ -29,14 +29,7 @@ export class SystemLogger extends BaseFileService {
    */
   #sink = null;
 
-  /**
-   * Constructs an instance.
-   *
-   * @param {FileServiceConfig} config Configuration for this service.
-   */
-  constructor(config) {
-    super(config);
-  }
+  // Note: The default constructor is fine for this class.
 
   /** @override */
   async _impl_init(isReload_unused) {
@@ -49,7 +42,6 @@ export class SystemLogger extends BaseFileService {
     const { config } = this;
     this.#rotator = config.rotate ? new Rotator(config, this.logger) : null;
   }
-
 
   /** @override */
   async _impl_start(isReload) {

--- a/src/built-ins/export/SystemLogger.js
+++ b/src/built-ins/export/SystemLogger.js
@@ -137,15 +137,17 @@ export class SystemLogger extends BaseFileService {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
-      super(config);
+    constructor(rawConfig) {
+      super(rawConfig);
 
-      this.#format = MustBe.string(config.format);
+      const { format } = rawConfig;
 
-      if (!TextFileSink.isValidFormat(this.#format)) {
-        throw new Error(`Unknown log format: ${this.#format}`);
+      this.#format = MustBe.string(format);
+
+      if (!TextFileSink.isValidFormat(format)) {
+        throw new Error(`Unknown log format: ${format}`);
       }
     }
 

--- a/src/built-ins/export/SystemLogger.js
+++ b/src/built-ins/export/SystemLogger.js
@@ -29,7 +29,7 @@ export class SystemLogger extends BaseFileService {
    */
   #sink = null;
 
-  // Note: The default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   async _impl_init(isReload_unused) {

--- a/src/built-ins/tests/PathRouter.test.js
+++ b/src/built-ins/tests/PathRouter.test.js
@@ -19,7 +19,7 @@ import { BaseApplication } from '@this/sys-framework';
  * for all `_impl_*` methods.
  */
 export class NopControllable extends BaseComponent {
-  // The default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   async _impl_init(isReload_unused) {
@@ -43,7 +43,7 @@ export class NopControllable extends BaseComponent {
 class MockApp extends BaseApplication {
   static mockCalls = [];
 
-  // The default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   async _impl_handleRequest(request, dispatch) {

--- a/src/clocks/export/IntfTimeSource.js
+++ b/src/clocks/export/IntfTimeSource.js
@@ -11,7 +11,7 @@ import { Methods } from '@this/typey';
  * @interface
  */
 export class IntfTimeSource {
-  // Note: The default constructor is fine.
+  // @defaultConstructor
 
   /**
    * Gets the current time.

--- a/src/clocks/export/StdTimeSource.js
+++ b/src/clocks/export/StdTimeSource.js
@@ -10,7 +10,7 @@ import { WallClock } from '#x/WallClock';
  * WallClock} as the underlying source of time.
  */
 export class StdTimeSource extends IntfTimeSource {
-  // Note: The default constructor is fine.
+  // @defaultConstructor
 
   /** @override */
   now() {

--- a/src/collections/private/TreePathNode.js
+++ b/src/collections/private/TreePathNode.js
@@ -51,7 +51,7 @@ export class TreePathNode {
    */
   #wildcardValue = null;
 
-  // Note: The default constructor is fine here.
+  // @defaultConstructor
 
   /**
    * Underlying implementation of `TreePathMap.add()`, see which for detailed

--- a/src/data-values/export/BaseConverter.js
+++ b/src/data-values/export/BaseConverter.js
@@ -14,7 +14,7 @@ import { Methods } from '@this/typey';
  * special value {@link BaseConverter#UNHANDLED}.
  */
 export class BaseConverter {
-  // Note: The default constructor is fine here.
+  // @defaultConstructor
 
   /**
    * Decodes a data value into an arbitrary value.

--- a/src/loggy-intf/export/IdGenerator.js
+++ b/src/loggy-intf/export/IdGenerator.js
@@ -33,7 +33,7 @@ export class IdGenerator {
    */
   #sequenceNumber = 0;
 
-  // The default constructor is fine here.
+  // @defaultConstructor
 
   /**
    * Makes a new ID.

--- a/src/loggy/export/BaseLoggingEnvironment.js
+++ b/src/loggy/export/BaseLoggingEnvironment.js
@@ -26,7 +26,7 @@ export class BaseLoggingEnvironment extends IntfLoggingEnvironment {
    */
   #dataConverter = new Converter(ConverterConfig.makeLoggingInstance());
 
-  // Note: The default constructor is fine here.
+  // @defaultConstructor
 
   /** @override */
   log(omitCount, tag, type, ...args) {

--- a/src/metacomp/export/BaseProxyHandler.js
+++ b/src/metacomp/export/BaseProxyHandler.js
@@ -15,7 +15,7 @@
  * convenient proxy construction.
  */
 export class BaseProxyHandler {
-  // Note: The default constructor suffices here.
+  // @defaultConstructor
 
   /**
    * Standard `Proxy` handler method.

--- a/src/metacomp/export/PropertyCacheProxyHandler.js
+++ b/src/metacomp/export/PropertyCacheProxyHandler.js
@@ -41,7 +41,7 @@ export class PropertyCacheProxyHandler extends BaseProxyHandler {
    */
   #properties = new Map();
 
-  // Note: The default constructor suffices here.
+  // @defaultConstructor
 
   /**
    * Standard `Proxy` handler method. This defers to {@link #_impl_valueFor} to

--- a/src/net-protocol/export/IntfRequestLogger.js
+++ b/src/net-protocol/export/IntfRequestLogger.js
@@ -28,16 +28,6 @@ export class IntfRequestLogger {
   }
 
   /**
-   * Logs a completed request.
-   *
-   * @abstract
-   * @param {string} line Line representing the completed request.
-   */
-  async logCompletedRequest(line) {
-    Methods.abstract(line);
-  }
-
-  /**
    * Indicates to this instance that a request has started.
    *
    * @abstract

--- a/src/net-protocol/private/Http2Wrangler.js
+++ b/src/net-protocol/private/Http2Wrangler.js
@@ -51,7 +51,7 @@ export class Http2Wrangler extends TcpWrangler {
    */
   #perConnectionStorage = new AsyncLocalStorage();
 
-  // The default constructor is fine for this class.
+  // @defaultConstructor
 
   /** @override */
   async _impl_initialize() {

--- a/src/net-protocol/private/HttpWrangler.js
+++ b/src/net-protocol/private/HttpWrangler.js
@@ -17,7 +17,7 @@ export class HttpWrangler extends TcpWrangler {
    */
   #protocolServer = null;
 
-  // Note: The default constructor suffices here.
+  // @defaultConstructor
 
   /** @override */
   async _impl_initialize() {

--- a/src/net-protocol/private/HttpsWrangler.js
+++ b/src/net-protocol/private/HttpsWrangler.js
@@ -17,7 +17,7 @@ export class HttpsWrangler extends TcpWrangler {
    */
   #protocolServer = null;
 
-  // Note: The default constructor suffices here.
+  // @defaultConstructor
 
   /** @override */
   async _impl_initialize() {

--- a/src/sys-compote/export/BaseComponent.js
+++ b/src/sys-compote/export/BaseComponent.js
@@ -39,28 +39,33 @@ export class BaseComponent {
   /**
    * Constructs an instance.
    *
-   * @param {?object} [config] Configuration for this instance, or `null` if it
-   *   has no associated configuration. If `null` then the class must define
-   *   {@link #CONFIG_CLASS} as `null`. If non-`null`, then it must either be an
-   *   instance of {@link #CONFIG_CLASS} _or_ must be a valid plain object value
-   *   to pass to the constructor of {@link #CONFIG_CLASS}.
+   * After this constructor returns, it is safe for configuration-bearing
+   * subclass instances to use {@link #config}, which will be a bona fide
+   * configuration object for the instance at that point (not just a plain
+   * object).
+   *
+   * @param {?object} [rawConfig] "Raw" configuration for this instance, or
+   *   `null` if it has no associated configuration. If `null` then the class
+   *   must define {@link #CONFIG_CLASS} as `null`. If non-`null`, then it must
+   *   either be an instance of {@link #CONFIG_CLASS} _or_ must be a valid plain
+   *   object value to pass to the constructor of {@link #CONFIG_CLASS}.
    * @param {?RootControlContext} [rootContext] Associated context if this
    *   instance is to be the root of its control hierarchy, or `null` for any
    *   other instance.
    */
-  constructor(config = null, rootContext = null) {
+  constructor(rawConfig = null, rootContext = null) {
     const configClass = this.constructor.CONFIG_CLASS;
-    if (config === null) {
+    if (rawConfig === null) {
       if (configClass !== null) {
         throw new Error('Expected object argument for `config`.');
       }
       this.#config = null;
     } else if (configClass === null) {
       throw new Error('Expected `null` argument for `config`.');
-    } else if (config instanceof configClass) {
-      this.#config = config;
-    } else if (AskIf.plainObject(config)) {
-      this.#config = new configClass(config);
+    } else if (rawConfig instanceof configClass) {
+      this.#config = rawConfig;
+    } else if (AskIf.plainObject(rawConfig)) {
+      this.#config = new configClass(rawConfig);
     } else {
       throw new Error('Expected plain object or config instance for `config`.');
     }

--- a/src/sys-compote/export/BaseComponent.js
+++ b/src/sys-compote/export/BaseComponent.js
@@ -44,11 +44,12 @@ export class BaseComponent {
    * configuration object for the instance at that point (not just a plain
    * object).
    *
-   * @param {?object} [rawConfig] "Raw" configuration for this instance, or
-   *   `null` if it has no associated configuration. If `null` then the class
-   *   must define {@link #CONFIG_CLASS} as `null`. If non-`null`, then it must
-   *   either be an instance of {@link #CONFIG_CLASS} _or_ must be a valid plain
-   *   object value to pass to the constructor of {@link #CONFIG_CLASS}.
+   * @param {?object} [rawConfig] "Raw" (not guaranteed to be parsed and
+   *   correct) configuration for this instance, or `null` if it has no
+   *   associated configuration. If `null` then the class must define {@link
+   *   #CONFIG_CLASS} as `null`. If non-`null`, then it must either be an
+   *   instance of {@link #CONFIG_CLASS} _or_ must be a valid plain object value
+   *   to pass to the constructor of {@link #CONFIG_CLASS}.
    * @param {?RootControlContext} [rootContext] Associated context if this
    *   instance is to be the root of its control hierarchy, or `null` for any
    *   other instance.

--- a/src/sys-compote/export/BaseConfig.js
+++ b/src/sys-compote/export/BaseConfig.js
@@ -18,10 +18,11 @@ export class BaseConfig {
   /**
    * Constructs an instance.
    *
-   * @param {object} config Configuration object. See class header for details.
+   * @param {object} rawConfig Raw configuration object. See class header for
+   *   details.
    */
-  constructor(config) {
-    MustBe.plainObject(config);
+  constructor(rawConfig) {
+    MustBe.plainObject(rawConfig);
   }
 
 

--- a/src/sys-compote/export/BaseNamedComponent.js
+++ b/src/sys-compote/export/BaseNamedComponent.js
@@ -18,12 +18,12 @@ export class BaseNamedComponent extends BaseComponent {
   /**
    * Constructs an instance.
    *
-   * @param {object} config Configuration for this component.
+   * @param {object} rawConfig Raw configuration for this component.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
-    Names.checkName(config.name);
+    Names.checkName(this.config.name);
   }
 
   /** @override */

--- a/src/sys-compote/export/BaseNamedConfig.js
+++ b/src/sys-compote/export/BaseNamedConfig.js
@@ -25,12 +25,13 @@ export class BaseNamedConfig extends BaseConfig {
   /**
    * Constructs an instance.
    *
-   * @param {object} config Configuration object. See class header for details.
+   * @param {object} rawConfig Raw configuration object. See class header for
+   *   details.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
-    this.#name = Names.checkName(config.name);
+    this.#name = Names.checkName(rawConfig.name);
   }
 
   /** @returns {string} The item's name. */

--- a/src/sys-config/export/ClassedConfig.js
+++ b/src/sys-config/export/ClassedConfig.js
@@ -26,12 +26,13 @@ export class ClassedConfig extends BaseNamedConfig {
   /**
    * Constructs an instance.
    *
-   * @param {object} config Configuration object. See class header for details.
+   * @param {object} rawConfig Raw configuration object. See class header for
+   *   details.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
-    const { class: cls } = config;
+    const { class: cls } = rawConfig;
 
     this.#class = MustBe.constructorFunction(cls);
   }

--- a/src/sys-config/export/EndpointConfig.js
+++ b/src/sys-config/export/EndpointConfig.js
@@ -55,10 +55,10 @@ export class EndpointConfig extends BaseNamedConfig {
   /**
    * Constructs an instance.
    *
-   * @param {object} config Configuration object. See class header for details.
+   * @param {object} rawConfig Raw configuration object.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
     const {
       hostnames = '*',
@@ -66,7 +66,7 @@ export class EndpointConfig extends BaseNamedConfig {
       application,
       protocol,
       services = {}
-    } = config;
+    } = rawConfig;
 
     this.#hostnames = Util.checkAndFreezeStrings(
       hostnames,

--- a/src/sys-config/export/FileServiceConfig.js
+++ b/src/sys-config/export/FileServiceConfig.js
@@ -61,18 +61,21 @@ export class FileServiceConfig extends ServiceConfig {
   /**
    * Constructs an instance.
    *
-   * @param {object} config Configuration object. See class header for details.
+   * @param {object} rawConfig Raw configuration object. See class header for
+   *   details.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
-    if (config.rotate && config.save) {
+    const { path, rotate, save } = rawConfig;
+
+    if (rotate && save) {
       throw new Error('Cannot specify both `rotate` and `save`.');
     }
 
-    this.#path   = Paths.checkAbsolutePath(config.path);
-    this.#rotate = config.rotate ? new RotateConfig(config.rotate) : null;
-    this.#save   = config.save ? new SaveConfig(config.save) : null;
+    this.#path   = Paths.checkAbsolutePath(path);
+    this.#rotate = rotate ? new RotateConfig(rotate) : null;
+    this.#save   = save ? new SaveConfig(save) : null;
   }
 
   /**

--- a/src/sys-config/export/HostConfig.js
+++ b/src/sys-config/export/HostConfig.js
@@ -12,20 +12,7 @@ import { Util } from '#x/Util';
 /**
  * Configuration representation for a "host" item, that is, a thing that defines
  * the mapping from one or more names to a certificate / key pair.
- *
- * Accepted configuration bindings (in the constructor).
- *
- * * `{string|Array<string>} hostnames` -- Names of the hosts associated with
- *   this entry. Names can in the form `*.<name>` to match any subdomain of
- *   `<name>`, `*` to be a complete wildcard (that is, matches any name not
- *   otherwise mentioned). Required.
- * * `{string|Buffer} certificate` -- The certificate chain for `hostnames`, as
- *   PEM-encoded data. Required if `selfSigned` is absent or `false`.
- * * `{string|Buffer} privateKey` -- The private key associated with
- *   `certificate`, as PEM-encoded data. Required if `selfSigned` is absent or
- *   `false`.
- * * `{boolean} selfSigned` -- Optional indicator of whether this entry should
- *   use a self-signed certificate.
+ * See `doc/configuration.md` for configuration object details.
  */
 export class HostConfig extends BaseConfig {
   /**
@@ -59,12 +46,12 @@ export class HostConfig extends BaseConfig {
   /**
    * Constructs an instance.
    *
-   * @param {object} config Configuration object. See class header for details.
+   * @param {object} rawConfig Raw configuration object.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
-    const { hostnames, certificate, privateKey, selfSigned = false } = config;
+    const { hostnames, certificate, privateKey, selfSigned = false } = rawConfig;
 
     this.#hostnames = Util.checkAndFreezeStrings(
       hostnames,

--- a/src/sys-config/export/HostConfig.js
+++ b/src/sys-config/export/HostConfig.js
@@ -11,8 +11,8 @@ import { Util } from '#x/Util';
 
 /**
  * Configuration representation for a "host" item, that is, a thing that defines
- * the mapping from one or more names to a certificate / key pair.
- * See `doc/configuration.md` for configuration object details.
+ * the mapping from one or more names to a certificate / key pair. See
+ * `doc/configuration.md` for configuration object details.
  */
 export class HostConfig extends BaseConfig {
   /**

--- a/src/sys-config/export/RotateConfig.js
+++ b/src/sys-config/export/RotateConfig.js
@@ -32,15 +32,15 @@ export class RotateConfig extends SaveConfig {
   /**
    * Constructs an instance.
    *
-   * @param {object} config Configuration object. See class header for details.
+   * @param {object} rawConfig Configuration object.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
     const {
       atSize      = null,
       checkPeriod = null
-    } = config;
+    } = rawConfig;
 
     this.#atSize = (atSize === null)
       ? null

--- a/src/sys-config/export/SaveConfig.js
+++ b/src/sys-config/export/SaveConfig.js
@@ -9,8 +9,8 @@ import { FileServiceConfig } from '#x/FileServiceConfig';
 
 /**
  * Configuration representation for file preservation, used in configuring some
- * file-writing services. (See {@link FileServiceConfig}.)
- * See `doc/configuration.md` for configuration object details.
+ * file-writing services. (See {@link FileServiceConfig}.) See
+ * `doc/configuration.md` for configuration object details.
  */
 export class SaveConfig extends BaseConfig {
   /**

--- a/src/sys-config/export/SaveConfig.js
+++ b/src/sys-config/export/SaveConfig.js
@@ -10,21 +10,7 @@ import { FileServiceConfig } from '#x/FileServiceConfig';
 /**
  * Configuration representation for file preservation, used in configuring some
  * file-writing services. (See {@link FileServiceConfig}.)
- *
- * Accepted configuration bindings (in the constructor). All are optional.
- *
- * * `{?number} maxOldBytes` -- How many bytes' worth of old (post-rotation)
- *   files should be allowed, or `null` not to have a limit. The oldest files
- *   over the limit get deleted after a rotation. Default `null`.
- * * `{?number} maxOldCount` -- How many old (post-rotation) files should be
- *   allowed, or `null` not to have a limit. The oldest files over the limit get
- *   deleted after a rotation. Default `null`.
- * * `{?boolean} onReload` -- Rotate when the system is reloaded (restarted
- *   in-process). Default `false`.
- * * `{?boolean} onStart` -- Rotate when the system is first started? Default
- *   `false`.
- * * `{?boolean} onStop` -- Rotate when the system is about to be stopped?
- *   Default `false`.
+ * See `doc/configuration.md` for configuration object details.
  */
 export class SaveConfig extends BaseConfig {
   /**
@@ -65,10 +51,10 @@ export class SaveConfig extends BaseConfig {
   /**
    * Constructs an instance.
    *
-   * @param {object} config Configuration object. See class header for details.
+   * @param {object} rawConfig Configuration object.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
     const {
       maxOldBytes = null,
@@ -76,7 +62,7 @@ export class SaveConfig extends BaseConfig {
       onReload    = false,
       onStart     = false,
       onStop      = false
-    } = config;
+    } = rawConfig;
 
     this.#maxOldBytes = (maxOldBytes === null)
       ? null

--- a/src/sys-config/export/ServiceUseConfig.js
+++ b/src/sys-config/export/ServiceUseConfig.js
@@ -31,12 +31,13 @@ export class ServiceUseConfig extends BaseConfig {
   /**
    * Constructs an instance.
    *
-   * @param {object} config Configuration object. See class header for details.
+   * @param {object} rawConfig Configuration object. See class header for
+   *   details.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
-    this.#map = Object.freeze(new Map(Object.entries(config)));
+    this.#map = Object.freeze(new Map(Object.entries(rawConfig)));
 
     for (const [role, name] of this.#map) {
       Names.checkName(role);

--- a/src/sys-config/export/WarehouseConfig.js
+++ b/src/sys-config/export/WarehouseConfig.js
@@ -55,17 +55,18 @@ export class WarehouseConfig extends BaseConfig {
   /**
    * Constructs an instance.
    *
-   * @param {object} config Configuration object. See class header for details.
+   * @param {object} rawConfig Configuration object. See class header for
+   *   details.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
     const {
       applications,
       endpoints,
       hosts = [],
       services = []
-    } = config;
+    } = rawConfig;
 
     this.#applications = ApplicationConfig.parseArray(applications);
     this.#hosts        = HostConfig.parseArray(hosts);

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -30,7 +30,7 @@ export class BaseApplication extends BaseNamedComponent {
   constructor(rawConfig) {
     super(rawConfig);
 
-    const config = this.config;
+    const { config } = this;
     this.#filterConfig =
       (config instanceof BaseApplication.FilterConfig) ? config : null;
   }

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -259,10 +259,10 @@ export class BaseApplication extends BaseNamedComponent {
     /**
      * Constructs an instance.
      *
-     * @param {object} config Configuration object.
+     * @param {object} rawConfig Raw configuration object.
      */
-    constructor(config) {
-      super(config);
+    constructor(rawConfig) {
+      super(rawConfig);
 
       const {
         acceptMethods       = null,
@@ -271,7 +271,7 @@ export class BaseApplication extends BaseNamedComponent {
         maxQueryLength      = null,
         redirectDirectories = false,
         redirectFiles       = false
-      } = config;
+      } = rawConfig;
 
       this.#redirectDirectories = MustBe.boolean(redirectDirectories);
       this.#redirectFiles       = MustBe.boolean(redirectFiles);

--- a/src/sys-framework/export/BaseApplication.js
+++ b/src/sys-framework/export/BaseApplication.js
@@ -25,12 +25,14 @@ export class BaseApplication extends BaseNamedComponent {
   /**
    * Constructs an instance.
    *
-   * @param {ApplicationConfig} config Configuration for this application.
+   * @param {object} rawConfig Raw configuration object.
    */
-  constructor(config) {
-    super(config);
+  constructor(rawConfig) {
+    super(rawConfig);
 
-    this.#filterConfig = (config instanceof BaseApplication.FilterConfig) ? config : null;
+    const config = this.config;
+    this.#filterConfig =
+      (config instanceof BaseApplication.FilterConfig) ? config : null;
   }
 
   /** @override */

--- a/src/sys-framework/export/BaseService.js
+++ b/src/sys-framework/export/BaseService.js
@@ -9,14 +9,7 @@ import { ServiceConfig } from '@this/sys-config';
  * Base class for system services.
  */
 export class BaseService extends BaseNamedComponent {
-  /**
-   * Constructs an instance.
-   *
-   * @param {ServiceConfig} config Configuration for this service.
-   */
-  constructor(config) {
-    super(config);
-  }
+  // Note: The default constructor is fine for this class.
 
 
   //

--- a/src/sys-framework/export/BaseService.js
+++ b/src/sys-framework/export/BaseService.js
@@ -9,7 +9,7 @@ import { ServiceConfig } from '@this/sys-config';
  * Base class for system services.
  */
 export class BaseService extends BaseNamedComponent {
-  // Note: The default constructor is fine for this class.
+  // @defaultConstructor
 
 
   //

--- a/src/sys-util/export/BaseFileService.js
+++ b/src/sys-util/export/BaseFileService.js
@@ -14,7 +14,7 @@ import { BaseService } from '@this/sys-framework';
  * (including subclasses).
  */
 export class BaseFileService extends BaseService {
-  // Note: Default constructor is fine for this class.
+  // @defaultConstructor
 
   /**
    * Creates the directory of `config.path`, if it doesn't already exist.


### PR DESCRIPTION
This PR takes a step towards (but does not quite complete) getting it so that it's possible to directly instantiate component objects in config files, instead of always having to pass around config objects.

The status quo isn't such a big deal when using Lactoserv standalone, but when it's used as a framework, it's a pain in the patootie to _not_ be able to do the usual `new Whatever(...)` thing.