### PR TITLE
"Wrangle Untangle II"

### DIFF
--- a/src/net-protocol/export/IntfRequestLogger.js
+++ b/src/net-protocol/export/IntfRequestLogger.js
@@ -1,11 +1,9 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IncomingMessage, ServerResponse } from 'node:http';
-import { Http2ServerRequest, Http2ServerResponse } from 'node:http2';
-
 import { Duration, Moment } from '@this/data-values';
-import { IncomingRequest, OutgoingResponse } from '@this/net-util';
+import { IncomingRequest, OutgoingResponse, TypeNodeRequest, TypeNodeResponse }
+  from '@this/net-util';
 import { Methods } from '@this/typey';
 
 
@@ -35,10 +33,9 @@ export class IntfRequestLogger {
    * @param {object} networkInfo.connectionSocket The socket (or socket-like
    *   object) used by the lowest level of the connection that the request is
    *   running on.
-   * @param {IncomingMessage|Http2ServerRequest} networkInfo.nodeRequest
-   *   Low-level request object.
-   * @param {ServerResponse|Http2ServerResponse} networkInfo.nodeResponse
-   *   Low-level response object.
+   * @param {TypeNodeRequest} networkInfo.nodeRequest Low-level request object.
+   * @param {TypeNodeResponse} networkInfo.nodeResponse Low-level response
+   *   object.
    * @param {object} timingInfo Information about request timing.
    * @param {Moment} timingInfo.start The moment the request started getting
    *   handled (or at least a reasonably close moment to that). This can be

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -226,22 +226,11 @@ export class ProtocolWrangler {
   }
 
   /**
-   * Initializes the instance. After this is called and (asynchronously) returns
-   * without throwing, {@link #_impl_server} is expected to work without error.
+   * Initializes the instance.
    *
    * @abstract
    */
   async _impl_init() {
-    Methods.abstract();
-  }
-
-  /**
-   * Gets the (`HttpServer`-like) protocol server instance.
-   *
-   * @abstract
-   * @returns {object} The (`HttpServer`-like) protocol server instance.
-   */
-  _impl_server() {
     Methods.abstract();
   }
 

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -187,7 +187,7 @@ export class ProtocolWrangler {
 
     const server = this._impl_server();
 
-    server.on('request', (...args) => this.#incomingRequest(...args));
+    server.on('request', (...args) => this._prot_incomingRequest(...args));
 
     // Set up an event handler to propagate the connection context. See
     // `WranglerContext.emitInContext()` for a treatise about what's going on.
@@ -309,61 +309,18 @@ export class ProtocolWrangler {
   }
 
   /**
-   * Top-level of the asynchronous request handling flow. This method will call
-   * out to the configured `requestHandler` when appropriate (e.g. not
-   * rate-limited, etc.).
-   *
-   * **Note:** There is nothing set up to catch errors thrown by this method. It
-   * is not supposed to `throw` (directly or indirectly).
-   *
-   * @param {IncomingRequest} request Request object.
-   * @returns {OutgoingResponse} The response to send.
-   */
-  async #handleRequest(request) {
-    if (!request.pathnameString) {
-      // It's not an `origin` request. We don't handle any other type of
-      // target... yet.
-      //
-      // Handy command for testing this code path:
-      // ```
-      // echo $'GET * HTTP/1.1\r\nHost: milk.com\r\n\r' \
-      //   | curl telnet://localhost:8080
-      // ```
-      return OutgoingResponse.makeMetaResponse(400); // "Bad Request."
-    }
-
-    try {
-      const result = await this.#requestHandler.handleRequest(request, null);
-
-      if (result instanceof OutgoingResponse) {
-        return result;
-      } else if (result === null) {
-        // The configured `requestHandler` didn't actually handle the request.
-        // Respond with a vanilla `404` error. (If the client wants something
-        // fancier, they can do it themselves.)
-        const bodyExtra = request.urlForLog;
-        return OutgoingResponse.makeNotFound({ bodyExtra });
-      } else {
-        // Caught by our direct caller, `#respondToRequest()`.
-        throw new Error(`Strange result from \`handleRequest\`: ${result}`);
-      }
-    } catch (e) {
-      // `500` == "Internal Server Error."
-      const bodyExtra = e.stack ?? e.message ?? '<unknown>';
-      return OutgoingResponse.makeMetaResponse(500, { bodyExtra });
-    }
-  }
-
-  /**
-   * Handles a request as received directly from the HTTP-ish server object.
-   * This performs everything that can be done synchronously as the event
-   * callback that this is, and then (assuming all's well) hands things off to
-   * our main `async` request handler.
+   * Asks the base class to handle a request as received directly from the
+   * protocol server object. This method should be called by the concrete
+   * subclass in response to receiving a request.
    *
    * @param {Http2ServerRequest|IncomingMessage} req Request object.
    * @param {Http2ServerResponse|ServerResponse} res Response object.
    */
-  #incomingRequest(req, res) {
+  _prot_incomingRequest(req, res) {
+    // This method performs everything that can be done synchronously as the
+    // event callback that this is, and then (assuming all's well) hands things
+    // off to our main `async` request handler.
+
     const { socket, stream, url } = req;
     const context                 = WranglerContext.get(socket, stream?.session);
     const logger                  = context?.logger ?? this.#logger;
@@ -413,6 +370,52 @@ export class ProtocolWrangler {
       // In case the response was never finished, this might unwedge things.
       res.statusCode = 500; // "Internal Server Error."
       res.end();
+    }
+  }
+
+  /**
+   * Top-level of the asynchronous request handling flow. This method will call
+   * out to the configured `requestHandler` when appropriate (e.g. not
+   * rate-limited, etc.).
+   *
+   * **Note:** There is nothing set up to catch errors thrown by this method. It
+   * is not supposed to `throw` (directly or indirectly).
+   *
+   * @param {IncomingRequest} request Request object.
+   * @returns {OutgoingResponse} The response to send.
+   */
+  async #handleRequest(request) {
+    if (!request.pathnameString) {
+      // It's not an `origin` request. We don't handle any other type of
+      // target... yet.
+      //
+      // Handy command for testing this code path:
+      // ```
+      // echo $'GET * HTTP/1.1\r\nHost: milk.com\r\n\r' \
+      //   | curl telnet://localhost:8080
+      // ```
+      return OutgoingResponse.makeMetaResponse(400); // "Bad Request."
+    }
+
+    try {
+      const result = await this.#requestHandler.handleRequest(request, null);
+
+      if (result instanceof OutgoingResponse) {
+        return result;
+      } else if (result === null) {
+        // The configured `requestHandler` didn't actually handle the request.
+        // Respond with a vanilla `404` error. (If the client wants something
+        // fancier, they can do it themselves.)
+        const bodyExtra = request.urlForLog;
+        return OutgoingResponse.makeNotFound({ bodyExtra });
+      } else {
+        // Caught by our direct caller, `#respondToRequest()`.
+        throw new Error(`Strange result from \`handleRequest\`: ${result}`);
+      }
+    } catch (e) {
+      // `500` == "Internal Server Error."
+      const bodyExtra = e.stack ?? e.message ?? '<unknown>';
+      return OutgoingResponse.makeMetaResponse(500, { bodyExtra });
     }
   }
 

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -1,13 +1,11 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IncomingMessage, ServerResponse } from 'node:http';
-import { Http2ServerRequest, Http2ServerResponse } from 'node:http2';
-
 import { ManualPromise, Threadlet } from '@this/async';
 import { ProductInfo } from '@this/host';
 import { IntfLogger } from '@this/loggy-intf';
