### PR TITLE
`RequestFilter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Other notable changes:
   * Loosened restrictions on path component syntax in `PathRouter`.
   * Added `bufferPeriod` configuration option to `AccessLogToFile` and
     `SyslogToFile`.
+  * New class `RequestFilter` to take over the duties of the former "filtering
+    for free" behavior of `BaseApplication`.
 
 ### v0.6.13 -- 2024-04-03
 

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -260,6 +260,92 @@ const applications = [
 ];
 ```
 
+## `RequestFilter`
+
+An application which filters requests that match particular criteria, either by
+responding with a particular "not-found-ish" status, or by redirecting to a
+modified path.
+
+When a request matches one or more filter criteria, this application responds
+with a status code to indicate the filtering (by default `404`). When it
+redirects, it uses status `308` ("Permanent Redirect"). In other cases &mdash;
+that is, when the request is not filtered out &mdash; this application returns
+`null`, meaning that it did not handle the request. This is done so that a
+filter can be included early in the list of applications of a
+[`SerialRouter`](#serialrouter).
+
+This application accepts the following configuration bindings:
+
+* `acceptMethods` &mdash; Array of strings indicating which request methods to
+  accept. The array can include any of `connect`, `delete`, `get`, `head`,
+  `options`, `patch`, `post`, `put`, and/or `trace`. Defaults to the entire set.
+* `filterResponseStatus` &mdash; Status to report when a request has been
+  filtered out (as opposed to having been redirected). Defaults to `404` ("Not
+  Found").
+* `maxPathDepth` &mdash; Number indicating the maximum (inclusive) allowed
+  length _in path components_ of a dispatched request path not including the
+  mount point, and not including the empty path component at the end of a
+  directory path. `null` indicates "no limit." Defaults to `null`.
+* `maxPathLength` &mdash; Number indicating the maximum (inclusive) allowed
+  length of the dispatched request path _in octets_. `null` indicates "no
+  limit." `0` indicates that no additional path is ever accepted (including even
+  a directory slash). Defaults to `null`.
+* `maxQueryLength` &mdash; Number indicating the maximum (inclusive) allowed
+  length of the query (a/k/a "search") portion of a request URI _in octets_,
+  including the leading question mark (`?`). `null` indicates "no limit." `0`
+  indicates that queries are not ever accepted. Defaults to `null`.
+* `redirectDirectories` &mdash; Boolean indicating whether or not directory
+  paths (those ending with an empty path component) should be automatically
+  redirected to the file (non-directory) version of the path. Defaults to
+  `false`.
+* `redirectFiles` &mdash; Boolean indicating whether or not file paths (those
+  not ending with an empty path component) should be automatically redirected to
+  the directory version of the path. Defaults to `false`.
+* `rejectDirectories` &mdash; Boolean indicating whether or not directory paths
+  (those ending with an empty path component) should be filtered out. Defaults
+  to `false`.
+* `rejectFiles` &mdash; Boolean indicating whether or not file paths (those
+  not ending with an empty path component) should be filtered out. Defaults to
+  `false`.
+
+With regards to the `redirect*` and `reject*` options:
+* It is an error to specify more than one as `true`. (It basically makes no
+  sense to do so.)
+* A redirection (or not) is entirely based on the form of the path &mdash;
+  that is, whether or not it ends with a slash &mdash; and not on any other
+  test. Notably, as opposed to this class, [`StaticFiles`](#staticfiles)
+  performs _content_-driven redirection.
+
+With regards to `maxPath*` options, note that these options are not meaningful
+for applications that are mounted at fixed paths (e.g. within a
+[`PathRouter`](#pathrouter) at a non-wildcard path).
+
+With regards to the other options, when a request is filtered out, the result is
+that the application simply _doesn't handle_ the request, meaning that the
+request will get re-dispatched to the next application in its routing chain (if
+any).
+
+**Note:** This application is meant to cover a good handful of common use cases.
+It is _not_ meant to be a "kitchen sink" of filtering. For filtering cases
+beyond what's covered here, the best option is to define a custom application
+class. That said, feature requests to add filtering options to this class will
+be seriously considered, should they meet a bar of "reasonably useful across
+many use cases."
+
+```js
+import { RequestFilter } from '@lactoserv/webapp-core';
+
+const applications = [
+  {
+    name:                'myFilter',
+    class:               RequestFilter,
+    acceptMethods:       ['get', 'head'],
+    maxQueryLength:      0,
+    redirectDirectories: true
+  }
+];
+```
+
 ## `SerialRouter`
 
 An application which routes requests to one of a list of applications, which are

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -170,8 +170,6 @@ const applications = [
 An application which responds to all requests with an HTTP "redirect" response.
 This application accepts the following configuration bindings:
 
-* `acceptMethods` &mdash; Common configuration option, but in this case the
-  default is `['delete', 'get', 'head', 'patch', 'post', 'put']`.
 * `statusCode` &mdash; Optional HTTP status code to respond with. If not
   specified, it defaults to `301` ("Moved Permanently").
 * `target` &mdash; The base URL to redirect to. This is prepended to the partial
@@ -322,8 +320,6 @@ An application which only ever sends one particular response. It's approximately
 like `StaticFiles`, except just one file. This application accepts the following
 configuration bindings:
 
-* `acceptMethods` &mdash; Common configuration option, but in this case the
-  default is `['get', 'head']`.
 * `body` &mdash; Optional body contents to respond with. If specified, this must
   be either a string or a Node `Buffer` object.
 * `contentType` &mdash; Content type to report. This can be either a MIME type
@@ -403,8 +399,6 @@ reasonable demand:
 An application which serves static files from a local directory. This
 application accepts the following configuration bindings:
 
-* `acceptMethods` &mdash; Common configuration option, but in this case the
-  default is `['get', 'head']`.
 * `etag` &mdash; ETag-generating options. If present and not `false`, the
   response comes with an `ETag` header. See "ETag Configuration" below for
   details.

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -10,68 +10,6 @@ indicate which (if any) apply.
 See also [Common Configuration](./2-common-configuration.md) for configuration
 details that apply to more than just applications.
 
-### Request Filtering
-
-Most built-in applications implement a set of common configuration options,
-which are generally about filtering out or automatically responding to certain
-kinds of requests. Exceptions to the use of these configurations are noted in
-the documentation of applications, as appropriate. Here are the options:
-
-* `acceptMethods` &mdash; Array of strings indicating which request methods to
-  accept. The array can include any of `connect`, `delete`, `get`, `head`,
-  `options`, `patch`, `post`, `put`, and/or `trace`. Defaults to the entire set.
-* `maxPathDepth` &mdash; Number indicating the maximum (inclusive) allowed
-  length _in path components_ of a dispatched request path not including the
-  mount point, and not including the empty path component at the end of a
-  directory path. `null` indicates "no limit." Defaults to `null`.
-* `maxPathLength` &mdash; Number indicating the maximum (inclusive) allowed
-  length of the dispatched request path _in octets_. `null` indicates "no
-  limit." `0` indicates that no additional path is ever accepted (including even
-  a directory slash). Defaults to `null`.
-* `maxQueryLength` &mdash; Number indicating the maximum (inclusive) allowed
-  length of the query (a/k/a "search") portion of a request URI _in octets_,
-  including the leading question mark (`?`). `null` indicates "no limit." `0`
-  indicates that queries are not ever accepted. Defaults to `null`.
-* `redirectDirectories` &mdash; Boolean indicating whether or not directory
-  paths (those ending with an empty path component) should be automatically
-  redirected to the file (non-directory) version of the path. Defaults to
-  `false`.
-* `redirectFiles` &mdash; Boolean indicating whether or not file paths (those
-  not ending with an empty path component) should be automatically redirected to
-  the directory version of the path. Defaults to `false`.
-
-With regards to the `redirect*` options:
-* It is an error to specify both as `true`.
-* The redirection (or not) is entirely based on the form of the path, not on any
-  file contents (for example). Notably, [`StaticFiles`](#staticfiles) does
-  _content_-driven redirection, which is different than what is done here.
-
-With regards to `maxPath*` options, note that these options are not meaningful
-for applications that are mounted at fixed paths (e.g. within a
-[`PathRouter`](#pathrouter) at a non-wildcard path).
-
-With regards to the other options, when a request is filtered out, the result is
-that the application simply _doesn't handle_ the request, meaning that the
-request will get re-dispatched to the next application in its routing chain (if
-any).
-
-```js
-import { BaseApplication } from '@lactoserv/webapp-core';
-
-class MyApplication extends BaseApplication {
-  // ... more ...
-}
-
-const applications = [
-  {
-    name:           'myCustomApp',
-    class:          MyApplication,
-    acceptMethods:  ['delete', 'put'],
-    maxQueryLength: 0
-  }
-];
-```
-
 ### Cache control configuration: `cacheControl`
 
 Applications and services that might generate `cache-control` headers accept
@@ -122,9 +60,8 @@ properties are recognized:
 ## `HostRouter`
 
 An application which can route requests to another application, based on the
-`host` (or equivalent) header in the requests. In addition to the
-[common application configuration](#common-application-configuration) options,
-it accepts the following bindings:
+`host` (or equivalent) header in the requests. This application accepts the
+following configuration bindings:
 
 * `hosts` &mdash; A plain object with possibly-wildcarded hostnames as keys, and
   the _names_ of other applications as values. A wildcard only covers the prefix
@@ -166,9 +103,8 @@ const applications = [
 ## `PathRouter`
 
 An application which can route requests to another application, based on the
-path of the requests. In addition to the
-[common application configuration](#common-application-configuration) options,
-it accepts the following bindings:
+path of the requests. This application accepts the following configuration
+bindings:
 
 * `paths` &mdash; A plain object with possibly-wildcarded paths as keys, and
   the _names_ of other applications as values. A wildcard only covers the suffix
@@ -232,9 +168,7 @@ const applications = [
 ## `Redirector`
 
 An application which responds to all requests with an HTTP "redirect" response.
-In addition to the
-[common application configuration](#common-application-configuration)
-options, it accepts the following bindings:
+This application accepts the following configuration bindings:
 
 * `acceptMethods` &mdash; Common configuration option, but in this case the
   default is `['delete', 'get', 'head', 'patch', 'post', 'put']`.
@@ -350,9 +284,8 @@ const applications = [
 
 An application which routes requests to one of a list of applications, which are
 tried in order. (This is the default / built-in routing strategy of the most
-common Node web application frameworks.) In addition to the
-[common application configuration](#common-application-configuration) options,
-it accepts the following bindings:
+common Node web application frameworks.) This application accepts the following
+configuration bindings:
 
 * `applications` &mdash; An array listing the _names_ of other applications as
   values.
@@ -386,9 +319,8 @@ const applications = [
 ## `SimpleResponse`
 
 An application which only ever sends one particular response. It's approximately
-like `StaticFiles`, except just one file. In addition to the
-[common application configuration](#common-application-configuration) options,
-it accepts the following configuration bindings:
+like `StaticFiles`, except just one file. This application accepts the following
+configuration bindings:
 
 * `acceptMethods` &mdash; Common configuration option, but in this case the
   default is `['get', 'head']`.
@@ -468,11 +400,8 @@ reasonable demand:
 
 ## `StaticFiles`
 
-An application which serves static files from a local directory. In addition to
-most of the
-[common application configuration](#common-application-configuration) options
-(all but the `redirect*` options, which could cause chaos in this case), it
-accepts the following configuration bindings:
+An application which serves static files from a local directory. This
+application accepts the following configuration bindings:
 
 * `acceptMethods` &mdash; Common configuration option, but in this case the
   default is `['get', 'head']`.

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -5,7 +5,8 @@ import * as fs from 'node:fs/promises';
 
 import { AccessLogToFile, AccessLogToSyslog, EventFan, HostRouter,
   MemoryMonitor, PathRouter, ProcessIdFile, ProcessInfoFile, RateLimiter,
-  Redirector, SerialRouter, SimpleResponse, StaticFiles, SyslogToFile }
+  Redirector, RequestFilter, SerialRouter, SimpleResponse, StaticFiles,
+  SyslogToFile }
   from '@lactoserv/webapp-builtins';
 
 
@@ -166,9 +167,15 @@ const applications = [
     }
   },
   {
+    name:           'myFilter',
+    class:          RequestFilter,
+    maxQueryLength: 0
+  },
+  {
     name:  'mySeries',
     class: SerialRouter,
     applications: [
+      'myFilter',
       'myStaticFunNo404',
       'responseNotFound'
     ]
@@ -182,8 +189,7 @@ const applications = [
     siteDirectory:  filePath('../site'),
     notFoundPath:   filePath('../site-extra/not-found.html'),
     cacheControl:   { public: true, maxAge: '5 min' },
-    etag:           { dataOnly: true, hashLength: 20 },
-    maxQueryLength: 20
+    etag:           { dataOnly: true, hashLength: 20 }
   },
   {
     name:          'myStaticFunNo404',
@@ -193,12 +199,10 @@ const applications = [
     etag:          { dataOnly: true, hashLength: 20 }
   },
   {
-    name:                'responseEmptyBody',
-    class:               SimpleResponse,
-    filePath:            filePath('../site-extra/empty-file.txt'),
-    cacheControl:        'public, immutable, max-age=600',
-    maxPathLength:       2,
-    redirectDirectories: true
+    name:         'responseEmptyBody',
+    class:        SimpleResponse,
+    filePath:     filePath('../site-extra/empty-file.txt'),
+    cacheControl: 'public, immutable, max-age=600'
   },
   {
     name:        'responseNotFound',
@@ -209,11 +213,10 @@ const applications = [
     statusCode:  404
   },
   {
-    name:          'responseNoBody',
-    class:         SimpleResponse,
-    cacheControl:  { public: true, immutable: true, maxAge: '11 min' },
-    etag:          true,
-    maxPathLength: 2,
+    name:         'responseNoBody',
+    class:        SimpleResponse,
+    cacheControl: { public: true, immutable: true, maxAge: '11 min' },
+    etag:         true
   },
   {
     name:         'responseDirOnly',

--- a/src/net-util/export/HttpUtil.js
+++ b/src/net-util/export/HttpUtil.js
@@ -5,7 +5,7 @@ import fs from 'node:fs/promises';
 
 import { Duration } from '@this/data-values';
 import { StatsBase } from '@this/fs-util';
-import { MustBe } from '@this/typey';
+import { AskIf, MustBe } from '@this/typey';
 
 
 /**
@@ -129,6 +129,21 @@ export class HttpUtil {
     }
 
     return parts.join(', ');
+  }
+
+  /**
+   * Checks an alleged HTTP-ish response status value for validity.
+   *
+   * @param {*} value The alleged status value.
+   * @returns {number} `value` if it is indeed a valid status value.
+   * @throws {Error} Thrown if `value` is not valid.
+   */
+  static checkStatus(value) {
+    if (AskIf.number(value, { safeInteger: true, minInclusive: 100, maxInclusive: 599 })) {
+      return value;
+    }
+
+    throw new Error(`Not a valid status value: ${value}`);
   }
 
   /**

--- a/src/net-util/export/StatusResponse.js
+++ b/src/net-util/export/StatusResponse.js
@@ -70,12 +70,12 @@ export class StatusResponse {
    *
    * @type {Map<number, StatusResponse>}
    */
-  #INSTANCES = new Map();
+  static #INSTANCES = new Map();
 
   /**
    * @returns {StatusResponse} The "not found" (`404`) instance.
    */
-  get NOT_FOUND() {
+  static get NOT_FOUND() {
     return this.fromStatus(404);
   }
 
@@ -86,7 +86,7 @@ export class StatusResponse {
    * @param {number} status The response status code.
    * @returns {StatusResponse} An instance of this class for the given status.
    */
-  fromStatus(status) {
+  static fromStatus(status) {
     const already = this.#INSTANCES.get(status);
 
     if (already) {

--- a/src/net-util/tests/HttpUtil.test.js
+++ b/src/net-util/tests/HttpUtil.test.js
@@ -28,6 +28,40 @@ describe('cacheControlHeader()', () => {
   });
 });
 
+describe('checkStatus()', () => {
+  // pass cases
+  test.each`
+  value
+  ${100}
+  ${200}
+  ${204}
+  ${300}
+  ${308}
+  ${400}
+  ${404}
+  ${500}
+  ${501}
+  ${599}
+  `('passes value $value', ({ value }) => {
+    expect(HttpUtil.checkStatus(value)).toBe(value);
+  });
+
+  // fail cases
+  test.each`
+  value
+  ${99}
+  ${0}
+  ${100.1}
+  ${NaN}
+  ${undefined}
+  ${false}
+  ${'123'}
+  ${[123]}
+  `('throws given value $value', ({ value }) => {
+    expect(() => HttpUtil.checkStatus(value)).toThrow();
+  });
+});
+
 describe('classicHeaderNameFrom()', () => {
   test.each`
   arg                | expected

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -88,7 +88,7 @@ export class HostRouter extends BaseApplication {
   /**
    * Configuration item subclass for this (outer) class.
    */
-  static #Config = class Config extends BaseApplication.FilterConfig {
+  static #Config = class Config extends BaseApplication.Config {
     /**
      * Like the outer `routeTree` except with names instead of handler
      * instances.

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -94,7 +94,7 @@ export class PathRouter extends BaseApplication {
   /**
    * Configuration item subclass for this (outer) class.
    */
-  static #Config = class Config extends BaseApplication.FilterConfig {
+  static #Config = class Config extends BaseApplication.Config {
     /**
      * Like the outer `routeTree` except with names instead of handler
      * instances.

--- a/src/webapp-builtins/export/Redirector.js
+++ b/src/webapp-builtins/export/Redirector.js
@@ -89,7 +89,7 @@ export class Redirector extends BaseApplication {
   /**
    * Configuration item subclass for this (outer) class.
    */
-  static #Config = class Config extends BaseApplication.FilterConfig {
+  static #Config = class Config extends BaseApplication.Config {
     /**
      * The redirect status code to use.
      *
@@ -118,10 +118,7 @@ export class Redirector extends BaseApplication {
      * @param {object} rawConfig Raw configuration object.
      */
     constructor(rawConfig) {
-      super({
-        acceptMethods: ['delete', 'get', 'head', 'patch', 'post', 'put'],
-        ...rawConfig
-      });
+      super(rawConfig);
 
       const {
         cacheControl = null,

--- a/src/webapp-builtins/export/RequestFilter.js
+++ b/src/webapp-builtins/export/RequestFilter.js
@@ -1,0 +1,319 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { FullResponse, HttpUtil, StatusResponse, TypeOutgoingResponse }
+  from '@this/net-util';
+import { MustBe } from '@this/typey';
+import { BaseApplication } from '@this/webapp-core';
+
+
+/**
+ * Application that filters requests that match certain commonly-used criteria,
+ * resulting in either redirection or some sort of not-found-like response.
+ * See docs for configuration object details.
+ *
+ * **Note:** This class is meant to handle a decent handful of commonly-used
+ * cases, but it is _not_ intended to be a "kitchen sink" of filtering. It is
+ * always possible to write one's own custom request filtering class, should the
+ * options on this one turn out to be insufficient for a particular use case.
+ */
+export class RequestFilter extends BaseApplication {
+  // @defaultConstructor
+
+  /** @override */
+  async _impl_handleRequest(request, dispatch) {
+    const {
+      acceptMethods, maxPathDepth, maxPathLength, maxQueryLength,
+      redirectDirectories, redirectFiles, rejectDirectories, rejectFiles
+    } = this.config;
+
+    if (redirectDirectories || redirectFiles || rejectDirectories || rejectFiles) {
+      if (dispatch.isDirectory()) {
+        if (rejectDirectories) {
+          return this.#filteredOut();
+        } else if (redirectDirectories) {
+          const redirect = dispatch.redirectToFileString;
+          // Don't redirect to `/`, because that would cause a redirect loop.
+          if (redirect !== '/') {
+            return FullResponse.makeRedirect(redirect, 308);
+          }
+        }
+      } else {
+        if (rejectFiles) {
+          return this.#filteredOut();
+        } else if (redirectFiles) {
+          return FullResponse.makeRedirect(dispatch.redirectToDirectoryString, 308);
+        }
+      }
+    }
+
+    if (acceptMethods && !acceptMethods.has(request.method)) {
+      return this.#filteredOut();
+    }
+
+    if (maxPathDepth !== null) {
+      const depth = dispatch.extra.length - (dispatch.isDirectory() ? 1 : 0);
+      if (depth > maxPathDepth) {
+        return this.#filteredOut();
+      }
+    }
+
+    if (maxPathLength !== null) {
+      // Note: We calculate this based on how the `extra` would get converted
+      // back to a path string if it were the entire `pathname` of the URL. This
+      // is arguably the most sensible tactic, in that if this instance actually
+      // is the one that was immediately dispatched to from an endpoint, `extra`
+      // will in fact be the same as `pathname`.
+      const extra  = dispatch.extra;
+      const length =
+        extra.length +    // One octet per slash if it were `pathname`.
+        extra.charLength; // Total count of characters in all components.
+      if (length > maxPathLength) {
+        return this.#filteredOut();
+      }
+    }
+
+    if ((maxQueryLength !== null) && (request.searchString.length > maxQueryLength)) {
+      return this.#filteredOut();
+    }
+
+    // No filter criteria applied to this request.
+    return null;
+  }
+
+  /** @override */
+  async _impl_init(isReload_unused) {
+    // @emptyBlock
+  }
+
+  /** @override */
+  async _impl_start(isReload_unused) {
+    // @emptyBlock
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // @emptyBlock
+  }
+
+  /**
+   * Returns the appropriate handler response for a request which has been
+   * filtered out.
+   *
+   * @returns {TypeOutgoingResponse} The response.
+   */
+  #filteredOut() {
+    return StatusResponse.fromStatus(this.config.filterResponseStatus);
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @override */
+  static _impl_configClass() {
+    return this.#Config;
+  }
+
+  /**
+   * Configuration item subclass for this (outer) class.
+   */
+  static #Config = class Config extends BaseApplication.Config {
+    /**
+     * The response status to use when filtering out a request.
+     *
+     * @type {number}
+     */
+    #filterResponseStatus;
+
+    /**
+     * Set of request methods (e.g. `post`) that the application accepts.
+     *
+     * @type {Set<string>}
+     */
+    #acceptMethods;
+
+    /**
+     * Maximum allowed dispatch `extra` path length in slash-separated
+     * components (inclusive), or `null` if there is no limit.
+     *
+     * @type {?number}
+     */
+    #maxPathDepth;
+
+    /**
+     * Maximum allowed dispatch `extra` path length in octets (inclusive), or
+     * `null` if there is no limit.
+     *
+     * @type {?number}
+     */
+    #maxPathLength;
+
+    /**
+     * Maximum allowed query (search string) length in octets (inclusive), or
+     * `null` if there is no limit.
+     *
+     * @type {?number}
+     */
+    #maxQueryLength;
+
+    /**
+     * Redirect file paths to the corresponding directory?
+     *
+     * @type {boolean}
+     */
+    #redirectDirectories;
+
+    /**
+     * Redirect directory paths to the corresponding file?
+     *
+     * @type {boolean}
+     */
+    #redirectFiles;
+
+    /**
+     * Reject directory (non-file) paths?
+     *
+     * @type {boolean}
+     */
+    #rejectDirectories;
+
+    /**
+     * Reject file (non-directory) paths?
+     *
+     * @type {boolean}
+     */
+    #rejectFiles;
+
+    /**
+     * Constructs an instance.
+     *
+     * @param {object} rawConfig Raw configuration object.
+     */
+    constructor(rawConfig) {
+      super(rawConfig);
+
+      const {
+        acceptMethods        = null,
+        filterResponseStatus = 404,
+        maxPathDepth         = null,
+        maxPathLength        = null,
+        maxQueryLength       = null,
+        redirectDirectories  = false,
+        redirectFiles        = false,
+        rejectDirectories    = false,
+        rejectFiles          = false
+      } = rawConfig;
+
+      this.#acceptMethods = (acceptMethods === null)
+        ? null
+        : new Set(MustBe.arrayOfString(acceptMethods, Config.#METHODS));
+      this.#filterResponseStatus = HttpUtil.checkStatus(filterResponseStatus);
+      this.#maxPathDepth = (maxPathDepth === null)
+        ? null
+        : MustBe.number(maxPathDepth, { safeInteger: true, minInclusive: 0 });
+      this.#maxPathLength = (maxPathLength === null)
+        ? null
+        : MustBe.number(maxPathLength, { safeInteger: true, minInclusive: 0 });
+      this.#maxQueryLength = (maxQueryLength === null)
+        ? null
+        : MustBe.number(maxQueryLength, { safeInteger: true, minInclusive: 0 });
+      this.#redirectDirectories = MustBe.boolean(redirectDirectories);
+      this.#redirectFiles       = MustBe.boolean(redirectFiles);
+      this.#rejectDirectories   = MustBe.boolean(rejectDirectories);
+      this.#rejectFiles         = MustBe.boolean(rejectFiles);
+
+      const boolCount =
+        redirectDirectories + redirectFiles + rejectDirectories + rejectFiles;
+      if (boolCount > 1) {
+        throw new Error('Cannot configure more than one `redirect*` or `reject*` option as `true`.');
+      }
+    }
+
+    /**
+     * @returns {Set<string>} Set of request methods (e.g. `post`) that the
+     * application accepts.
+     */
+    get acceptMethods() {
+      return this.#acceptMethods;
+    }
+
+    /**
+     * @returns {number} The response status to use when filtering out a
+     * request.
+     */
+    get filterResponseStatus() {
+      return this.#filterResponseStatus;
+    }
+
+    /**
+     * Maximum allowed dispatch `extra` path length in slash-separated
+     * components (inclusive), or `null` if there is no limit.
+     *
+     * @type {?number}
+     */
+    get maxPathDepth() {
+      return this.#maxPathDepth;
+    }
+
+    /**
+     * Maximum allowed dispatch `extra` path length in octets (inclusive), or
+     * `null` if there is no limit.
+     *
+     * @type {?number}
+     */
+    get maxPathLength() {
+      return this.#maxPathLength;
+    }
+
+    /**
+     * Maximum allowed query (search string) length in octets (inclusive), or
+     * `null` if there is no limit.
+     *
+     * @type {?number}
+     */
+    get maxQueryLength() {
+      return this.#maxQueryLength;
+    }
+
+    /**
+     * @returns {boolean} Redirect file paths to the corresponding directory?
+     */
+    get redirectDirectories() {
+      return this.#redirectDirectories;
+    }
+
+    /**
+     * @returns {boolean} Redirect directory paths to the corresponding file?
+     */
+    get redirectFiles() {
+      return this.#redirectFiles;
+    }
+
+    /** @returns {boolean} Reject directory (non-file) paths? */
+    get rejectDirectories() {
+      return this.#rejectDirectories;
+    }
+
+    /** @returns {boolean} Reject file (non-directory) paths? */
+    get rejectFiles() {
+      return this.#rejectFiles;
+    }
+
+
+    //
+    // Static members.
+    //
+
+    /**
+     * Allowed values for `methods`.
+     *
+     * @type {Set<string>}
+     */
+    static #METHODS = new Set([
+      'connect', 'delete', 'get', 'head', 'options',
+      'patch', 'post', 'put', 'trace'
+    ]);
+  };
+}

--- a/src/webapp-builtins/export/SerialRouter.js
+++ b/src/webapp-builtins/export/SerialRouter.js
@@ -78,7 +78,7 @@ export class SerialRouter extends BaseApplication {
   /**
    * Configuration item subclass for this (outer) class.
    */
-  static #Config = class Config extends BaseApplication.FilterConfig {
+  static #Config = class Config extends BaseApplication.Config {
     /**
      * Like the outer `routeList` except with names instead of application
      * instances.

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -120,7 +120,7 @@ export class SimpleResponse extends BaseApplication {
   /**
    * Configuration item subclass for this (outer) class.
    */
-  static #Config = class Config extends BaseApplication.FilterConfig {
+  static #Config = class Config extends BaseApplication.Config {
     /**
      * Predefined status code of the response, or `null` to use the most
      * appropriate "success" status code (most typically `200`).
@@ -173,10 +173,7 @@ export class SimpleResponse extends BaseApplication {
      * @param {object} rawConfig Raw configuration object.
      */
     constructor(rawConfig) {
-      super({
-        acceptMethods: ['get', 'head'],
-        ...rawConfig
-      });
+      super(rawConfig);
 
       const {
         body         = null,

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -267,7 +267,7 @@ export class StaticFiles extends BaseApplication {
   /**
    * Configuration item subclass for this (outer) class.
    */
-  static #Config = class Config extends BaseApplication.FilterConfig {
+  static #Config = class Config extends BaseApplication.Config {
     /**
      * Path to the file to serve for a not-found result, or `null` if not-found
      * handling shouldn't be done.
@@ -304,14 +304,7 @@ export class StaticFiles extends BaseApplication {
      * @param {object} rawConfig Raw configuration object.
      */
     constructor(rawConfig) {
-      super({
-        acceptMethods: ['get', 'head'],
-        ...rawConfig,
-
-        // These are always disabled. See configuration docs for explanation.
-        redirectDirectories: false,
-        redirectFiles:       false
-      });
+      super(rawConfig);
 
       const {
         cacheControl = null,

--- a/src/webapp-builtins/index.js
+++ b/src/webapp-builtins/index.js
@@ -11,6 +11,7 @@ export * from '#x/ProcessIdFile';
 export * from '#x/ProcessInfoFile';
 export * from '#x/RateLimiter';
 export * from '#x/Redirector';
+export * from '#x/RequestFilter';
 export * from '#x/SerialRouter';
 export * from '#x/SimpleResponse';
 export * from '#x/StaticFiles';

--- a/src/webapp-builtins/tests/RequestFilter.test.js
+++ b/src/webapp-builtins/tests/RequestFilter.test.js
@@ -1,0 +1,120 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { TreePathKey } from '@this/collections';
+import { RootControlContext } from '@this/compote';
+import { DispatchInfo, HttpHeaders, IncomingRequest, RequestContext,
+  StatusResponse }
+  from '@this/net-util';
+import { RequestFilter } from '@this/webapp-builtins';
+
+
+// TODO: Extract this function, which also has a variant in
+// `PathRouter.test.js`.
+function makeRequest(method, path) {
+  return new IncomingRequest({
+    context: new RequestContext(
+      Object.freeze({ address: 'localhost', port: 12345 }),
+      Object.freeze({ address: 'awayhost',  port: 54321 })),
+    headers: new HttpHeaders({
+      'some-header': 'something'
+    }),
+    protocolName: 'http-2',
+    pseudoHeaders: new HttpHeaders({
+      authority: 'your.host',
+      method,
+      path,
+      scheme:    'https'
+    })
+  });
+}
+
+describe('constructor', () => {
+  test('accepts an omnibus valid set of options', () => {
+    const opts = {
+      name:                 'myFavoriteFilter',
+      acceptMethods:        ['get'],
+      filterResponseStatus: 503,
+      maxPathDepth:         5,
+      maxPathLength:        50,
+      maxQueryLength:       123,
+      redirectDirectories:  true,
+      redirectFiles:        false,
+      rejectDirectories:    false,
+      rejectFiles:          false
+    };
+
+    expect(() => new RequestFilter(opts)).not.toThrow();
+  });
+
+  test('rejects more than one of the redirect/reject options being `true`', () => {
+    let opts = {
+      name:                 'myFavoriteFilter',
+      redirectDirectories:  true,
+      redirectFiles:        true,
+      rejectDirectories:    false,
+      rejectFiles:          false
+    };
+
+    expect(() => new RequestFilter(opts)).toThrow();
+
+    opts = {
+      ...opts,
+      redirectDirectories:  false,
+      redirectFiles:        true,
+      rejectDirectories:    true,
+      rejectFiles:          false
+    };
+
+    expect(() => new RequestFilter(opts)).toThrow();
+
+    opts = {
+      ...opts,
+      redirectDirectories:  true,
+      redirectFiles:        false,
+      rejectDirectories:    false,
+      rejectFiles:          true
+    };
+
+    expect(() => new RequestFilter(opts)).toThrow();
+  });
+});
+
+describe('_impl_handleRequest()', () => {
+  async function makeInstance(opts) {
+    opts = { name: 'theOne', ...opts };
+    const rf = new RequestFilter(opts, new RootControlContext(null));
+    await rf.start();
+
+    return rf;
+  }
+
+  describe('with non-`null` `acceptMethods`', () => {
+    test('accepts an allowed method', async () => {
+      const rf = await makeInstance({
+        acceptMethods:        ['get', 'post'],
+        filterResponseStatus: 599
+      });
+
+      const req    = makeRequest('get', '/florp');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeNull();
+    });
+
+    test('filters out a disallowed method', async () => {
+      const rf = await makeInstance({
+        acceptMethods:        ['post'],
+        filterResponseStatus: 599
+      });
+
+      const req    = makeRequest('get', '/florp');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeInstanceOf(StatusResponse);
+      expect(result.status).toBe(599);
+    });
+  });
+});

--- a/src/webapp-builtins/tests/RequestFilter.test.js
+++ b/src/webapp-builtins/tests/RequestFilter.test.js
@@ -117,4 +117,116 @@ describe('_impl_handleRequest()', () => {
       expect(result.status).toBe(599);
     });
   });
+
+  describe('with non-`null` `maxPathDepth`', () => {
+    test('accepts a short-enough file path', async () => {
+      const rf = await makeInstance({
+        maxPathDepth:         2,
+        filterResponseStatus: 599
+      });
+
+      const req    = makeRequest('get', '/florp/flop');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeNull();
+    });
+
+    test('accepts a short-enough directory path', async () => {
+      const rf = await makeInstance({
+        maxPathDepth:         2,
+        filterResponseStatus: 599
+      });
+
+      const req    = makeRequest('get', '/florp/flop/');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeNull();
+    });
+
+    test('filters out a too-long file path', async () => {
+      const rf = await makeInstance({
+        maxPathDepth:         2,
+        filterResponseStatus: 501
+      });
+
+      const req    = makeRequest('get', '/florp/flop/oopsie');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeInstanceOf(StatusResponse);
+      expect(result.status).toBe(501);
+    });
+
+    test('filters out a too-long directory path', async () => {
+      const rf = await makeInstance({
+        maxPathDepth:         2,
+        filterResponseStatus: 501
+      });
+
+      const req    = makeRequest('get', '/florp/flop/oopsie/');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeInstanceOf(StatusResponse);
+      expect(result.status).toBe(501);
+    });
+  });
+
+  describe('with non-`null` `maxPathLength`', () => {
+    test('accepts a short-enough file path', async () => {
+      const rf = await makeInstance({
+        maxPathLength:        20,
+        filterResponseStatus: 400
+      });
+
+      const req    = makeRequest('get', '/23456/8901/34/67890');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeNull();
+    });
+
+    test('accepts a short-enough directory path', async () => {
+      const rf = await makeInstance({
+        maxPathLength:        20,
+        filterResponseStatus: 400
+      });
+
+      const req    = makeRequest('get', '/23456/8901/34/6789/');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeNull();
+    });
+
+    test('filters out a too-long file path', async () => {
+      const rf = await makeInstance({
+        maxPathLength:        20,
+        filterResponseStatus: 400
+      });
+
+      const req    = makeRequest('get', '/23456/8901/34/678901');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeInstanceOf(StatusResponse);
+      expect(result.status).toBe(400);
+    });
+
+    test('filters out a too-long directory path', async () => {
+      const rf = await makeInstance({
+        maxPathLength:        20,
+        filterResponseStatus: 400
+      });
+
+      const req    = makeRequest('get', '/23456/8901/34/67890/');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeInstanceOf(StatusResponse);
+      expect(result.status).toBe(400);
+    });
+  });
 });

--- a/src/webapp-builtins/tests/RequestFilter.test.js
+++ b/src/webapp-builtins/tests/RequestFilter.test.js
@@ -229,4 +229,33 @@ describe('_impl_handleRequest()', () => {
       expect(result.status).toBe(400);
     });
   });
+
+  describe('with non-`null` `maxQueryLength`', () => {
+    test('accepts a short-enough query', async () => {
+      const rf = await makeInstance({
+        maxQueryLength:       8,
+        filterResponseStatus: 420
+      });
+
+      const req    = makeRequest('get', '/beep/boop/bop/biff?abcd=ef');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeNull();
+    });
+
+    test('filters out a too-long query', async () => {
+      const rf = await makeInstance({
+        maxPathLength:        8,
+        filterResponseStatus: 420
+      });
+
+      const req    = makeRequest('get', '/beep/boop/bop/biff?abcd=efg');
+      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeInstanceOf(StatusResponse);
+      expect(result.status).toBe(420);
+    });
+  });
 });

--- a/src/webapp-core/export/BaseApplication.js
+++ b/src/webapp-core/export/BaseApplication.js
@@ -1,12 +1,11 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { BaseClassedConfig, BaseComponent, RootControlContext }
-  from '@this/compote';
+import { BaseClassedConfig, BaseComponent } from '@this/compote';
 import { DispatchInfo, FullResponse, IncomingRequest, IntfRequestHandler,
   StatusResponse, TypeOutgoingResponse }
   from '@this/net-util';
-import { Methods, MustBe } from '@this/typey';
+import { Methods } from '@this/typey';
 
 
 /**
@@ -15,29 +14,7 @@ import { Methods, MustBe } from '@this/typey';
  * @implements {IntfRequestHandler}
  */
 export class BaseApplication extends BaseComponent {
-  /**
-   * Config instance, if it is an instance of this class's config class, or
-   * `null` if not.
-   *
-   * @type {?BaseApplication.FilterConfig}
-   */
-  #filterConfig;
-
-  /**
-   * Constructs an instance.
-   *
-   * @param {object} rawConfig Raw configuration object.
-   * @param {?RootControlContext} [rootContext] Associated context if this
-   *   instance is to be the root of its control hierarchy, or `null` for any
-   *   other instance.
-   */
-  constructor(rawConfig, rootContext = null) {
-    super(rawConfig, rootContext);
-
-    const { config } = this;
-    this.#filterConfig =
-      (config instanceof BaseApplication.FilterConfig) ? config : null;
-  }
+  // @defaultConstructor
 
   /** @override */
   async handleRequest(request, dispatch) {
@@ -54,13 +31,6 @@ export class BaseApplication extends BaseComponent {
     };
 
     logger?.handling(requestId, dispatch.infoForLog);
-
-    const filterResult = this.#applyFilters(request, dispatch);
-
-    if (filterResult !== false) {
-      logDone(filterResult ? 'filterHandled' : 'filteredOut');
-      return filterResult;
-    }
 
     try {
       const result = await this.#callHandler(request, dispatch);
@@ -83,75 +53,6 @@ export class BaseApplication extends BaseComponent {
    */
   async _impl_handleRequest(request, dispatch) {
     Methods.abstract(request, dispatch);
-  }
-
-  /**
-   * Performs request / dispatch filtering, if the instance is configured to do
-   * that. Does nothing (returns `false`) if not.
-   *
-   * @param {IncomingRequest} request Request object.
-   * @param {DispatchInfo} dispatch Dispatch information.
-   * @returns {?TypeOutgoingResponse|false} A response indicator (including
-   *   `null` to indicate "not handled"), or `false` to indicate that no
-   *   filtering was applied.
-   */
-  #applyFilters(request, dispatch) {
-    const filterConfig = this.#filterConfig;
-
-    if (!filterConfig) {
-      return false;
-    }
-
-    const {
-      acceptMethods, maxPathDepth, maxPathLength, maxQueryLength,
-      redirectDirectories, redirectFiles
-    } = filterConfig;
-
-    if (acceptMethods && !acceptMethods.has(request.method)) {
-      return null;
-    }
-
-    if (maxPathDepth !== null) {
-      const depth = dispatch.extra.length - (dispatch.isDirectory() ? 1 : 0);
-      if (depth > maxPathDepth) {
-        return null;
-      }
-    }
-
-    if (maxPathLength !== null) {
-      // Note: We calculate this based on how the `extra` would get converted
-      // back to a path string if it were the entire `pathname` of the URL. This
-      // is arguably the most sensible tactic, in that if this instance actually
-      // is the one that was immediately dispatched to from an endpoint, `extra`
-      // will in fact be the same as `pathname`.
-      const extra  = dispatch.extra;
-      const length =
-        extra.length +    // One octet per slash if it were `pathname`.
-        extra.charLength; // Total count of characters in all components.
-      if (length > maxPathLength) {
-        return null;
-      }
-    }
-
-    if ((maxQueryLength !== null) && (request.searchString.length > maxQueryLength)) {
-      return null;
-    }
-
-    if (redirectDirectories) {
-      if (dispatch.isDirectory()) {
-        const redirect = dispatch.redirectToFileString;
-        // Don't redirect to `/`, because that would cause a redirect loop.
-        if (redirect !== '/') {
-          return FullResponse.makeRedirect(redirect, 308);
-        }
-      }
-    } else if (redirectFiles) {
-      if (!dispatch.isDirectory()) {
-        return FullResponse.makeRedirect(dispatch.redirectToDirectoryString, 308);
-      }
-    }
-
-    return false;
   }
 
   /**
@@ -221,167 +122,5 @@ export class BaseApplication extends BaseComponent {
    */
   static Config = class Config extends BaseClassedConfig {
     // @defaultConstructor
-  };
-
-  /**
-   * Configuration item subclass for this (outer) class, which accepts URI
-   * filtering options.
-   *
-   * Subclasses of `BaseApplication` can use this directly as their
-   * configuration class, _or_ a subclass, _or_ something else entirely. If
-   * appropriate, subclasses can "pin" the configured values by modifying the
-   * incoming configuration object in the `super()` call in the constructor.
-   * Subclasses that do not use this config class will not have this (outer)
-   * class's filtering behavior.
-   */
-  static FilterConfig = class FilterConfig extends BaseApplication.Config {
-    /**
-     * Set of request methods (e.g. `post`) that the application accepts.
-     *
-     * @type {Set<string>}
-     */
-    #acceptMethods;
-
-    /**
-     * Maximum allowed dispatch `extra` path length in slash-separated
-     * components (inclusive), or `null` if there is no limit.
-     *
-     * @type {?number}
-     */
-    #maxPathDepth;
-
-    /**
-     * Maximum allowed dispatch `extra` path length in octets (inclusive), or
-     * `null` if there is no limit.
-     *
-     * @type {?number}
-     */
-    #maxPathLength;
-
-    /**
-     * Maximum allowed query (search string) length in octets (inclusive), or
-     * `null` if there is no limit.
-     *
-     * @type {?number}
-     */
-    #maxQueryLength;
-
-    /**
-     * Redirect file paths to the corresponding directory?
-     *
-     * @type {boolean}
-     */
-    #redirectDirectories;
-
-    /**
-     * Redirect directory paths to the corresponding file?
-     *
-     * @type {boolean}
-     */
-    #redirectFiles;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const {
-        acceptMethods       = null,
-        maxPathDepth        = null,
-        maxPathLength       = null,
-        maxQueryLength      = null,
-        redirectDirectories = false,
-        redirectFiles       = false
-      } = rawConfig;
-
-      this.#redirectDirectories = MustBe.boolean(redirectDirectories);
-      this.#redirectFiles       = MustBe.boolean(redirectFiles);
-      this.#acceptMethods       = (acceptMethods === null)
-        ? null
-        : new Set(MustBe.arrayOfString(acceptMethods, FilterConfig.#METHODS));
-      this.#maxPathDepth = (maxPathDepth === null)
-        ? null
-        : MustBe.number(maxPathDepth, { safeInteger: true, minInclusive: 0 });
-      this.#maxPathLength = (maxPathLength === null)
-        ? null
-        : MustBe.number(maxPathLength, { safeInteger: true, minInclusive: 0 });
-      this.#maxQueryLength = (maxQueryLength === null)
-        ? null
-        : MustBe.number(maxQueryLength, { safeInteger: true, minInclusive: 0 });
-
-      if (redirectFiles && redirectDirectories) {
-        throw new Error('Cannot configure both `redirect*` values as `true`.');
-      }
-    }
-
-    /**
-     * @returns {Set<string>} Set of request methods (e.g. `post`) that the
-     * application accepts.
-     */
-    get acceptMethods() {
-      return this.#acceptMethods;
-    }
-
-    /**
-     * Maximum allowed dispatch `extra` path length in slash-separated
-     * components (inclusive), or `null` if there is no limit.
-     *
-     * @type {?number}
-     */
-    get maxPathDepth() {
-      return this.#maxPathDepth;
-    }
-
-    /**
-     * Maximum allowed dispatch `extra` path length in octets (inclusive), or
-     * `null` if there is no limit.
-     *
-     * @type {?number}
-     */
-    get maxPathLength() {
-      return this.#maxPathLength;
-    }
-
-    /**
-     * Maximum allowed query (search string) length in octets (inclusive), or
-     * `null` if there is no limit.
-     *
-     * @type {?number}
-     */
-    get maxQueryLength() {
-      return this.#maxQueryLength;
-    }
-
-    /**
-     * @returns {boolean} Redirect file paths to the corresponding directory?
-     */
-    get redirectDirectories() {
-      return this.#redirectDirectories;
-    }
-
-    /**
-     * @returns {boolean} Redirect directory paths to the corresponding file?
-     */
-    get redirectFiles() {
-      return this.#redirectFiles;
-    }
-
-
-    //
-    // Static members.
-    //
-
-    /**
-     * Allowed values for `methods`.
-     *
-     * @type {Set<string>}
-     */
-    static #METHODS = new Set([
-      'connect', 'delete', 'get', 'head', 'options',
-      'patch', 'post', 'put', 'trace'
-    ]);
   };
 }

--- a/src/webapp-core/export/BaseApplication.js
+++ b/src/webapp-core/export/BaseApplication.js
@@ -1,7 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { BaseClassedConfig, BaseComponent } from '@this/compote';
+import { BaseClassedConfig, BaseComponent, RootControlContext }
+  from '@this/compote';
 import { DispatchInfo, FullResponse, IncomingRequest, IntfRequestHandler,
   StatusResponse, TypeOutgoingResponse }
   from '@this/net-util';
@@ -26,9 +27,12 @@ export class BaseApplication extends BaseComponent {
    * Constructs an instance.
    *
    * @param {object} rawConfig Raw configuration object.
+   * @param {?RootControlContext} [rootContext] Associated context if this
+   *   instance is to be the root of its control hierarchy, or `null` for any
+   *   other instance.
    */
-  constructor(rawConfig) {
-    super(rawConfig);
+  constructor(rawConfig, rootContext = null) {
+    super(rawConfig, rootContext);
 
     const { config } = this;
     this.#filterConfig =


### PR DESCRIPTION
This PR removes the former "for free" filtering from `BaseApplication` and puts it in its own concrete application class, `RequestFilter`. The reason for doing this is because the former case ended up seeing the filtering re-re-…-applied on every application, which was pointless / redundant and of course slower than just doing filtering once (or never, if not actually needed).