### PR TITLE
Standard "empty block" comment.

### DIFF
--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -114,6 +114,14 @@ meant to record them, in order to keep track of them and maintain consistency.
   historically prefers `'utf8'`, but web standards seem to prefer `'utf-8'`.
   Node generally accepts both, and so we go with the latter.
 
+* If a code block (including a full method body) is intentionally empty, and
+  there's no more-specific comment to be made, the block should include a single
+  line with the following comment:
+
+  ```js
+  // @emptyBlock
+  ```
+
 - - - - - - - - - -
 ```
 Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).

--- a/src/async/export/PromiseUtil.js
+++ b/src/async/export/PromiseUtil.js
@@ -31,7 +31,7 @@ export class PromiseUtil {
       try {
         await maybePromise;
       } catch {
-        // Ignore it.
+        // @emptyBlock
       }
     })();
   }

--- a/src/async/tests/EventSource.test.js
+++ b/src/async/tests/EventSource.test.js
@@ -9,12 +9,12 @@ import { EventPayload, EventSource, LinkedEvent, PromiseState }
 
 // For testing subclass scenarios.
 class ZanyEvent extends LinkedEvent {
-  // This space intentionally left blank.
+  // @emptyBlock
 }
 
 // For testing subclass scenarios.
 class ZanyPayload extends EventPayload {
-  // This space intentionally left blank.
+  // @emptyBlock
 }
 
 

--- a/src/async/tests/LinkedEvent.test.js
+++ b/src/async/tests/LinkedEvent.test.js
@@ -265,7 +265,7 @@ describe('.emitter', () => {
 
   test('returns a function which requires the payload to be an `instanceof` this class\'s payload', () => {
     class SomePayload extends EventPayload {
-      // This space intentionally left blank.
+      // @emptyBlock
     }
 
     const event   = new LinkedEvent(new SomePayload('beep', 1, 2, 3));
@@ -461,7 +461,7 @@ describe('withPayload()', () => {
 
   test('fails if the given payload does not match the class of the existing payload', () => {
     class SomePayload extends EventPayload {
-      // This space intentionally left blank.
+      // @emptyBlock
     }
 
     const event = new LinkedEvent(new SomePayload('boop'));
@@ -506,7 +506,7 @@ describe('withPushedHead()', () => {
 
   test('fails if the given payload does not match the class of the existing payload', () => {
     class SomePayload extends EventPayload {
-      // This space intentionally left blank.
+      // @emptyBlock
     }
 
     const event = new LinkedEvent(new SomePayload('boop'));
@@ -517,7 +517,7 @@ describe('withPushedHead()', () => {
 
 describe('subclass behavior', () => {
   class FlorpEvent extends LinkedEvent {
-    // This space intentionally left blank.
+    // @emptyBlock
   }
 
   test('constructs instances of the subclass when emitting', () => {

--- a/src/async/tests/PromiseState.test.js
+++ b/src/async/tests/PromiseState.test.js
@@ -17,7 +17,7 @@ promRejected.testState  = 'rejected';
   try {
     await promRejected;
   } catch {
-    // Ignore it.
+    // @emptyBlock
   }
 })();
 

--- a/src/built-ins/export/EventFan.js
+++ b/src/built-ins/export/EventFan.js
@@ -87,7 +87,7 @@ export class EventFan extends BaseService {
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // No need to do anything.
+    // @emptyBlock
   }
 
 

--- a/src/built-ins/export/HostRouter.js
+++ b/src/built-ins/export/HostRouter.js
@@ -72,7 +72,7 @@ export class HostRouter extends BaseApplication {
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // Nothing to do here.
+    // @emptyBlock
   }
 
 

--- a/src/built-ins/export/MemoryMonitor.js
+++ b/src/built-ins/export/MemoryMonitor.js
@@ -38,7 +38,7 @@ export class MemoryMonitor extends BaseService {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // Nothing needed here for this class.
+    // @emptyBlock
   }
 
   /** @override */

--- a/src/built-ins/export/PathRouter.js
+++ b/src/built-ins/export/PathRouter.js
@@ -78,7 +78,7 @@ export class PathRouter extends BaseApplication {
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // Nothing to do here.
+    // @emptyBlock
   }
 
 

--- a/src/built-ins/export/ProcessIdFile.js
+++ b/src/built-ins/export/ProcessIdFile.js
@@ -35,7 +35,7 @@ export class ProcessIdFile extends BaseFileService {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // Nothing needed here for this class.
+    // @emptyBlock
   }
 
   /** @override */

--- a/src/built-ins/export/RateLimiter.js
+++ b/src/built-ins/export/RateLimiter.js
@@ -81,7 +81,7 @@ export class RateLimiter extends BaseService {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // Nothing needed here for this class.
+    // @emptyBlock
   }
 
   /** @override */

--- a/src/built-ins/export/RateLimiter.js
+++ b/src/built-ins/export/RateLimiter.js
@@ -86,7 +86,7 @@ export class RateLimiter extends BaseService {
 
   /** @override */
   async _impl_start(isReload_unused) {
-    // Nothing to do here.
+    // @emptyBlock
   }
 
   /** @override */

--- a/src/built-ins/export/Redirector.js
+++ b/src/built-ins/export/Redirector.js
@@ -68,12 +68,12 @@ export class Redirector extends BaseApplication {
 
   /** @override */
   async _impl_start(isReload_unused) {
-    // Nothing to do here.
+    // @emptyBlock
   }
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // Nothing to do here.
+    // @emptyBlock
   }
 
 

--- a/src/built-ins/export/Redirector.js
+++ b/src/built-ins/export/Redirector.js
@@ -63,7 +63,7 @@ export class Redirector extends BaseApplication {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // Nothing needed here for this class.
+    // @emptyBlock
   }
 
   /** @override */

--- a/src/built-ins/export/RequestSyslogger.js
+++ b/src/built-ins/export/RequestSyslogger.js
@@ -48,16 +48,16 @@ export class RequestSyslogger extends BaseService {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // Nothing needed here for this class.
+    // @emptyBlock
   }
 
   /** @override */
   async _impl_start(isReload_unused) {
-    // No need to do anything.
+    // @emptyBlock
   }
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // No need to do anything.
+    // @emptyBlock
   }
 }

--- a/src/built-ins/export/SerialRouter.js
+++ b/src/built-ins/export/SerialRouter.js
@@ -62,7 +62,7 @@ export class SerialRouter extends BaseApplication {
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // Nothing to do here.
+    // @emptyBlock
   }
 
 

--- a/src/built-ins/export/SimpleResponse.js
+++ b/src/built-ins/export/SimpleResponse.js
@@ -45,7 +45,7 @@ export class SimpleResponse extends BaseApplication {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // Nothing needed here for this class.
+    // @emptyBlock
   }
 
   /** @override */

--- a/src/built-ins/export/SimpleResponse.js
+++ b/src/built-ins/export/SimpleResponse.js
@@ -104,7 +104,7 @@ export class SimpleResponse extends BaseApplication {
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // Nothing to do here.
+    // @emptyBlock
   }
 
 

--- a/src/built-ins/export/StaticFiles.js
+++ b/src/built-ins/export/StaticFiles.js
@@ -120,7 +120,7 @@ export class StaticFiles extends BaseApplication {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // Nothing needed here for this class.
+    // @emptyBlock
   }
 
   /** @override */

--- a/src/built-ins/export/StaticFiles.js
+++ b/src/built-ins/export/StaticFiles.js
@@ -155,7 +155,7 @@ export class StaticFiles extends BaseApplication {
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // Nothing to do here.
+    // @emptyBlock
   }
 
   /**

--- a/src/built-ins/tests/PathRouter.test.js
+++ b/src/built-ins/tests/PathRouter.test.js
@@ -23,17 +23,17 @@ export class NopControllable extends BaseComponent {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // This space intentionally left blank.
+    // @emptyBlock
   }
 
   /** @override */
   async _impl_start(isReload_unused) {
-    // This space intentionally left blank.
+    // @emptyBlock
   }
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // This space intentionally left blank.
+    // @emptyBlock
   }
 }
 
@@ -71,17 +71,17 @@ class MockApp extends BaseApplication {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // This space intentionally left blank.
+    // @emptyBlock
   }
 
   /** @override */
   async _impl_start(isReload_unused) {
-    // This space intentionally left blank.
+    // @emptyBlock
   }
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // This space intentionally left blank.
+    // @emptyBlock
   }
 }
 

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -131,7 +131,7 @@ ${'subtract'}
 
   test('returns an instance of the same class as `this`', () => {
     class UqSub extends UnitQuantity {
-      // This space intentionally left blank.
+      // @emptyBlock
     }
 
     const uq1    = new UqSub(123, 'x', 'y');
@@ -150,7 +150,7 @@ describe('inverse()', () => {
 
   test('returns an instance of the preferred inverse class for a subclass that specifies it', () => {
     class UqSub1 extends UnitQuantity {
-      // This space intentionally left blank.
+      // @emptyBlock
     }
 
     class UqSub2 extends UnitQuantity {

--- a/src/loggy/private/LogProxyHandler.js
+++ b/src/loggy/private/LogProxyHandler.js
@@ -231,7 +231,7 @@ export class LogProxyHandler extends PropertyCacheProxyHandler {
     } else if (typeof tag === 'string') {
       tag = new LogTag(tag);
     } else if (tag instanceof LogTag) {
-      // Nothing to do here.
+      // @emptyBlock
     } else {
       // Assume array of string. (The constructor will do a thorough check.)
       tag = new LogTag(...tag);

--- a/src/main-lactoserv/private/Debugging.js
+++ b/src/main-lactoserv/private/Debugging.js
@@ -63,7 +63,7 @@ export class Debugging {
       try {
         await problem;
       } catch {
-        // Ignore.
+        // @emptyBlock
       }
 
       // Wait a moment before continuing with the actually-uncaught examples.

--- a/src/net-protocol/private/HttpWrangler.js
+++ b/src/net-protocol/private/HttpWrangler.js
@@ -35,7 +35,7 @@ export class HttpWrangler extends TcpWrangler {
 
   /** @override */
   async _impl_serverStart(isReload_unused) {
-    // Nothing to do in this case.
+    // @emptyBlock
   }
 
   /** @override */

--- a/src/net-protocol/private/HttpsWrangler.js
+++ b/src/net-protocol/private/HttpsWrangler.js
@@ -41,7 +41,7 @@ export class HttpsWrangler extends TcpWrangler {
 
   /** @override */
   async _impl_serverStart(isReload_unused) {
-    // Nothing to do in this case.
+    // @emptyBlock
   }
 
   /** @override */

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -24,7 +24,7 @@ export class Cookies {
    * Constructs an empty instance.
    */
   constructor() {
-    // This space intentionally left blank.
+    // @emptyBlock
   }
 
   /** @returns {number} How many cookies are in this instance. */

--- a/src/net-util/export/UriUtil.js
+++ b/src/net-util/export/UriUtil.js
@@ -44,7 +44,7 @@ export class UriUtil {
         return value;
       }
     } catch {
-      // Fall through.
+      // Fall through to throw the error.
     }
 
     throw new Error('Must be an absolute URI path.');

--- a/src/sys-framework/export/NetworkHost.js
+++ b/src/sys-framework/export/NetworkHost.js
@@ -98,7 +98,7 @@ export class NetworkHost extends BaseComponent {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    // No need to do anything.
+    // @emptyBlock
   }
 
   /** @override */
@@ -116,7 +116,7 @@ export class NetworkHost extends BaseComponent {
 
   /** @override */
   async _impl_stop(willReload_unused) {
-    // No need to do anything.
+    // @emptyBlock
   }
 
 

--- a/src/sys-util/export/Saver.js
+++ b/src/sys-util/export/Saver.js
@@ -23,7 +23,7 @@ export class Saver extends BaseFilePreserver {
 
   /** @override */
   async _impl_doWork() {
-    // Nothing to do here.
+    // @emptyBlock
   }
 
   /** @override */


### PR DESCRIPTION
This is a little spring-cleaning PR, where all the various `// This space intentionally left blank.` type comments that indicate an intentionally empty block (or method body) are changed to consistently be `// @emptyBlock`.