### PR TITLE
`PathRouter` path syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Breaking changes:
 * None.
 
 Other notable changes:
-* None.
+* `built-ins`:
+  * Loosened restrictions on path component syntax in `PathRouter`.
 
 ### v0.6.13 -- 2024-04-03
 

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -178,14 +178,17 @@ it accepts the following bindings:
 The keys in `paths` must start with a slash (`/`). (The idea is that they are
 _absolute_ paths within the scope of the router, even though they are
 effectively _relative_ paths with respect to whatever the router is mounted
-within.)
+within.) The components within paths are required to adhere to the normal syntax of URIs,
+with the following additional restrictions:
 
-The components within paths are required to adhere to the normal syntax of URIs,
-with the one additional restriction that path components consisting solely of
-one or more asterisks (`*`) are not allowed (to avoid confusion with wildcards).
-See [RFC 3986
-section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3) for the
-details.
+* No path components consisting solely of one or more asterisks (`*`), to avoid
+  confusion with wildcards.
+* No empty path components (`...//...`). It's too confusing.
+* No "directory navigation" components, that is, `.` or `..`. They couldn't
+  ever be matched anyway, because of URI canonicalization.
+
+See [RFC 3986 section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3)
+for the full syntax of URI paths.
 
 The routing works by starting with the most specific match to the path of an
 incoming request. If that app does not try to handle the request &mdash;

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -172,12 +172,20 @@ it accepts the following bindings:
 
 * `paths` &mdash; A plain object with possibly-wildcarded paths as keys, and
   the _names_ of other applications as values. A wildcard only covers the suffix
-  of a path; it cannot be used for prefixes or infixes.
+  of a path; it cannot be used for prefixes or infixes. Wildcards are indicated
+  with the path suffix `/*`.
 
 The keys in `paths` must start with a slash (`/`). (The idea is that they are
 _absolute_ paths within the scope of the router, even though they are
 effectively _relative_ paths with respect to whatever the router is mounted
 within.)
+
+The components within paths are required to adhere to the normal syntax of URIs,
+with the one additional restriction that path components consisting solely of
+one or more asterisks (`*`) are not allowed (to avoid confusion with wildcards).
+See [RFC 3986
+section 3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3) for the
+details.
 
 The routing works by starting with the most specific match to the path of an
 incoming request. If that app does not try to handle the request &mdash;

--- a/src/built-ins/export/PathRouter.js
+++ b/src/built-ins/export/PathRouter.js
@@ -167,20 +167,27 @@ export class PathRouter extends BaseApplication {
       }
 
       for (const p of parts) {
+        const error = (detail) => {
+          detail = detail ? ` (${detail})` : '';
+          return new Error(`Invalid path component \`${p}\`${detail} in: ${path}`);
+        };
+
         switch (p) {
           case '': {
-            throw new Error(`Empty path component in: ${path}`);
+            throw error('empty');
           }
           case '.':
           case '..': {
-            throw new Error(`Invalid path component \`${p}\` in: ${path}`);
+            throw error('navigation');
           }
           case '*': {
-            throw new Error(`Non-final \`*\` in path: ${path}`);
+            throw error('non-final wildcard');
           }
           default: {
-            if (!/^[-_.a-zA-Z0-9]+$/.test(p)) {
-              throw new Error(`Invalid path component \`${p}\` in: ${path}`);
+            if (/^[*]+$/.test(p)) {
+              throw error();
+            } else if (!UriUtil.isPathComponent(p)) {
+              throw error();
             }
           }
         }

--- a/src/net-protocol/export/ProtocolWranglers.js
+++ b/src/net-protocol/export/ProtocolWranglers.js
@@ -1,6 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { MustBe } from '@this/typey';
+
 import { Http2Wrangler } from '#p/Http2Wrangler';
 import { HttpWrangler } from '#p/HttpWrangler';
 import { HttpsWrangler } from '#p/HttpsWrangler';
@@ -40,5 +42,23 @@ export class ProtocolWranglers {
     }
 
     return new cls(options);
+  }
+
+  /**
+   * Checks that this module knows of a protocol by the given name.
+   *
+   * @param {string} name Protocol name.
+   * @returns {string} `name` if it is a known protocol.
+   * @throws {Error} Thrown if `name` is not a known protocol (or is not a
+   *   string).
+   */
+  static checkProtocol(name) {
+    MustBe.string(name);
+
+    if (!this.#WRANGLER_CLASSES.has(name)) {
+      throw new Error(`Unknown protocol: ${name}`);
+    }
+
+    return name;
   }
 }

