### PR TITLE
`EventFan` and knock-on effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Breaking changes:
   * Moved the higher layer of classes from `sys-config` to be inner classes of
     the things-they-are-configuring.
   * (Per the previous two items) Removed the now-empty module `sys-config`.
-  * Added `_impl_implementedInterfaces()` as an overridable `static` method on
+  * Added `_impl_implementedInterfaces()` as an overridable instance method on
     `BaseComponent`, to allow for runtime declaration and validation of
     component interfaces.
   * Reworked `static` property `CONFIG_CLASS` to be `_impl_configClass()`, to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Other notable changes:
     code a lot in the process.
   * Added general event-reporting and service-calling methods to `BaseService`,
     as a way to eventually enable metaprogramming with services.
+* `built-ins`:
+  * New service `EventFan`, to do parallel fan-out of events. Notably, this is
+    useful for sending network request logs to multiple loggers.
 
 ### v0.6.12 -- 2024-03-28
 

--- a/doc/configuration/3-built-in-services.md
+++ b/doc/configuration/3-built-in-services.md
@@ -260,20 +260,16 @@ the following configuration bindings:
 * `rotate` &mdash; Optional file rotation configuration. If not specified, no
   file rotation is done. See "File Rotation and Preservation" below for
   configuration details.
-* `sendToSystemLog` &mdash; Boolean which, if `true`, causes requests and
-  responses to _also_ get sent to the system log. (It's like getting an instance
-  of `RequestSyslogger` for free.)
 
 ```js
 import { RequestLogger } from '@lactoserv/built-ins';
 
 const services = [
   {
-    name:            'requests',
-    class:           RequestLogger,
-    path:            '/path/to/var/log/request-log.txt',
-    rotate:          { /* ... */ },
-    sendToSystemLog: true
+    name:   'requests',
+    class:  RequestLogger,
+    path:   '/path/to/var/log/request-log.txt',
+    rotate: { /* ... */ }
   }
 ];
 ```

