### PR TITLE
Threadlet cleanup

### DIFF
--- a/src/async/export/BaseExposedThreadlet.js
+++ b/src/async/export/BaseExposedThreadlet.js
@@ -66,7 +66,7 @@ export class BaseExposedThreadlet {
    * @returns {*} Arbitrary result of starting.
    * @throws {Error} Arbitrary error from starting.
    */
-  async _impl_start(runnerAccess) { // eslint-disable-line no-unused-vars
+  async _impl_threadStart(runnerAccess) { // eslint-disable-line no-unused-vars
     return null;
   }
 
@@ -80,7 +80,7 @@ export class BaseExposedThreadlet {
    * @returns {*} Arbitrary result of starting.
    * @throws {Error} Arbitrary error from starting.
    */
-  async _impl_run(runnerAccess) { // eslint-disable-line no-unused-vars
+  async _impl_threadRun(runnerAccess) { // eslint-disable-line no-unused-vars
     return null;
   }
 
@@ -102,13 +102,13 @@ export class BaseExposedThreadlet {
    */
   async #start(runnerAccess) {
     this.#runnerAccess = runnerAccess;
-    return this._impl_start(runnerAccess);
+    return this._impl_threadStart(runnerAccess);
   }
 
   /**
    * Threadlet main function.
    */
   async #main() {
-    return this._impl_run(this.#runnerAccess);
+    return this._impl_threadRun(this.#runnerAccess);
   }
 }

--- a/src/async/export/BaseExposedThreadlet.js
+++ b/src/async/export/BaseExposedThreadlet.js
@@ -1,0 +1,114 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { IntfThreadlike } from '#x/IntfThreadlike';
+import { Threadlet } from '#x/Threadlet';
+
+
+/**
+ * Base class which implements {@link IntfThreadlike} by deferring to an
+ * internally-managed {@link Threadlet} instance, whose run functions are
+ * defined by the concrete subclass.
+ *
+ * @implements {IntfThreadlike}
+ */
+export class BaseExposedThreadlet {
+  /**
+   * The threadlet which runs this instance.
+   *
+   * @type {Threadlet}
+   */
+  #threadlet = new Threadlet(
+    (runnerAccess) => this.#start(runnerAccess),
+    () => this.#main());
+
+  /**
+   * The runner access instance, if known.
+   *
+   * @type {?Threadlet.RunnerAccess}
+   */
+  #runnerAccess = null;
+
+  // @defaultConstructor
+
+  /** @override */
+  isRunning() {
+    return this.#threadlet.isRunning();
+  }
+
+  /** @override */
+  async run() {
+    return this.#threadlet.run();
+  }
+
+  /** @override */
+  async start() {
+    return this.#threadlet.start();
+  }
+
+  /** @override */
+  async stop() {
+    return this.#threadlet.stop();
+  }
+
+  /** @override */
+  async whenStarted() {
+    return this.#threadlet.whenStarted();
+  }
+
+  /**
+   * Runs subclass-specific start-time actions. This corresponds to the "start
+   * function" described by {@link Threadlet}. Subclasses that wish to have
+   * start actions must override this. By default it does nothing except return
+   * `null`.
+   *
+   * @param {Threadlet.RunnerAccess} runnerAccess The runner access instance.
+   * @returns {*} Arbitrary result of starting.
+   * @throws {Error} Arbitrary error from starting.
+   */
+  async _impl_start(runnerAccess) { // eslint-disable-line no-unused-vars
+    return null;
+  }
+
+  /**
+   * Runs the subclass-specific main thread action. This corresponds to the
+   * "main function" described by {@link Threadlet}. Subclasses that wish to
+   * have any main action must override this. By default it does nothing except
+   * return `null`.
+   *
+   * @param {Threadlet.RunnerAccess} runnerAccess The runner access instance.
+   * @returns {*} Arbitrary result of starting.
+   * @throws {Error} Arbitrary error from starting.
+   */
+  async _impl_main(runnerAccess) { // eslint-disable-line no-unused-vars
+    return null;
+  }
+
+  /**
+   * Gets the {@link Threadlet.RunnerAccess} instance associated with this
+   * instance's {@link Threadlet}. This protected method is only supposed to be
+   * used in this class's `_impl_*` methods.
+   *
+   * @returns {Threadlet.RunnerAccess} The runner access instance.
+   */
+  _prot_runnerAccess() {
+    return this.#runnerAccess;
+  }
+
+  /**
+   * Threadlet start function.
+   *
+   * @param {Threadlet.RunnerAccess} runnerAccess The runner access instance.
+   */
+  async #start(runnerAccess) {
+    this.#runnerAccess = runnerAccess;
+    return this._impl_start(runnerAccess);
+  }
+
+  /**
+   * Threadlet main function.
+   */
+  async #main() {
+    return this._impl_main(this.#runnerAccess);
+  }
+}

--- a/src/async/export/BaseExposedThreadlet.js
+++ b/src/async/export/BaseExposedThreadlet.js
@@ -80,7 +80,7 @@ export class BaseExposedThreadlet {
    * @returns {*} Arbitrary result of starting.
    * @throws {Error} Arbitrary error from starting.
    */
-  async _impl_main(runnerAccess) { // eslint-disable-line no-unused-vars
+  async _impl_run(runnerAccess) { // eslint-disable-line no-unused-vars
     return null;
   }
 
@@ -109,6 +109,6 @@ export class BaseExposedThreadlet {
    * Threadlet main function.
    */
   async #main() {
-    return this._impl_main(this.#runnerAccess);
+    return this._impl_run(this.#runnerAccess);
   }
 }

--- a/src/async/export/EventSink.js
+++ b/src/async/export/EventSink.js
@@ -74,7 +74,7 @@ export class EventSink extends BaseExposedThreadlet {
   }
 
   /** @override */
-  async _impl_run() {
+  async _impl_threadRun() {
     // Main thread body: Processes events as they become available, until a
     // problem is encountered or we're requested to stop.
 

--- a/src/async/export/EventSink.js
+++ b/src/async/export/EventSink.js
@@ -3,6 +3,7 @@
 
 import { MustBe } from '@this/typey';
 
+import { BaseExposedThreadlet } from '#x/BaseExposedThreadlet';
 import { EventOrPromise } from '#p/EventOrPromise';
 import { LinkedEvent } from '#x/LinkedEvent';
 import { Threadlet } from '#x/Threadlet';
@@ -15,7 +16,7 @@ import { Threadlet } from '#x/Threadlet';
  * running they are always either processing existing events or waiting for new
  * events to be emitted on the chain they track.
  */
-export class EventSink extends Threadlet {
+export class EventSink extends BaseExposedThreadlet {
   /**
    * Function to call, to process each event.
    *
@@ -47,7 +48,7 @@ export class EventSink extends Threadlet {
    *   processed by the instance, or promise for same.
    */
   constructor(processor, firstEvent) {
-    super(() => this.#run());
+    super();
 
     this.#processor = MustBe.callableFunction(processor).bind(null);
     this.#head      = new EventOrPromise(firstEvent);
@@ -72,6 +73,20 @@ export class EventSink extends Threadlet {
     await this.stop();
   }
 
+  /** @override */
+  async _impl_run() {
+    // Main thread body: Processes events as they become available, until a
+    // problem is encountered or we're requested to stop.
+
+    this.#draining = false;
+
+    for (;;) {
+      if (await this.#runStep()) {
+        break;
+      }
+    }
+  }
+
   /**
    * Gets the current head event -- possibly waiting for it -- or returns `null`
    * if the instance has been asked to stop.
@@ -80,14 +95,16 @@ export class EventSink extends Threadlet {
    * @throws {Error} Thrown if there is any trouble getting the event.
    */
   async #headEvent() {
+    const runnerAccess = this._prot_runnerAccess();
+
     for (let pass = 1; pass <= 2; pass++) {
       if (pass === 2) {
         // On the second pass, wait for something salient to happen. (On the
         // first pass, waiting would achieve nothing but inefficiency.)
-        await this.raceWhenStopRequested([this.#head.eventPromise]);
+        await runnerAccess.raceWhenStopRequested([this.#head.eventPromise]);
       }
 
-      if (!this.#draining && this.shouldStop()) {
+      if (!this.#draining && runnerAccess.shouldStop()) {
         return null;
       }
 
@@ -103,21 +120,8 @@ export class EventSink extends Threadlet {
   }
 
   /**
-   * Main thread body: Processes events as they become available, until a
-   * problem is encountered or we're requested to stop.
-   */
-  async #run() {
-    this.#draining = false;
-
-    for (;;) {
-      if (await this.#runStep()) {
-        break;
-      }
-    }
-  }
-
-  /**
-   * Helper for {@link #run}, which performs one iteration of the inner loop.
+   * Helper for {@link #_impl_run}, which performs one iteration of the inner
+   * loop.
    *
    * @returns {boolean} Done flag: if `true`, the caller of this method should
    *   itself return.

--- a/src/async/export/IntfThreadlike.js
+++ b/src/async/export/IntfThreadlike.js
@@ -1,0 +1,78 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { Methods } from '@this/typey';
+
+
+/**
+ * Interface for thread-like things, which can be started, stopped, queried
+ * about state, and are capable of yielding a result from running.
+ *
+ * @interface
+ */
+export class IntfThreadlike {
+  /**
+   * Is this instance currently running?
+   *
+   * @returns {boolean} The answer.
+   */
+  isRunning() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * Starts this instance running, if it isn't already. This async-returns once
+   * the run is complete.
+   *
+   * **Note:** To be clear, if the instance was already running when this method
+   * was called, the return value from this method will be the same value as
+   * returned (or the same exception thrown) from the call which actually
+   * started the instance running.
+   *
+   * @returns {*} Whatever result is produced by the instance's action of
+   *   running whatever it is that it runs.
+   * @throws {Error} Anything thrown while the instance ran or tried to run.
+   */
+  async run() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * Starts this instance running as with {@link #run}, except that it
+   * async-returns once the instance is _started_, as with {@link #whenStarted}.
+   *
+   * @returns {*} Return value from {@link #whenStarted} (see which).
+   * @throws {Error} Error thrown by {@link #whenStarted} (see which).
+   */
+  async start() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * Requests that this instance stop running as soon as possible. If this
+   * instance was started by a call to {@link #run}, then this method
+   * async-returns the same return value as what that call returns. If the
+   * instance isn't running when this method is called, it promptly returns
+   * `null` (and _not_, e.g., the result of an earlier run).
+   *
+   * @returns {*} Whatever was (or would have been) returned by {@link #run}.
+   * @throws {Error} Whatever was (or would have been) thrown by {@link #run}.
+   */
+  async stop() {
+    throw Methods.abstract();
+  }
+
+  /**
+   * Gets a promise that becomes settled when this instance is running and after
+   * any pre-run actions have been completed. It becomes settled (fulfilled or
+   * rejected) with the result of the pre-run actions. If `isRunning() ===
+   * false` when this method is called, it async-returns `null` promptly.
+   *
+   * @returns {*} Whatever was returned by the pre-run actions, or `null` if
+   *   there were no pre-run actions.
+   * @throws {Error} Whatever was thrown by the pre-run actions.
+   */
+  async whenStarted() {
+    throw Methods.abstract();
+  }
+}

--- a/src/async/export/Threadlet.js
+++ b/src/async/export/Threadlet.js
@@ -362,19 +362,45 @@ export class Threadlet {
       Object.freeze(this);
     }
 
+    /**
+     * @returns {Threadlet} The `Threadlet` instance which this instance
+     *   provides access to.
+     */
     get threadlet() {
       return this.#outerThis;
     }
 
+    /**
+     * Runs a `Promise.race()` between the result of {@link #whenStopRequested}
+     * and the given additional promises.
+     *
+     * @param {Array<*>} promises Array (or iterable in general) of promises to
+     *   race.
+     * @returns {boolean} `true` iff this instance has been asked to stop
+     *  (as with {@link #shouldStop}), if the race was won by a non-rejected
+     *  promise.
+     * @throws {*} The rejected result of the promise that won the race.
+     */
     async raceWhenStopRequested(promises) {
       return this.#outerThis.raceWhenStopRequested(promises);
     }
 
+    /**
+     * Should the current run stop?
+     *
+     * @returns {boolean} `true` iff this instance has been asked to stop.
+     */
     shouldStop() {
       return this.#outerThis.shouldStop();
     }
 
-    async whenStopRequested() {
+    /**
+     * Gets a promise that becomes fulfilled when this instance has been asked
+     * to stop (or when it is already stopped).
+     *
+     * @returns {Promise} A promise as described.
+     */
+    whenStopRequested() {
       return this.#outerThis.whenStopRequested();
     }
   };

--- a/src/async/export/Threadlet.js
+++ b/src/async/export/Threadlet.js
@@ -4,6 +4,7 @@
 import { MustBe } from '@this/typey';
 
 import { Condition } from '#x/Condition';
+import { IntfThreadlike } from '#x/IntfThreadlike';
 import { PromiseUtil } from '#x/PromiseUtil';
 
 
@@ -15,6 +16,8 @@ import { PromiseUtil } from '#x/PromiseUtil';
  * function is responsible for proactively figuring out when to stop. It can do
  * this by using the methods {@link #shouldStop} and {@link #whenStopRequested}
  * on the instance of this class that it is called with.
+ *
+ * @implements {IntfThreadlike}
  */
 export class Threadlet {
   /**
@@ -109,11 +112,7 @@ export class Threadlet {
     }
   }
 
-  /**
-   * Is this instance currently running?
-   *
-   * @returns {boolean} The answer.
-   */
+  /** @override */
   isRunning() {
     return this.#runResult !== null;
   }
@@ -144,23 +143,15 @@ export class Threadlet {
   }
 
   /**
-   * Starts this instance running, if it isn't already.  All processing in the
-   * thread happens asynchronously with respect to the caller of this method.
-   * The async-return value or exception thrown from this method is (in order):
+   * As a clarification to the interface's contract for this method, the
+   * async-return value or exception thrown from this method is (in order):
    *
    * * The exception thrown by the start function, if this instance has a start
    *   function which threw.
    * * The exception thrown by the main function, if it threw.
    * * The return value from the main function.
    *
-   * **Note:** To be clear, if the instance was already running when this method
-   * was called, the return value from this method will be the same value as
-   * returned (or the same exception thrown) from the call which actually
-   * started the instance running.
-   *
-   * @returns {*} Whatever is returned by the main function.
-   * @throws {Error} Whatever was thrown by either the start function or the
-   *   main function.
+   * @override
    */
   async run() {
     return this.#run(true);
@@ -176,13 +167,7 @@ export class Threadlet {
     return this.#runningCondition.value === false;
   }
 
-  /**
-   * Starts this instance running as with {@link #run}, except that it
-   * async-returns once the instance is _started_ as with {@link #whenStarted}.
-   *
-   * @returns {*} Return value from {@link #whenStarted} (see which).
-   * @throws {Error} Error thrown by {@link #whenStarted} (see which).
-   */
+  /** @override */
   async start() {
     // Squelch any error from `run()`, because otherwise it will turn into an
     // impossible-to-actually-handle promise rejection. It's up to clients to
@@ -192,16 +177,7 @@ export class Threadlet {
     return this.whenStarted();
   }
 
-  /**
-   * Requests that this instance stop running as soon as possible. This method
-   * async-returns the same return value as the call to {@link #run} which
-   * started instance. If the instance isn't running when this method is called,
-   * it promptly returns `null` (and _not_, e.g., the result of an earlier run).
-   *
-   * @returns {*} Whatever is returned by the main function.
-   * @throws {Error} Whatever was thrown by either the start function or the
-   *   main function.
-   */
+  /** @override */
   async stop() {
     if (!this.isRunning()) {
       return null;
@@ -211,19 +187,7 @@ export class Threadlet {
     return this.#run(true);
   }
 
-  /**
-   * Gets a promise that becomes settled when this instance is running and after
-   * its start function has completed. It becomes _fulfilled_ with the result of
-   * calling the start function, if the start function returned without error.
-   * It becomes _rejected_ with the same reason as whatever the start function
-   * threw, if the start function indeed threw an error. If `isRunning() ===
-   * false` when this method is called, it async-returns `null` promptly.
-   *
-   * @returns {*} Whatever was returned by the start function, with exceptions
-   *   as noted above.
-   * @throws {Error} The same error as thrown by the start function, if it threw
-   *   an error.
-   */
+  /** @override */
   async whenStarted() {
     if (!this.isRunning()) {
       return null;

--- a/src/async/export/Threadlet.js
+++ b/src/async/export/Threadlet.js
@@ -32,7 +32,9 @@ export class Threadlet {
   #mainFunction;
 
   /**
-   * Intended current state of whether or not this instance is running.
+   * Intended current state of whether or not this instance is running. That is,
+   * it answers the question "Should we be running?" and not "Are we actually
+   * running?"
    *
    * @type {Condition}
    */

--- a/src/async/export/Threadlet.js
+++ b/src/async/export/Threadlet.js
@@ -244,17 +244,6 @@ export class Threadlet {
   }
 
   /**
-   * Properly wraps a function so it can be called with no arguments in {@link
-   * #run}.
-   *
-   * @param {function(*)} func Function to wrap.
-   * @returns {function(*)} Wrapped version.
-   */
-  #wrapFunction(func) {
-    return () => func(this);
-  }
-
-  /**
    * Runs the thread if it's not already running, or just returns the promise
    * for the current run-in-progress.
    *

--- a/src/async/export/Threadlet.js
+++ b/src/async/export/Threadlet.js
@@ -36,7 +36,7 @@ export class Threadlet {
    *
    * @type {Condition}
    */
-  #runCondition = new Condition();
+  #runningCondition = new Condition();
 
   /**
    * Promised result of the currently-executing {@link #run}, if the instance is
@@ -127,7 +127,7 @@ export class Threadlet {
 
     // List our stop condition last, because it is likely to be unresolved; we
     // thus might get to avoid some work in the call to `race()`.
-    const allProms = [...promises, this.#runCondition.whenFalse()];
+    const allProms = [...promises, this.#runningCondition.whenFalse()];
 
     await PromiseUtil.race(allProms);
 
@@ -164,7 +164,7 @@ export class Threadlet {
    * @returns {boolean} `true` iff this instance has been asked to stop.
    */
   shouldStop() {
-    return this.#runCondition.value === false;
+    return this.#runningCondition.value === false;
   }
 
   /**
@@ -198,7 +198,7 @@ export class Threadlet {
       return null;
     }
 
-    this.#runCondition.value = false;
+    this.#runningCondition.value = false;
     return this.#run(true);
   }
 
@@ -231,7 +231,7 @@ export class Threadlet {
    * @returns {Promise} A promise as described.
    */
   whenStopRequested() {
-    return this.#runCondition.whenFalse();
+    return this.#runningCondition.whenFalse();
   }
 
   /**
@@ -255,8 +255,8 @@ export class Threadlet {
    */
   #run(exposed = false) {
     if (!this.isRunning()) {
-      this.#runCondition.value = true;
-      this.#runResult          = this.#run0();
+      this.#runningCondition.value = true;
+      this.#runResult              = this.#run0();
     }
 
     this.#runResultExposed ||= exposed;
@@ -307,10 +307,10 @@ export class Threadlet {
       // as of the end of this method (which will be happening synchronously),
       // running will have stopped. Similar logic applies to the other
       // properties.
-      this.#startResult        = null;
-      this.#runResultExposed   = false;
-      this.#runResult          = null;
-      this.#runCondition.value = false;
+      this.#startResult            = null;
+      this.#runResultExposed       = false;
+      this.#runResult              = null;
+      this.#runningCondition.value = false;
     }
   }
 

--- a/src/async/index.js
+++ b/src/async/index.js
@@ -6,6 +6,7 @@ export * from '#x/EventPayload';
 export * from '#x/EventSink';
 export * from '#x/EventSource';
 export * from '#x/EventTracker';
+export * from '#x/IntfThreadlike';
 export * from '#x/LinkedEvent';
 export * from '#x/ManualPromise';
 export * from '#x/Mutex';

--- a/src/async/index.js
+++ b/src/async/index.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+export * from '#x/BaseExposedThreadlet';
 export * from '#x/Condition';
 export * from '#x/EventPayload';
 export * from '#x/EventSink';

--- a/src/async/tests/Threadlet.test.js
+++ b/src/async/tests/Threadlet.test.js
@@ -296,7 +296,7 @@ describe('run()', () => {
       await expect(runResult).toResolve();
     });
 
-    test('causes the main function to be called, with the thread as its argument', async () => {
+    test('causes the main function to be called, with an appropriate access object as its argument', async () => {
       let gotArgs = null;
       const thread = new Threadlet(...startArg, (...args) => {
         gotArgs = args;
@@ -304,7 +304,10 @@ describe('run()', () => {
 
       const runResult = thread.run();
       await setImmediate();
-      expect(gotArgs).toStrictEqual([thread]);
+      expect(gotArgs).toBeArrayOfSize(1);
+      const gotArg = gotArgs[0];
+      expect(gotArg).toBeInstanceOf(Threadlet.RunnerAccess);
+      expect(gotArg.threadlet).toBe(thread);
 
       await expect(runResult).toResolve();
     });
@@ -444,13 +447,16 @@ describe('run()', () => {
       await expect(runResult).toResolve();
     });
 
-    test('causes the start function to be called, with the thread as its argument', async () => {
+    test('causes the start function to be called, with an appropriate access object as its argument', async () => {
       let gotArgs = null;
       const thread = new Threadlet((...args) => { gotArgs = args; }, () => null);
 
       const runResult = thread.run();
       await setImmediate();
-      expect(gotArgs).toStrictEqual([thread]);
+      expect(gotArgs).toBeArrayOfSize(1);
+      const gotArg = gotArgs[0];
+      expect(gotArg).toBeInstanceOf(Threadlet.RunnerAccess);
+      expect(gotArg.threadlet).toBe(thread);
 
       await expect(runResult).toResolve();
     });

--- a/src/async/tests/Threadlet.test.js
+++ b/src/async/tests/Threadlet.test.js
@@ -784,7 +784,7 @@ describe('whenStarted()', () => {
 
 describe('`RunnerAccess` class', () => {
   test('is consistently the same instance for a given threadlet', async () => {
-    let got = [];
+    const got = [];
 
     const thread = new Threadlet((ra) => got.push(ra), (ra) => got.push(ra));
     await thread.run();
@@ -941,8 +941,8 @@ describe('`RunnerAccess` class', () => {
     });
 
     test('returns `false` while running and not asked to stop', async () => {
-      let got       = [];
-      let shouldRun = true;
+      const got       = [];
+      let   shouldRun = true;
       const thread = new Threadlet(async (ra) => {
         while (shouldRun) {
           got.push(ra.shouldStop());
@@ -1061,7 +1061,7 @@ describe('`RunnerAccess` class', () => {
 
       await thread.run();
 
-      const result = thread.whenStopRequested();
+      const result = runnerAccess.whenStopRequested();
 
       expect(PromiseState.isFulfilled(result)).toBeTrue();
     });

--- a/src/built-ins/export/ProcessIdFile.js
+++ b/src/built-ins/export/ProcessIdFile.js
@@ -29,7 +29,7 @@ export class ProcessIdFile extends BaseFileService {
    *
    * @type {Threadlet}
    */
-  #runner = new Threadlet(() => this.#run());
+  #runner = new Threadlet((ra) => this.#run(ra));
 
   // @defaultConstructor
 
@@ -121,18 +121,20 @@ export class ProcessIdFile extends BaseFileService {
 
   /**
    * Runs the service thread.
+   *
+   * @param {Threadlet.RunnerAccess} runnerAccess Thread runner access object.
    */
-  async #run() {
+  async #run(runnerAccess) {
     const updateMsec = this.config.updatePeriod?.msec ?? null;
 
-    while (!this.#runner.shouldStop()) {
+    while (!runnerAccess.shouldStop()) {
       await this.#updateFile(true);
 
       if (updateMsec) {
         const timeout = WallClock.waitForMsec(updateMsec);
-        await this.#runner.raceWhenStopRequested([timeout]);
+        await runnerAccess.raceWhenStopRequested([timeout]);
       } else {
-        await this.#runner.whenStopRequested();
+        await runnerAccess.whenStopRequested();
       }
     }
 

--- a/src/host/export/KeepRunning.js
+++ b/src/host/export/KeepRunning.js
@@ -35,7 +35,7 @@ export class KeepRunning {
    * Constructs an instance.
    */
   constructor() {
-    this.#thread = new Threadlet(() => this.#keepRunning());
+    this.#thread = new Threadlet((ra) => this.#keepRunning(ra));
   }
 
   /**
@@ -67,15 +67,17 @@ export class KeepRunning {
   /**
    * Remains running and mostly waiting for a recurring timeout, until asked to
    * stop.
+   *
+   * @param {Threadlet.RunnerAccess} runnerAccess Thread runner access object.
    */
-  async #keepRunning() {
+  async #keepRunning(runnerAccess) {
     this.#logger?.running();
 
     // This is a standard-ish trick to keep a Node process alive: Repeatedly set
     // a timeout (or, alternatively, set a recurring timeout), and cancel it
     // (one way or another) when it's okay for the process to exit.
-    while (!this.#thread.shouldStop()) {
-      await this.#thread.raceWhenStopRequested([
+    while (!runnerAccess.shouldStop()) {
+      await runnerAccess.raceWhenStopRequested([
         WallClock.waitForMsec(KeepRunning.#MSEC_PER_DAY)
       ]);
 

--- a/src/net-protocol/private/Http2Wrangler.js
+++ b/src/net-protocol/private/Http2Wrangler.js
@@ -41,7 +41,7 @@ export class Http2Wrangler extends TcpWrangler {
    *
    * @type {Threadlet}
    */
-  #runner = new Threadlet(() => this.#run());
+  #runner = new Threadlet((ra) => this.#run(ra));
 
   /**
    * Per-connection storage, used to plumb connection context through to the
@@ -94,7 +94,7 @@ export class Http2Wrangler extends TcpWrangler {
    * @param {http2.ServerHttp2Session} session The new session.
    */
   #addSession(session) {
-    if (this.#runner.shouldStop()) {
+    if (this._prot_isStopping()) {
       // Immediately close a session that managed to slip in while we're trying
       // to stop.
       session.close();
@@ -187,11 +187,13 @@ export class Http2Wrangler extends TcpWrangler {
 
   /**
    * Runs the high-level stack.
+   *
+   * @param {Threadlet.RunnerAccess} runnerAccess Thread runner access object.
    */
-  async #run() {
+  async #run(runnerAccess) {
     // As things stand, there isn't actually anything to do other than wait for
     // the stop request and then shut things down.
-    await this.#runner.whenStopRequested();
+    await runnerAccess.whenStopRequested();
 
     this.#protocolServer.close();
 

--- a/src/sys-util/private/BaseFilePreserver.js
+++ b/src/sys-util/private/BaseFilePreserver.js
@@ -53,7 +53,7 @@ export class BaseFilePreserver {
    *
    * @type {Threadlet}
    */
-  #runner = new Threadlet(() => this.#run());
+  #runner = new Threadlet((ra) => this.#run(ra));
 
   /**
    * Condition which indicates a need to save now.
@@ -292,9 +292,11 @@ export class BaseFilePreserver {
 
   /**
    * Main function of the threadlet for this instance.
+   *
+   * @param {Threadlet.RunnerAccess} runnerAccess Thread runner access object.
    */
-  async #run() {
-    while (!this.#runner.shouldStop()) {
+  async #run(runnerAccess) {
+    while (!runnerAccess.shouldStop()) {
       await this._impl_doWork();
 
       if (this.#saveNow.value === true) {
@@ -308,7 +310,7 @@ export class BaseFilePreserver {
         ...(subclassPromise ? [subclassPromise] : [])
       ];
 
-      await this.#runner.raceWhenStopRequested(racers);
+      await runnerAccess.raceWhenStopRequested(racers);
     }
 
     // Give the subclass one last opportunity to request a save.


### PR DESCRIPTION
This fixes a couple `Threadlet`-related things. Highlights:

* Extracted an interface `IntfThreadlike` for just the use-as-an-opaque-thread-like-thing aspects of `Threadlet`.
* Changed `Threadlet` to move the handful of public methods that are meant for use by runner functions to instead be methods on an inner class `RunnerAccess`. An instance of this class gets passed to the runner functions.
* Fixed every place in the system which used to use the for-the-runner methods on `Threadlet` to instead access those through a `RunnerAccess` instance.
* Added new class `BaseExposedThreadlet` which implements `IntfThreadlike` for things which want to expose that interface but which want to hide the inner details. (The class name's not great, I admit.)
* Changed the two classes in the system which inherited from `Threadlet` to instead inherit from `BaseExposedThreadlet`.