--- a/src/net-util/export/UriUtil.js
+++ b/src/net-util/export/UriUtil.js
@@ -55,20 +55,6 @@ export class UriUtil {
   }
 
   /**
-   * Checks that a given value is a string representing a protocol name (as
-   * allowed by this system).
-   *
-   * @param {*} value Value in question.
-   * @returns {string} `value` if it is a string which matches the stated
-   *   pattern.
-   * @throws {Error} Thrown if `value` does not match.
-   */
-  static checkProtocol(value) {
-    const pattern = /^(http|https|http2)$/;
-    return MustBe.string(value, pattern);
-  }
-
-  /**
    * Checks if a given string is syntactically valid as a received URI path
    * component (thing between slashes or at the end of a path before queries,
    * etc.), per RFC 3986. The caveat "received" is that `.` and `..` are

--- a/src/net-util/export/UriUtil.js
+++ b/src/net-util/export/UriUtil.js
@@ -109,6 +109,39 @@ export class UriUtil {
   }
 
   /**
+   * Checks if a given string is syntactically valid as a received URI path
+   * component (thing between slashes or at the end of a path before queries,
+   * etc.), per RFC 3986. The caveat "received" is that `.` and `..` are
+   * supposed to get "resolved away" before being sent to a server.
+   *
+   * @param {*} component Alleged path component.
+   * @returns {boolean} `true` if `component` is actually syntactically valid.
+   */
+  static isPathComponent(component) {
+    MustBe.string(component);
+
+    if ((component === '.') || (component === '..')) {
+      return false;
+    }
+
+    // Allow ASCII alphanumerics, plus any of `-_.~!$&'()*+,;=:@%`.
+    if (!/^[-_.~!$&'()*+,;=:@%A-Za-z0-9]*$/.test(component)) {
+      return false;
+    }
+
+    // If there are any `%`s, they must be valid percent-encoded sequences.
+    if (/%/.test(component)) {
+      for (const [match] of component.matchAll(/%.{0,2}/g)) {
+        if (!/^%[0-9A-F]{2}$/.test(match)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * Gets the string form of a {@link TreePathKey} as a URI path, that is, the
    * part of a URI after the hostname. The result is in absolute form by default
    * (prefixed with `/`), or is optionally in relative form (prefixed with

--- a/src/net-util/export/UriUtil.js
+++ b/src/net-util/export/UriUtil.js
@@ -11,46 +11,6 @@ import { MustBe } from '@this/typey';
  */
 export class UriUtil {
   /**
-   * Checks that a given value is a string which can be interpreted as an
-   * absolute URI path (no protocol, host, etc.). It must:
-   *
-   * * Start with a slash (`/`).
-   * * End with a slash (`/`).
-   * * Not contain double (or more) slashes.
-   * * Not contain `.` or `..` path components.
-   * * Not contain a query or hash fragment.
-   * * Not contain characters that need `%`-encoding. (It is expected to be
-   *   pre-encoded.)
-   *
-   * @param {*} value Value in question.
-   * @returns {string} `value` if it is a string which matches the pattern.
-   * @throws {Error} Thrown if `value` does not match.
-   */
-  static checkAbsolutePath(value) {
-    // Basic constraints.
-    const pattern =
-      '^' +
-      '(?=[/])' +              // Must start with a slash.
-      '(?!.*[/][.]{0,2}[/])' + // No empty, `.`, or `..` components.
-      '.*/$';                  // Must end with a slash.
-
-    MustBe.string(value, pattern);
-
-    // Check the rest of the constraints by parsing and only accepting it if
-    // a successfully-parsed path is the same as the given one.
-    try {
-      const url = new URL(`http://x${value}`);
-      if (url.pathname === value) {
-        return value;
-      }
-    } catch {
-      // Fall through to throw the error.
-    }
-
-    throw new Error('Must be an absolute URI path.');
-  }
-
-  /**
    * Checks that a given value is a string which can be interpreted as a "basic"
    * absolute URI. It must:
    *

--- a/src/net-util/tests/UriUtil.test.js
+++ b/src/net-util/tests/UriUtil.test.js
@@ -5,39 +5,6 @@ import { TreePathKey } from '@this/collections';
 import { UriUtil } from '@this/net-util';
 
 
-describe('checkAbsolutePath()', () => {
-  // Failure cases.
-  test.each`
-  label                               | path
-  ${'null'}                           | ${null}
-  ${'non-string'}                     | ${123}
-  ${'no slash at start'}              | ${'foo/bar/'}
-  ${'no slash at end'}                | ${'/foo/bar'}
-  ${'double slash at start'}          | ${'//foo/bar/'}
-  ${'double slash in middle'}         | ${'/foo//bar/'}
-  ${'double slash at end'}            | ${'/foo/bar//'}
-  ${'triple slash'}                   | ${'/foo///bar/'}
-  ${'`.` component'}                  | ${'/foo/./bar/'}
-  ${'`..` component'}                 | ${'/foo/../bar/'}
-  ${'query'}                          | ${'/foo?x=123/'}
-  ${'hash fragment'}                  | ${'/foo#123/'}
-  ${'character needing `%`-encoding'} | ${'/foo/b ar/'}
-  `('fails for $label', ({ path }) => {
-    expect(() => UriUtil.checkAbsolutePath(path)).toThrow();
-  });
-
-  // Success cases.
-  test.each`
-  path
-  ${'/'}
-  ${'/foo/'}
-  ${'/foo/bar/'}
-  ${'/foo/b%20ar/'}
-  `('succeeds for $path', ({ path }) => {
-    expect(UriUtil.checkAbsolutePath(path)).toBe(path);
-  });
-});
-
 describe('checkBasicUri()', () => {
   // Failure cases.
   test.each`

--- a/src/net-util/tests/UriUtil.test.js
+++ b/src/net-util/tests/UriUtil.test.js
@@ -43,28 +43,6 @@ describe('checkBasicUri()', () => {
   });
 });
 
-describe('checkProtocol()', () => {
-  // Failure cases.
-  test.each`
-  label                 | protocol
-  ${'null'}             | ${null}
-  ${'non-string'}       | ${123}
-  ${'invalid protocol'} | ${'ftp'}
-  `('fails for $label', ({ protocol }) => {
-    expect(() => UriUtil.checkProtocol(protocol)).toThrow();
-  });
-
-  // Success cases.
-  test.each`
-  protocol
-  ${'http'}
-  ${'https'}
-  ${'http2'}
-  `('succeeds for $protocol', ({ protocol }) => {
-    expect(UriUtil.checkProtocol(protocol)).toBe(protocol);
-  });
-});
-
 describe('pathStringFrom()', () => {
   describe.each`
   relArg     | label

--- a/src/sys-framework/export/NetworkEndpoint.js
+++ b/src/sys-framework/export/NetworkEndpoint.js
@@ -208,7 +208,7 @@ export class NetworkEndpoint extends BaseComponent {
 
       this.#interface   = Object.freeze(HostUtil.parseInterface(iface));
       this.#application = Names.checkName(application);
-      this.#protocol    = UriUtil.checkProtocol(protocol);
+      this.#protocol    = ProtocolWranglers.checkProtocol(protocol);
       this.#services    = new ServiceUseConfig(services);
     }
 


### PR DESCRIPTION
This PR loosens up the allowed syntax for path components in `PathRouter`.