--- a/doc/configuration/3-built-in-services.md
+++ b/doc/configuration/3-built-in-services.md
@@ -101,6 +101,37 @@ const services = [
 ];
 ```
 
+## `EventFan`
+
+A service which "fans out" any events it receives to a set of other services, in
+parallel. It accepts the following configuration bindings:
+
+* `services` &mdash; An array listing the _names_ of other services as values.
+
+An instance of this service can be used, for example, to get two different
+network request loggers to be attached to a single network endpoint. (This is
+done in the example configuration file, for reference.)
+
+```js
+import { EventFan } from '@lactoserv/built-ins';
+
+const services = [
+  {
+    name:     'myFan',
+    class:    EventFan,
+    services: ['goHere', 'goThere']
+  },
+  {
+    name: 'goHere',
+    // ... more ...
+  },
+  {
+    name: 'goThere',
+    // ... more ...
+  }
+];
+```
+
 ## `ProcessIdFile`
 
 A service which writes a simple text file containing the process ID (number) of

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -3,9 +3,9 @@
 
 import * as fs from 'node:fs/promises';
 
-import { HostRouter, MemoryMonitor, PathRouter, ProcessIdFile, ProcessInfoFile,
-  RateLimiter, Redirector, RequestLogger, SerialRouter, SimpleResponse,
-  StaticFiles, SystemLogger }
+import { EventFan, HostRouter, MemoryMonitor, PathRouter, ProcessIdFile,
+  ProcessInfoFile, RateLimiter, Redirector, RequestLogger, RequestSyslogger,
+  SerialRouter, SimpleResponse, StaticFiles, SystemLogger }
   from '@lactoserv/built-ins';
 
 
@@ -88,15 +88,23 @@ const services = [
     }
   },
   {
-    name:  'requests',
+    name:  'requestFile',
     class: RequestLogger,
     path:  `${LOG_DIR}/request-log.txt`,
     rotate: {
       atSize:      10000,
       maxOldCount: 10,
       checkPeriod: '1 min'
-    },
-    sendToSystemLog: true
+    }
+  },
+  {
+    name:  'requestSyslog',
+    class: RequestSyslogger
+  },
+  {
+    name:     'requests',
+    class:    EventFan,
+    services: ['requestFile', 'requestSyslog']
   },
   {
     name:        'limiter',

--- a/src/built-ins/export/EventFan.js
+++ b/src/built-ins/export/EventFan.js
@@ -1,0 +1,142 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { Names } from '@this/compote';
+import { BaseService } from '@this/sys-framework';
+import { MustBe } from '@this/typey';
+
+
+/**
+ * Service which fans out all events in parallel to a set of other services. It
+ * implements no call (non-event) handlers. Instances will claim to implement
+ * any interface claimed by any of the set it fans out to.
+ *
+ * See `doc/configuration` for configuration object details.
+ */
+export class EventFan extends BaseService {
+  /**
+   * List of services to fan out to.
+   *
+   * @type {Array<BaseService>}
+   */
+  #services = null;
+
+  // @defaultConstructor
+
+  /** @override */
+  async _impl_handleEvent(payload) {
+    const promises = [];
+
+    for (const service of this.#services) {
+      promises.push(service.handleEvent(payload));
+    }
+
+    const results = await Promise.allSettled(promises);
+    const errors  = [];
+    let   handled = false;
+
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        handled ||= result.value;
+      } else {
+        errors.push(result.reason);
+      }
+    }
+
+    if (errors.length === 0) {
+      return handled;
+    } else {
+      throw new AggregateError(errors);
+    }
+  }
+
+  /** @override */
+  _impl_implementedInterfaces() {
+    const ifaces = new Set();
+
+    for (const service of this.#services) {
+      for (const iface of service.implementedInterfaces) {
+        ifaces.add(iface);
+      }
+    }
+
+    return [...ifaces];
+  }
+
+  /** @override */
+  async _impl_init(isReload_unused) {
+    this.logger?.targets(this.config.services);
+  }
+
+  /** @override */
+  async _impl_start(isReload_unused) {
+    // Note: We can't do this setup in `_impl_init()` because it might not be
+    // the case that all of the referenced services have already been added when
+    // that runs.
+
+    const context  = this.context;
+    const services = [];
+
+    for (const name of this.config.routeList) {
+      const service = context.getComponent(name, BaseService);
+      services.push(service);
+    }
+
+    this.#services = services;
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // No need to do anything.
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @override */
+  static _impl_configClass() {
+    return this.#Config;
+  }
+
+  /**
+   * Configuration item subclass for this (outer) class.
+   */
+  static #Config = class Config extends BaseService.Config {
+    /**
+     * Like the outer `services` except with names instead of service instances.
+     *
+     * @type {Array<string>}
+     */
+    #services;
+
+    /**
+     * Constructs an instance.
+     *
+     * @param {object} rawConfig Raw configuration object.
+     */
+    constructor(rawConfig) {
+      super(rawConfig);
+
+      const { services } = rawConfig;
+
+      MustBe.arrayOfString(services);
+
+      for (const name of services) {
+        Names.checkName(name);
+      }
+
+      // `[...]` to copy the list in order to avoid outside interference.
+      this.#services = [...services];
+    }
+
+    /**
+     * @returns {Array<string>} Like the outer `services` except with names
+     * instead of service instances.
+     */
+    get services() {
+      return this.#services;
+    }
+  };
+}

--- a/src/built-ins/export/EventFan.js
+++ b/src/built-ins/export/EventFan.js
@@ -77,7 +77,7 @@ export class EventFan extends BaseService {
     const context  = this.context;
     const services = [];
 
-    for (const name of this.config.routeList) {
+    for (const name of this.config.services) {
       const service = context.getComponent(name, BaseService);
       services.push(service);
     }

--- a/src/built-ins/export/RateLimiter.js
+++ b/src/built-ins/export/RateLimiter.js
@@ -75,6 +75,11 @@ export class RateLimiter extends BaseService {
   }
 
   /** @override */
+  _impl_implementedInterfaces() {
+    return [IntfRateLimiter];
+  }
+
+  /** @override */
   async _impl_init(isReload_unused) {
     // Nothing needed here for this class.
   }
@@ -101,11 +106,6 @@ export class RateLimiter extends BaseService {
   /** @override */
   static _impl_configClass() {
     return this.#Config;
-  }
-
-  /** @override */
-  static _impl_implementedInterfaces() {
-    return [IntfRateLimiter];
   }
 
   /**

--- a/src/built-ins/export/RequestLogger.js
+++ b/src/built-ins/export/RequestLogger.js
@@ -107,6 +107,11 @@ export class RequestLogger extends BaseFileService {
   }
 
   /** @override */
+  _impl_implementedInterfaces() {
+    return [IntfRequestLogger];
+  }
+
+  /** @override */
   async _impl_init(isReload_unused) {
     const { config } = this;
     this.#rotator = config.rotate ? new Rotator(config, this.logger) : null;
@@ -160,11 +165,6 @@ export class RequestLogger extends BaseFileService {
   /** @override */
   static _impl_configClass() {
     return this.#Config;
-  }
-
-  /** @override */
-  static _impl_implementedInterfaces() {
-    return [IntfRequestLogger];
   }
 
   /**

--- a/src/built-ins/export/RequestLogger.js
+++ b/src/built-ins/export/RequestLogger.js
@@ -8,7 +8,6 @@ import { Moment } from '@this/data-values';
 import { FormatUtils } from '@this/loggy-intf';
 import { IntfRequestLogger } from '@this/net-protocol';
 import { BaseFileService, Rotator } from '@this/sys-util';
-import { MustBe } from '@this/typey';
 
 
 /**

--- a/src/built-ins/export/RequestLogger.js
+++ b/src/built-ins/export/RequestLogger.js
@@ -32,10 +32,6 @@ export class RequestLogger extends BaseFileService {
   async _impl_handleEvent_requestStarted(request) {
     request[RequestLogger.#SYM_startTime] = this.#now();
 
-    if (this.config.doSyslog) {
-      request.logger?.request(request.infoForLog);
-    }
-
     return true;
   }
 
@@ -76,10 +72,6 @@ export class RequestLogger extends BaseFileService {
     const startTime = request[RequestLogger.#SYM_startTime];
     const endTime   = this.#now();
     const duration  = endTime.subtract(startTime);
-
-    if (this.config.doSyslog) {
-      request.logger?.response(responseInfo);
-    }
 
     const { method, origin, protocol, url }             = requestInfo;
     const { contentLength, errorCodes, ok, statusCode } = responseInfo;
@@ -161,39 +153,4 @@ export class RequestLogger extends BaseFileService {
    * @type {symbol}
    */
   static #SYM_startTime = Symbol('RequestLogger.startTime');
-
-  /** @override */
-  static _impl_configClass() {
-    return this.#Config;
-  }
-
-  /**
-   * Configuration item subclass for this (outer) class.
-   */
-  static #Config = class Config extends BaseFileService.Config {
-    /**
-     * Also log to the system log?
-     *
-     * @type {boolean}
-     */
-    #doSyslog;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const { sendToSystemLog = false } = rawConfig;
-
-      this.#doSyslog = MustBe.boolean(sendToSystemLog);
-    }
-
-    /** @returns {boolean} Also log to the system log? */
-    get doSyslog() {
-      return this.#doSyslog;
-    }
-  };
 }

--- a/src/built-ins/export/RequestSyslogger.js
+++ b/src/built-ins/export/RequestSyslogger.js
@@ -42,6 +42,11 @@ export class RequestSyslogger extends BaseService {
   }
 
   /** @override */
+  _impl_implementedInterfaces() {
+    return [IntfRequestLogger];
+  }
+
+  /** @override */
   async _impl_init(isReload_unused) {
     // Nothing needed here for this class.
   }
@@ -54,14 +59,5 @@ export class RequestSyslogger extends BaseService {
   /** @override */
   async _impl_stop(willReload_unused) {
     // No need to do anything.
-  }
-
-  //
-  // Static members
-  //
-
-  /** @override */
-  static _impl_implementedInterfaces() {
-    return [IntfRequestLogger];
   }
 }

--- a/src/built-ins/export/SerialRouter.js
+++ b/src/built-ins/export/SerialRouter.js
@@ -49,7 +49,6 @@ export class SerialRouter extends BaseApplication {
     // the case that all of the referenced apps have already been added when
     // that runs.
 
-
     const context   = this.context;
     const routeList = [];
 

--- a/src/built-ins/index.js
+++ b/src/built-ins/index.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+export * from '#x/EventFan';
 export * from '#x/HostRouter';
 export * from '#x/MemoryMonitor';
 export * from '#x/PathRouter';

--- a/src/compote/export/BaseComponent.js
+++ b/src/compote/export/BaseComponent.js
@@ -135,7 +135,7 @@ export class BaseComponent {
    */
   get implementedInterfaces() {
     if (this.#implementedInterfaces === null) {
-      const ifaces = this.constructor._impl_implementedInterfaces();
+      const ifaces = this._impl_implementedInterfaces();
 
       MustBe.arrayOf(ifaces, AskIf.constructorFunction);
       Object.freeze(ifaces);
@@ -197,6 +197,16 @@ export class BaseComponent {
     BaseComponent.logStopping(this.logger, willReload);
     await this._impl_stop(willReload);
     BaseComponent.logStopped(this.logger, willReload);
+  }
+
+  /**
+   * @returns {Array<function(new:object)>} Array of interface classes that this
+   * instance claims to implement. The base class calls this exactly once to get
+   * the value to return from {@link #implementedInterfaces}. Defaults to `[]`.
+   * Subclasses are expected to override this as necessary.
+   */
+  _impl_implementedInterfaces() {
+    return [];
   }
 
   /**
@@ -392,16 +402,6 @@ export class BaseComponent {
    */
   static logStopping(logger, willReload) {
     logger?.stopping(willReload ? 'willReload' : 'shutdown');
-  }
-
-  /**
-   * @returns {Array<function(new:object)>} Array of interface classes that this
-   * class claims to implement. The base class calls this exactly once to get
-   * the value to return from {@link #implementedInterfaces}. Defaults to `[]`.
-   * Subclasses are expected to override this as necessary.
-   */
-  static _impl_implementedInterfaces() {
-    return [];
   }
 
   /**

--- a/src/compote/export/BaseComponent.js
+++ b/src/compote/export/BaseComponent.js
@@ -42,6 +42,13 @@ export class BaseComponent {
   #context = null;
 
   /**
+   * Value for {@link #implementedInterfaces}, or `null` if not yet calculated.
+   *
+   * @type {Array<function(new:object)>}
+   */
+  #implementedInterfaces = null;
+
+  /**
    * Constructs an instance.
    *
    * After this constructor returns, it is safe for configuration-bearing
@@ -120,6 +127,23 @@ export class BaseComponent {
   /** @override */
   get context() {
     return (this.#initialized ? this.#context : this.#context?.nascentRoot) ?? null;
+  }
+
+  /**
+   * @returns {Array<function(new:object)>} Array of interface classes that this
+   * class claims to implement. Always a frozen object.
+   */
+  get implementedInterfaces() {
+    if (this.#implementedInterfaces === null) {
+      const ifaces = this.constructor._impl_implementedInterfaces();
+
+      MustBe.arrayOf(ifaces, AskIf.constructorFunction);
+      Object.freeze(ifaces);
+
+      this.#implementedInterfaces = ifaces;
+    }
+
+    return this.#implementedInterfaces;
   }
 
   /** @override */
@@ -230,14 +254,6 @@ export class BaseComponent {
   static #configClass = new Map();
 
   /**
-   * Map from each subclass to its return value for {@link
-   * #IMPLEMENTED_INTERFACES}, lazily filled in.
-   *
-   * @type {Map<function(new:BaseComponent),Array<function(new:object)>>}
-   */
-  static #implementedInterfaces = new Map();
-
-  /**
    * @returns {?function(new:object, object)} The expected configuration class
    * for this class, or `null` if this class does not use a configuration class.
    * Defaults to `null`. Subclasses are expected to override this as necessary.
@@ -258,26 +274,6 @@ export class BaseComponent {
     BaseComponent.#configClass.set(this, configClass);
 
     return configClass;
-  }
-
-  /**
-   * @returns {Array<function(new:object)>} Array of interface classes that this
-   * class claims to implement. Always a frozen object.
-   */
-  static get IMPLEMENTED_INTERFACES() {
-    const already = BaseComponent.#implementedInterfaces.get(this);
-
-    if (already) {
-      return already;
-    }
-
-    const ifaces = this._impl_implementedInterfaces();
-
-    MustBe.arrayOf(ifaces, AskIf.constructorFunction);
-    Object.freeze(ifaces);
-    BaseComponent.#implementedInterfaces.set(this, ifaces);
-
-    return ifaces;
   }
 
   /**
@@ -401,7 +397,7 @@ export class BaseComponent {
   /**
    * @returns {Array<function(new:object)>} Array of interface classes that this
    * class claims to implement. The base class calls this exactly once to get
-   * the value to return from {@link #IMPLEMENTED_INTERFACES}. Defaults to `[]`.
+   * the value to return from {@link #implementedInterfaces}. Defaults to `[]`.
    * Subclasses are expected to override this as necessary.
    */
   static _impl_implementedInterfaces() {

--- a/src/compote/export/RootControlContext.js
+++ b/src/compote/export/RootControlContext.js
@@ -55,7 +55,7 @@ export class RootControlContext extends ControlContext {
     }
 
     if (classes.length !== 0) {
-      const ifaces = found.constructor.IMPLEMENTED_INTERFACES ?? [];
+      const ifaces = found.implementedInterfaces;
       for (const cls of classes) {
         if (!((found instanceof cls) || ifaces.includes(cls))) {
           if (classes.length === 1) {


### PR DESCRIPTION
This PR adds a general `EventFan` service, which fans out events to other named services. This can be used, for example, to do network request logging to multiple destinations, which was in fact the motivation for doing this. And, having done that, the special case of `sendToSystemLog` for `RequestLogger` is no longer necessary and has been removed.