### PR TITLE
`SyslogToFile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@ Breaking changes:
   * Made `getLogInfo()` an instance (not `static`) method, and fixed its
     reporting of `contentLength`.
 * `built-ins`:
-  * Renamed network access log services to use the name `AccessLog*`, instead
-    of `RequestLogger` (or similar). This is to avoid confusion with system
-    logging stuff, which more or less has a lock on the term "logger" in this
-    project.
+  * Renamed network access log services to use the class name `AccessLogTo*`,
+    instead of `RequestLogger` (or similar). This is to avoid confusion with the
+    objects used to emit system logging messages, which more or less have a lock
+    on the term name `*loggger` in this project.
+  * Renamed `SystemLogger` to `SyslogToFile`, to match the analogous access log
+    class name.
 * Configuration:
   * As with `built-ins`, renamed the service role name for access logging from
     `requestLogger` to `accessLog`.

--- a/doc/configuration/3-built-in-services.md
+++ b/doc/configuration/3-built-in-services.md
@@ -292,10 +292,10 @@ const services = [
 ];
 ```
 
-## `SystemLogger`
+## `SyslogToFile`
 
-A service which logs system activity either in a human-friendly or JSON form. It
-accepts the following configuration bindings:
+A service which writes system activity logis either in a human-friendly or JSON
+form, to a (filesystem) file. It accepts the following configuration bindings:
 
 * `path` &mdash; Path to the log file(s) to write. When rotation is performed, a
   date stamp and (if necessary) sequence number are "infixed" into the final
@@ -311,12 +311,12 @@ highly advisable to set up sane limits on the amount of storage used by
 configuring `rotate`.
 
 ```js
-import { SystemLogger } from '@lactoserv/built-ins';
+import { SyslogToFile } from '@lactoserv/built-ins';
 
 const services = [
   {
     name:   'syslog-json',
-    class:  SystemLogger,
+    class:  SyslogToFile,
     path:   '/path/to/var/log/system-log.json',
     format: 'json',
     rotate: { /* ... */ }

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -5,7 +5,7 @@ import * as fs from 'node:fs/promises';
 
 import { AccessLogToFile, AccessLogToSyslog, EventFan, HostRouter,
   MemoryMonitor, PathRouter, ProcessIdFile, ProcessInfoFile, RateLimiter,
-  Redirector, SerialRouter, SimpleResponse, StaticFiles, SystemLogger }
+  Redirector, SerialRouter, SimpleResponse, StaticFiles, SyslogToFile }
   from '@lactoserv/built-ins';
 
 
@@ -62,7 +62,7 @@ const services = [
   },
   {
     name:   'syslog',
-    class:  SystemLogger,
+    class:  SyslogToFile,
     path:   `${LOG_DIR}/system-log.txt`,
     format: 'human',
     rotate: {
@@ -74,7 +74,7 @@ const services = [
   },
   {
     name:   'syslogJson',
-    class:  SystemLogger,
+    class:  SyslogToFile,
     path:   `${LOG_DIR}/system-log.json`,
     format: 'json',
     rotate: {

--- a/src/built-ins/export/SyslogToFile.js
+++ b/src/built-ins/export/SyslogToFile.js
@@ -13,7 +13,7 @@ import { MustBe } from '@this/typey';
  *
  * See `doc/configuration` for configuration object details.
  */
-export class SystemLogger extends BaseFileService {
+export class SyslogToFile extends BaseFileService {
   /**
    * File rotator to use, if any.
    *
@@ -69,7 +69,7 @@ export class SystemLogger extends BaseFileService {
     // during a same-process system restart (e.g. in response to a restart
     // signal). In particular, this is an attempt to minimize double-logging
     // events.
-    this.logger[SystemLogger.#END_EVENT_TYPE]();
+    this.logger[SyslogToFile.#END_EVENT_TYPE]();
 
     await this.#sink.drainAndStop();
     await this.#rotator?.stop(willReload);
@@ -90,7 +90,7 @@ export class SystemLogger extends BaseFileService {
     const tagToFind     = this.logger.$meta.tag;
 
     const found = tracker.advanceSync((event) => {
-      return (event.type === SystemLogger.#END_EVENT_TYPE)
+      return (event.type === SyslogToFile.#END_EVENT_TYPE)
         && (event.payload.tag.equals(tagToFind));
     });
 

--- a/src/built-ins/index.js
+++ b/src/built-ins/index.js
@@ -14,4 +14,4 @@ export * from '#x/Redirector';
 export * from '#x/SerialRouter';
 export * from '#x/SimpleResponse';
 export * from '#x/StaticFiles';
-export * from '#x/SystemLogger';
+export * from '#x/SyslogToFile';


### PR DESCRIPTION
This small PR makes the system logging service have a name that is more harmonious with the access log services.