-import { IncomingRequest, IntfRequestHandler, OutgoingResponse, RequestContext }
+import { IncomingRequest, IntfRequestHandler, OutgoingResponse, RequestContext,
+  TypeNodeRequest, TypeNodeResponse }
   from '@this/net-util';
 import { Methods, MustBe } from '@this/typey';
 
@@ -313,8 +311,8 @@ export class ProtocolWrangler {
    * protocol server object. This method should be called by the concrete
    * subclass in response to receiving a request.
    *
-   * @param {Http2ServerRequest|IncomingMessage} req Request object.
-   * @param {Http2ServerResponse|ServerResponse} res Response object.
+   * @param {TypeNodeRequest} req Request object.
+   * @param {TypeNodeResponse} res Response object.
    */
   _prot_incomingRequest(req, res) {
     // This method performs everything that can be done synchronously as the
@@ -429,7 +427,7 @@ export class ProtocolWrangler {
    *
    * @param {IncomingRequest} request Request object.
    * @param {WranglerContext} outerContext The outer context of `request`.
-   * @param {Http2ServerResponse|ServerResponse} res Low-level response object.
+   * @param {TypeNodeResponse} res Low-level response object.
    * @returns {OutgoingResponse} The response object that was ultimately sent
    *   (or was at least ulitmately attempted to be sent).
    */
@@ -508,7 +506,7 @@ export class ProtocolWrangler {
    *
    * @param {IncomingRequest} request Request object.
    * @param {WranglerContext} outerContext The outer context of `request`.
-   * @param {Http2ServerResponse|ServerResponse} res Low-level response object.
+   * @param {TypeNodeResponse} res Low-level response object.
    * @returns {OutgoingResponse} The response object that was ultimately sent
    *   (or was at least ulitmately attempted to be sent).
    */

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -182,14 +182,6 @@ export class ProtocolWrangler {
     this.#requestLogger = logger?.req ?? null;
 
     await this._impl_init();
-
-    const server = this._impl_server();
-
-    server.on('request', (...args) => this._prot_incomingRequest(...args));
-
-    // Set up an event handler to propagate the connection context. See
-    // `WranglerContext.emitInContext()` for a treatise about what's going on.
-    server.on('secureConnection', (socket) => WranglerContext.bindCurrent(socket));
   }
 
   /**

--- a/src/net-protocol/private/Http2Wrangler.js
+++ b/src/net-protocol/private/Http2Wrangler.js
@@ -79,11 +79,6 @@ export class Http2Wrangler extends TcpWrangler {
   }
 
   /** @override */
-  _impl_server() {
-    return this.#protocolServer;
-  }
-
-  /** @override */
   async _impl_serverStart(isReload_unused) {
     this.#runner.run();
   }

--- a/src/net-protocol/private/Http2Wrangler.js
+++ b/src/net-protocol/private/Http2Wrangler.js
@@ -74,6 +74,11 @@ export class Http2Wrangler extends TcpWrangler {
   }
 
   /** @override */
+  async _impl_newConnection(context) {
+    context.emitInContext(this.#protocolServer, 'connection', context.socket);
+  }
+
+  /** @override */
   _impl_server() {
     return this.#protocolServer;
   }

--- a/src/net-protocol/private/HttpWrangler.js
+++ b/src/net-protocol/private/HttpWrangler.js
@@ -34,11 +34,6 @@ export class HttpWrangler extends TcpWrangler {
   }
 
   /** @override */
-  _impl_server() {
-    return this.#protocolServer;
-  }
-
-  /** @override */
   async _impl_serverStart(isReload_unused) {
     // Nothing to do in this case.
   }

--- a/src/net-protocol/private/HttpWrangler.js
+++ b/src/net-protocol/private/HttpWrangler.js
@@ -29,6 +29,11 @@ export class HttpWrangler extends TcpWrangler {
   }
 
   /** @override */
+  async _impl_newConnection(context) {
+    context.emitInContext(this.#protocolServer, 'connection', context.socket);
+  }
+
+  /** @override */
   _impl_server() {
     return this.#protocolServer;
   }

--- a/src/net-protocol/private/HttpWrangler.js
+++ b/src/net-protocol/private/HttpWrangler.js
@@ -21,9 +21,11 @@ export class HttpWrangler extends TcpWrangler {
 
   /** @override */
   async _impl_init() {
-    if (!this.#protocolServer) {
-      this.#protocolServer = http.createServer();
-    }
+    const server = http.createServer();
+
+    server.on('request', (...args) => this._prot_incomingRequest(...args));
+
+    this.#protocolServer = server;
   }
 
   /** @override */

--- a/src/net-protocol/private/HttpsWrangler.js
+++ b/src/net-protocol/private/HttpsWrangler.js
@@ -40,11 +40,6 @@ export class HttpsWrangler extends TcpWrangler {
   }
 
   /** @override */
-  _impl_server() {
-    return this.#protocolServer;
-  }
-
-  /** @override */
   async _impl_serverStart(isReload_unused) {
     // Nothing to do in this case.
   }

--- a/src/net-protocol/private/HttpsWrangler.js
+++ b/src/net-protocol/private/HttpsWrangler.js
@@ -35,6 +35,11 @@ export class HttpsWrangler extends TcpWrangler {
   }
 
   /** @override */
+  async _impl_newConnection(context) {
+    context.emitInContext(this.#protocolServer, 'connection', context.socket);
+  }
+
+  /** @override */
   _impl_server() {
     return this.#protocolServer;
   }

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -1,9 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IncomingMessage } from 'node:http';
-import { Http2ServerRequest } from 'node:http2';
-
 import { TreePathKey } from '@this/collections';
 import { FormatUtils, IntfLogger } from '@this/loggy-intf';
 import { MustBe } from '@this/typey';
@@ -12,7 +9,7 @@ import { Cookies } from '#x/Cookies';
 import { HostInfo } from '#x/HostInfo';
 import { HttpHeaders } from '#x/HttpHeaders';
 import { RequestContext } from '#x/RequestContext';
-
+import { TypeNodeRequest } from '#x/TypeNodeRequest';
 
 /**
  * Representation of a received and in-progress HTTP(ish) request. This is meant
@@ -362,9 +359,9 @@ export class IncomingRequest {
    *
    * For example, for the requested URL
    * `https://example.com:123/foo/bar?baz=10`, this would be `/foo/bar?baz=10`.
-   * This property name corresponds to the standard Node field {@link
-   * IncomingMessage#url}, even though it's not actually a URL per se. We chose
-   * to diverge from Node for the sake of clarity.
+   * This property name corresponds to the standard Node field `request.url`,
+   * even though it's not actually a URL per se. We chose to diverge from Node
+   * for the sake of clarity.
    */
   get targetString() {
     return this.#parsedTarget.targetString;
@@ -550,7 +547,7 @@ export class IncomingRequest {
   /**
    * Constructs an instance based on a low-level Node HTTP-ish request object.
    *
-   * @param {IncomingMessage|Http2ServerRequest} request Request object.
+   * @param {TypeNodeRequest} request Request object.
    * @param {RequestContext} context Information about the request not
    *   represented in `request`.
    * @param {?IntfLogger} logger Logger to use as a base, or `null` to not do
@@ -579,7 +576,7 @@ export class IncomingRequest {
   /**
    * Extracts the two sets of headers from a low-level request object.
    *
-   * @param {IncomingMessage|Http2ServerRequest} request Request object.
+   * @param {TypeNodeRequest} request Request object.
    * @returns {{ headers: HttpHeaders, pseudoHeaders: HttpHeaders }} The
    *   extracted headers.
    */

--- a/src/net-util/export/OutgoingResponse.js
+++ b/src/net-util/export/OutgoingResponse.js
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import fs from 'node:fs/promises';
-import { ServerResponse } from 'node:http';
-import { Http2ServerResponse } from 'node:http2';
 import { Duplex } from 'node:stream';
 
 import statuses from 'statuses';
@@ -18,6 +16,7 @@ import { HttpHeaders } from '#x/HttpHeaders';
 import { HttpRange } from '#x/HttpRange';
 import { HttpUtil } from '#x/HttpUtil';
 import { MimeTypes } from '#x/MimeTypes';
+import { TypeNodeResponse } from '#x/TypeNodeResponse';
 
 
 /**
@@ -262,7 +261,7 @@ export class OutgoingResponse {
    * header is always omitted, and the `:status` pseudo-header is omitted from
    * HTTP2 response headers.)
    *
-   * @param {ServerResponse|Http2ServerResponse} res The response object.
+   * @param {TypeNodeResponse} res The response object.
    * @param {Duplex} connectionSocket The underlying socket for the connection.
    * @returns {object} Loggable information about the response.
    */
@@ -601,16 +600,15 @@ export class OutgoingResponse {
   }
 
   /**
-   * Sends this instance as a response to the request linked to the given core
-   * {@link ServerResponse} object (or similar).
+   * Sends this instance as a response to the request linked to the given
+   * low-level Node response object.
    *
    * **Note:** This method takes into account if the given response corresponds
    * to a `HEAD` request, in which case it won't bother trying to send any body
    * data for a successful response (status `2xx` or `3xx`), even if this
    * instance has a body set.
    *
-   * @param {ServerResponse|Http2ServerResponse} res The response object to
-   *   invoke.
+   * @param {TypeNodeResponse} res The low-level response object to respond via.
    * @returns {boolean} `true` when the response is completed.
    */
   async writeTo(res) {
@@ -675,8 +673,7 @@ export class OutgoingResponse {
    * Should we send a body in response to the given request? This takes into
    * account the request method and whether the status code allows bodies.
    *
-   * @param {ServerResponse|Http2ServerResponse} res The low-level Node response
-   *   object.
+   * @param {TypeNodeResponse} res The low-level response object to check.
    * @returns {boolean} `true` if a body should be sent, or `false` if not.
    */
   #shouldSendBody(res) {
@@ -693,7 +690,7 @@ export class OutgoingResponse {
   /**
    * Writes the body from a buffer, and ends the response.
    *
-   * @param {ServerResponse|Http2ServerResponse} res The response object to use.
+   * @param {TypeNodeResponse} res The low-level response object to write to.
    * @param {boolean} shouldSendBody Should the body actually be sent?
    * @returns {boolean} `true` when closed without error.
    * @throws {Error} Any error reported by `res`.
@@ -719,7 +716,7 @@ export class OutgoingResponse {
   /**
    * Writes the body from a file, and ends the response.
    *
-   * @param {ServerResponse|Http2ServerResponse} res The response object to use.
+   * @param {TypeNodeResponse} res The low-level response object to write to.
    * @param {boolean} shouldSendBody Should the body actually be sent?
    * @returns {boolean} `true` when closed without error.
    * @throws {Error} Any error reported by `res`.
@@ -783,7 +780,7 @@ export class OutgoingResponse {
   /**
    * Writes the body for a diagnostic message, and ends the response.
    *
-   * @param {ServerResponse|Http2ServerResponse} res The response object to use.
+   * @param {TypeNodeResponse} res The low-level response object to write to.
    * @param {boolean} shouldSendBody Should the body actually be sent?
    * @returns {boolean} `true` when closed without error.
    * @throws {Error} Any error reported by `res`.
@@ -831,7 +828,7 @@ export class OutgoingResponse {
   /**
    * Ends a response without writing a body.
    *
-   * @param {ServerResponse|Http2ServerResponse} res The response object to use.
+   * @param {TypeNodeResponse} res The low-level response object to write to.
    * @returns {boolean} `true` when closed without error.
    * @throws {Error} Any error reported by `res`.
    */
@@ -1046,8 +1043,7 @@ export class OutgoingResponse {
    * of the response is believed to be sent) or has errored. Returns `true` for
    * a normal close, or throws whatever error the response reports.
    *
-   * @param {ServerResponse|Http2ServerResponse} res The response object in
-   *   question.
+   * @param {TypeNodeResponse} res The low-level response object to check.
    * @returns {boolean} `true` when closed without error.
    * @throws {Error} Any error reported by the underlying response object.
    */

--- a/src/net-util/export/TypeNodeRequest.js
+++ b/src/net-util/export/TypeNodeRequest.js
@@ -1,0 +1,14 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { IncomingMessage } from 'node:http';
+import { Http2ServerRequest } from 'node:http2';
+
+
+/**
+ * Type which covers all the recognized forms of a request object that come from
+ * the low-level Node libraries.
+ *
+ * @typedef {IncomingMessage|Http2ServerRequest} TypeNodeRequest
+ */
+export const TypeNodeRequest = Symbol('TypeNodeRequest');

--- a/src/net-util/export/TypeNodeResponse.js
+++ b/src/net-util/export/TypeNodeResponse.js
@@ -1,0 +1,14 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { ServerResponse } from 'node:http';
+import { Http2ServerResponse } from 'node:http2';
+
+
+/**
+ * Type which covers all the recognized forms of a response object that come
+ * from the low-level Node libraries.
+ *
+ * @typedef {ServerResponse|Http2ServerResponse} TypeNodeResponse
+ */
+export const TypeNodeResponse = Symbol('TypeNodeResponse');

--- a/src/net-util/index.js
+++ b/src/net-util/index.js
@@ -16,4 +16,6 @@ export * from '#x/IntfRequestHandler';
 export * from '#x/MimeTypes';
 export * from '#x/OutgoingResponse';
 export * from '#x/RequestContext';
+export * from '#x/TypeNodeRequest';
+export * from '#x/TypeNodeResponse';
 export * from '#x/UriUtil';


### PR DESCRIPTION
This PR finishes the work from a couple weeks ago of straightening out the code path when handling incoming connections, and as a result we no longer have to expose a protocol server implementation (e.g. the result of `http.createServer()`) to any of the base classes in the `ProtocolWrangler` hierarchy.