### PR TITLE
Names and paths and loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,12 @@ Breaking changes:
     The other classes weren't really serving much of a purpose, and to the
     extent that they were, it didn't help that they were separate from the main
     base class.
+  * The component hierarchy is now tracked as a unified `TreePathMap`, and
+    `getComponent()` now takes absolute paths instead of simple names.
 
 Other notable changes:
 * `compote`:
-  * Components now track their children directly.
-  * New method `BaseComponent._prot_addChild()`, to simplify adding children,
-    though as of this version things are still more complicated than they would
-    ideally be.
+  * New method `BaseComponent._prot_addChild()`, to simplify adding children.
 
 ### v0.6.14 -- 2024-04-11
 

--- a/src/collections/export/TreePathKey.js
+++ b/src/collections/export/TreePathKey.js
@@ -238,6 +238,29 @@ export class TreePathKey {
     return result.join('');
   }
 
+  /**
+   * Gets an instance just like this one, except with `wildcard` as specified.
+   * If this instance in fact already has the specified value for `wildcard`,
+   * this method returns this instance.
+   *
+   * @param {boolean} wildcard Value for `wildcard`.
+   * @returns {TreePathKey} An appropriately-constructed instance.
+   */
+  withWildcard(wildcard) {
+    MustBe.boolean(wildcard);
+
+    if (this.#wildcard === wildcard) {
+      return this;
+    }
+
+    const result = new TreePathKey(this.#path, wildcard);
+
+    // Avoid recalculating `charLength` if already known on the original.
+    result.#charLength = this.#charLength;
+
+    return result;
+  }
+
 
   //
   // Static members

--- a/src/collections/tests/TreePathKey.test.js
+++ b/src/collections/tests/TreePathKey.test.js
@@ -514,6 +514,46 @@ describe('toString()', () => {
   });
 });
 
+describe('withWildcard()', () => {
+  test('returns the given instance if `wildcard` matches', () => {
+    const key1 = new TreePathKey(['beep'], false);
+    expect(key1.withWildcard(false)).toBe(key1);
+
+    const key2 = new TreePathKey(['beep', 'boop'], true);
+    expect(key2.withWildcard(true)).toBe(key2);
+  });
+
+  test('returns a new instance, with the same path, if `wildcard` does not match', () => {
+    const key1    = new TreePathKey(['beep'], false);
+    const result1 = key1.withWildcard(true);
+    expect(result1).not.toBe(key1);
+    expect(result1.wildcard).toBe(true);
+    expect(result1.path).toBe(key1.path);
+
+    const key2    = new TreePathKey(['beep', 'boop'], true);
+    const result2 = key2.withWildcard(false);
+    expect(result2).not.toBe(key2);
+    expect(result2.wildcard).toBe(false);
+    expect(result2.path).toBe(key2.path);
+  });
+
+  test('when returning a new instance, gets `charLength` right', () => {
+    const key1    = new TreePathKey(['abc', 'xyz', 'pdq'], false);
+    const clen1   = key1.charLength; // Makes sure it's cached by `key1`.
+    const result1 = key1.withWildcard(true).charLength;
+
+    expect(result1).toBe(clen1);
+
+    // No initial `.charLength` so that it should get calculated separately by
+    // each key.
+    const key2    = new TreePathKey(['foo', 'florp'], true);
+    const result2 = key2.withWildcard(false).charLength;
+
+    expect(result2).toBe(key2.charLength);
+  });
+});
+
+
 describe('checkArguments()', () => {
   test('rejects `path` which is a non-array', () => {
     expect(() => TreePathKey.checkArguments(null, false)).toThrow();

--- a/src/compote/export/BaseComponent.js
+++ b/src/compote/export/BaseComponent.js
@@ -273,15 +273,9 @@ export class BaseComponent {
       throw new Error('Child already initialized; cannot add to different parent.');
     }
 
-    const { logger }       = this;
-    const { logTag, name } = child.config;
-
-    let subLogger = logger;
-    if (logTag) {
-      subLogger = logger?.[logTag];
-    } else if (name) {
-      subLogger = logger?.[name];
-    }
+    const { logger } = this;
+    const { name }   = child.config;
+    const subLogger  = logger?.[name];
 
     const context = new ControlContext(child, this, subLogger);
     await child.init(context, isReload);

--- a/src/compote/export/BaseComponent.js
+++ b/src/compote/export/BaseComponent.js
@@ -162,6 +162,11 @@ export class BaseComponent {
   }
 
   /** @override */
+  get root() {
+    return this.context.root.associate;
+  }
+
+  /** @override */
   get state() {
     return this.#initialized
       ? this.context.state

--- a/src/compote/export/BaseComponent.js
+++ b/src/compote/export/BaseComponent.js
@@ -19,7 +19,9 @@ import { ThisModule } from '#p/ThisModule';
  *
  * **Note:** If a concrete subclass uses a configuration object with a `name`
  * property, then this class requires that that name honor the contract of
- * {@link Names#checkName}.
+ * {@link Names#checkName}. And if a concrete subclass _does not_ use a
+ * configuration object with a `name` property, then that subclass _also_ has
+ * to override {@link #name} to return a non-`null` name.
  *
  * @implements {IntfComponent}
  */
@@ -150,7 +152,13 @@ export class BaseComponent {
 
   /** @override */
   get name() {
-    return this.#config?.name ?? null;
+    const name = this.#config?.name;
+
+    if (name) {
+      return name;
+    } else {
+      throw new Error('Component must define `name`.');
+    }
   }
 
   /** @override */

--- a/src/compote/export/BaseComponent.js
+++ b/src/compote/export/BaseComponent.js
@@ -20,8 +20,8 @@ import { ThisModule } from '#p/ThisModule';
  * **Note:** If a concrete subclass uses a configuration object with a `name`
  * property, then this class requires that that name honor the contract of
  * {@link Names#checkName}. And if a concrete subclass _does not_ use a
- * configuration object with a `name` property, then that subclass _also_ has
- * to override {@link #name} to return a non-`null` name.
+ * configuration object with a `name` property, then that subclass _also_ has to
+ * override {@link #name} to return a non-`null` name.
  *
  * @implements {IntfComponent}
  */

--- a/src/compote/export/BaseComponent.js
+++ b/src/compote/export/BaseComponent.js
@@ -281,11 +281,7 @@ export class BaseComponent {
       throw new Error('Child already initialized; cannot add to different parent.');
     }
 
-    const { logger } = this;
-    const { name }   = child.config;
-    const subLogger  = logger?.[name];
-
-    const context = new ControlContext(child, this, subLogger);
+    const context = new ControlContext(child, this);
     await child.init(context, isReload);
 
     if (this.state === 'running') {

--- a/src/compote/export/BaseConfig.js
+++ b/src/compote/export/BaseConfig.js
@@ -21,8 +21,6 @@ import { Names } from '#x/Names';
  *   constructor). This binding isn't required in general, but it _is_ required
  *   if the configuration instance gets used in a context where the concrete
  *   component class is not in fact implied.
- * * `logTag` -- Optional string to use as a tag when logging. (TODO: This is
- *   going to be removed.)
  * * `name` -- Optional name for the component, for use when finding it in its
  *   hierarchy, and for use when logging. If non-`null`, it must adhere to the
  *   syntax defined by {@link Names#checkName}.
@@ -35,14 +33,6 @@ export class BaseConfig {
    * @type {?function(new:object)}
    */
   #class;
-
-  /**
-   * Log tag (name) to use for the configured instance, or `null` for this
-   * instance to not have a predefined tag.
-   *
-   * @type {?string}
-   */
-  #logTag;
 
   /**
    * The item's name, or `null` if it does not have a configured name.
@@ -61,15 +51,14 @@ export class BaseConfig {
   constructor(rawConfig, requireName = false) {
     MustBe.plainObject(rawConfig);
 
-    const { class: cls = null, logTag = null, name = null } = rawConfig;
+    const { class: cls = null, name = null } = rawConfig;
 
     if (requireName && (name === null)) {
       throw new Error('Missing `name` binding.');
     }
 
-    this.#class  = (cls === null)    ? null : MustBe.constructorFunction(cls);
-    this.#logTag = (logTag === null) ? null : MustBe.string(logTag);
-    this.#name   = (name === null)   ? null : Names.checkName(name);
+    this.#class  = (cls === null)  ? null : MustBe.constructorFunction(cls);
+    this.#name   = (name === null) ? null : Names.checkName(name);
   }
 
   /**
@@ -79,14 +68,6 @@ export class BaseConfig {
    */
   get class() {
     return this.#class;
-  }
-
-  /**
-   * @returns {?string} Log tag (name) to use for the configured instance, or
-   * `null` for this instance to not have a predefined tag.
-   */
-  get logTag() {
-    return this.#logTag;
   }
 
   /**

--- a/src/compote/export/ControlContext.js
+++ b/src/compote/export/ControlContext.js
@@ -25,11 +25,11 @@ import { ThisModule } from '#p/ThisModule';
  */
 export class ControlContext {
   /**
-   * Logger to use, or `null` to not do any logging.
+   * Logger to use, `null` to not do any logging, or `false` if not yet set up.
    *
    * @type {?IntfLogger}
    */
-  #logger;
+  #logger = false;
 
   /**
    * Current component state.
@@ -80,8 +80,6 @@ export class ControlContext {
    *   logging.
    */
   constructor(associate, parent, logger = null) {
-    this.#logger = logger;
-
     if (associate === 'root') {
       this.#associate = null; // Gets set in `linkRoot()`.
       this.#parent    = null; // This will remain `null` forever.
@@ -108,6 +106,16 @@ export class ControlContext {
 
   /** @returns {?IntfLogger} Logger to use, or `null` to not do any logging. */
   get logger() {
+    if (this.#logger === false) {
+      let logger = this.#root.rootLogger ?? null;
+      if (logger) {
+        for (const k of this.#pathKey.path) {
+          logger = logger[k];
+        }
+      }
+      this.#logger = logger;
+    }
+
     return this.#logger;
   }
 

--- a/src/compote/export/ControlContext.js
+++ b/src/compote/export/ControlContext.js
@@ -76,10 +76,15 @@ export class ControlContext {
    *   the string `root` if this instance is to represent the root instance.
    * @param {?IntfComponent} parent Parent of `associate`, or `null` if this
    *   instance is to represent the root instance.
-   * @param {?IntfLogger} [logger] Logger to use, or `null` to not do any
-   *   logging.
+   * @param {?IntfLogger} [loggerObsolete] Old unused logger argument. Throws an
+   *   error if used.
    */
-  constructor(associate, parent, logger = null) {
+  constructor(associate, parent, loggerObsolete = null) {
+    if (loggerObsolete !== null) {
+      // TODO: Remove this check once client code is believed to be fixed.
+      throw new Error('Stop passing a non-`null` logger.');
+    }
+
     if (associate === 'root') {
       this.#associate = null; // Gets set in `linkRoot()`.
       this.#parent    = null; // This will remain `null` forever.

--- a/src/compote/export/ControlContext.js
+++ b/src/compote/export/ControlContext.js
@@ -87,10 +87,9 @@ export class ControlContext {
       this.#parent    = null; // This will remain `null` forever.
       this.#root      = this;
       this.#pathKey   = TreePathKey.EMPTY;
-      // Note: We can't call `#root.addDescendant()` here, because we're still
-      // in the middle of constructing `#root` _and_ we don't even have an
-      // `associate` yet. That all get resolved in `linkRoot()`, which happens
-      // soon after this instance is constructed.
+      // Note: We can't used `#root.contextTree` here, because we're still in
+      // the middle of constructing `#root`. That gets fixed in `linkRoot()`,
+      // which gets called soon after this instance is constructed.
     } else {
       // TODO: We should figure out how to type-check interfaces.
       this.#associate = associate;
@@ -99,7 +98,6 @@ export class ControlContext {
       this.#pathKey   = parent.context.#pathKeyForChild(associate);
 
       this.#root[ThisModule.SYM_contextTree].add(this.#pathKey, this);
-      this.#root[ThisModule.SYM_addDescendant](this);
     }
   }
 
@@ -211,7 +209,7 @@ export class ControlContext {
     }
 
     this.#associate = root;
-    this.#root[ThisModule.SYM_addDescendant](this);
+    this.#root[ThisModule.SYM_contextTree].add(this.#pathKey, this);
   }
 
   /**

--- a/src/compote/export/ControlContext.js
+++ b/src/compote/export/ControlContext.js
@@ -240,7 +240,7 @@ export class ControlContext {
    * of this one. If the component doesn't already have a name, this will
    * synthesize one based on its class.
    *
-   * @param {BaseComponent} component The will-be child component.
+   * @param {IntfComponent} component The will-be child component.
    * @returns {TreePathKey} The key to use for it.
    */
   #pathKeyForChild(component) {
@@ -285,7 +285,7 @@ export class ControlContext {
    * Gets a component name prefix based on the name of the class of the given
    * component.
    *
-   * @param {BaseComponent} component The component in question.
+   * @param {IntfComponent} component The component in question.
    * @returns {string} A reasonable prefix to use for its name.
    */
   static #namePrefixFrom(component) {

--- a/src/compote/export/ControlContext.js
+++ b/src/compote/export/ControlContext.js
@@ -63,14 +63,6 @@ export class ControlContext {
   #parent;
 
   /**
-   * Instances which represent the children of this instance's associated
-   * controllable.
-   *
-   * @type {Set<ControlContext>}
-   */
-  #children = new Set();
-
-  /**
    * Instance which represents the root of the containership hierarchy.
    *
    * @type {RootControlContext}
@@ -107,7 +99,6 @@ export class ControlContext {
       this.#pathKey   = parent.context.#pathKeyForChild(associate);
 
       this.#root[ThisModule.SYM_contextTree].add(this.#pathKey, this);
-      this.#parent.#addChild(this);
       this.#root[ThisModule.SYM_addDescendant](this);
     }
   }
@@ -231,15 +222,6 @@ export class ControlContext {
    */
   [ThisModule.SYM_setState](state) {
     this.#state = state;
-  }
-
-  /**
-   * Adds a child (direct descendant) to the set of children of this instance.
-   *
-   * @param {ControlContext} context The child context instance.
-   */
-  #addChild(context) {
-    this.#children.add(context);
   }
 
   /**

--- a/src/compote/export/ControlContext.js
+++ b/src/compote/export/ControlContext.js
@@ -85,6 +85,10 @@ export class ControlContext {
       this.#associate = null; // Gets set in `linkRoot()`.
       this.#parent    = null; // ...and it stays that way.
       this.#root      = this;
+      // Note: We can't call `#root.addDescendant()` here, because we're still
+      // in the middle of constructing `#root` _and_ we don't even have an
+      // `associate` yet. That all get resolved in `linkRoot()`, which happens
+      // soon after this instance is constructed.
     } else {
       // TODO: We should figure out how to type-check interfaces.
       this.#associate = associate;
@@ -196,6 +200,7 @@ export class ControlContext {
     }
 
     this.#associate = root;
+    this.#root[ThisModule.SYM_addDescendant](this);
   }
 
   /**

--- a/src/compote/export/ControlContext.js
+++ b/src/compote/export/ControlContext.js
@@ -236,8 +236,8 @@ export class ControlContext {
   }
 
   /**
-   * Gets the path key to use for the given component, which is to be a child
-   * of this one. If the component doesn't already have a name, this will
+   * Gets the path key to use for the given component, which is to be a child of
+   * this one. If the component doesn't already have a name, this will
    * synthesize one based on its class.
    *
    * @param {IntfComponent} component The will-be child component.

--- a/src/compote/export/IntfComponent.js
+++ b/src/compote/export/IntfComponent.js
@@ -37,7 +37,7 @@ export class IntfComponent {
     throw Methods.abstract();
   }
 
-  /** @returns {?string} Component name, or `null` if it does not have one. */
+  /** @returns {string} Component name. */
   get name() {
     throw Methods.abstract();
   }

--- a/src/compote/export/IntfComponent.js
+++ b/src/compote/export/IntfComponent.js
@@ -43,6 +43,14 @@ export class IntfComponent {
   }
 
   /**
+   * @returns {IntfComponent} The root component of the hierarchy that this
+   * instance is in.
+   */
+  get root() {
+    throw Methods.abstract();
+  }
+
+  /**
    * @returns {string} Current component state. One of:
    *
    * * `new` -- Not yet initialized, which also means not yet attached to a

--- a/src/compote/export/Names.js
+++ b/src/compote/export/Names.js
@@ -89,9 +89,9 @@ export class Names {
   }
 
   /**
-   * Like {@link #parsePath}, but allows `null` and `undefined` which both
-   * cause the method to return `null`. Other invalid inputs still cause an
-   * error to be thrown.
+   * Like {@link #parsePath}, but allows `null` and `undefined` which both cause
+   * the method to return `null`. Other invalid inputs still cause an error to
+   * be thrown.
    *
    * @param {?string|Array<string>|TreePathKey} path The absolute path to parse.
    * @returns {?TreePathKey} The parsed path, or `null`.

--- a/src/compote/export/Names.js
+++ b/src/compote/export/Names.js
@@ -61,7 +61,6 @@ export class Names {
    */
   static parsePath(path) {
     if (Array.isArray(path)) {
-      console.log('####### GOT', path);
       path = new TreePathKey(path, false);
     } else if (typeof path === 'string') {
       const elements = path.split('/');

--- a/src/compote/export/Names.js
+++ b/src/compote/export/Names.js
@@ -1,7 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { AskIf } from '@this/typey';
+import { TreePathKey } from '@this/collections';
+import { MustBe } from '@this/typey';
 
 
 /**
@@ -20,12 +21,57 @@ export class Names {
    * @throws {Error} Thrown if `value` does not match.
    */
   static checkName(value) {
-    const pattern = /^(?![-.])[-_.+a-zA-Z0-9]+(?<![-.])$/;
-
-    if (AskIf.string(value, pattern)) {
+    if (this.isName(value)) {
       return value;
-    } else {
-      throw new Error(`Invalid component name: ${value}`);
     }
+
+    throw new Error(`Invalid component name: ${value}`);
+  }
+
+  /**
+   * Checks whether or not a given value is a string which can be used as a
+   * "name of something" in this system. Allowed strings must be non-empty and
+   * consist only of alphanumerics plus any of `-_.+`, and furthermore must
+   * start and end with an alphanumeric character or `_`.
+   *
+   * @param {string} value Value in question.
+   * @returns {boolean} `true` if it is a string which matches the stated
+   *   pattern, or `false` if not.
+   * @throws {Error} Thrown if `value` is not even a string.
+   */
+  static isName(value) {
+    MustBe.string(value);
+
+    const pattern = /^(?![-.])[-_.+a-zA-Z0-9]+(?<![-.])$/;
+    return pattern.test(value);
+  }
+
+  /**
+   * Parses an absolute component path from a slash-separated list of elements,
+   * which must begin with a slash.
+   *
+   * @param {string} path The absolute path to parse.
+   * @returns {TreePathKey} The parsed path.
+   */
+  static parsePath(path) {
+    MustBe.string(path);
+
+    const elements = path.split('/');
+    const len      = elements.length;
+
+    if ((len < 2) || (elements[0] !== '')) {
+      throw new Error(`Not an absolute component path: ${path}`);
+    }
+
+    elements.pop(); // Drop the initial empty element.
+
+    for (const e of elements) {
+      if (!this.isName(e)) {
+        throw new Error(`Not an absolute component path: ${path}`);
+      }
+    }
+
+    // `Object.freeze()` means `TreePathKey` can avoid making a copy.
+    return new TreePathKey(Object.freeze(elements), false);
   }
 }

--- a/src/compote/export/RootControlContext.js
+++ b/src/compote/export/RootControlContext.js
@@ -15,22 +15,12 @@ import { ThisModule } from '#p/ThisModule';
  * hierarchy.
  */
 export class RootControlContext extends ControlContext {
+  /**
+   * Tree which maps each component path to its context instance.
+   *
+   * @type {TreePathMap<ControlContext>}
+   */
   #contextTree = new TreePathMap();
-
-  /**
-   * For each context which represents a _named_ component, a mapping from its
-   * name to the context. This represents a subset of all descendants.
-   *
-   * @type {Map<string, ControlContext>}
-   */
-  #components = new Map();
-
-  /**
-   * Set of all descendants.
-   *
-   * @type {Set<ControlContext>}
-   */
-  #descendants = new Set();
 
   /**
    * Constructs an instance. It initially has no `associate`.
@@ -80,29 +70,5 @@ export class RootControlContext extends ControlContext {
     }
 
     return found;
-  }
-
-  /**
-   * Registers a descendant with this instance.
-   *
-   * @param {ControlContext} descendant The descendant.
-   */
-  [ThisModule.SYM_addDescendant](descendant) {
-    if (this.#descendants.has(descendant)) {
-      throw new Error('Cannot register same component twice.');
-    }
-
-    const associate = descendant.associate;
-    const name      = associate.name;
-
-    if (name !== null) {
-      Names.checkName(name);
-      if (this.#components.has(name)) {
-        throw new Error(`Cannot register two components with the same name: ${name}`);
-      }
-      this.#components.set(name, descendant);
-    }
-
-    this.#descendants.add(descendant);
   }
 }

--- a/src/compote/export/RootControlContext.js
+++ b/src/compote/export/RootControlContext.js
@@ -36,7 +36,7 @@ export class RootControlContext extends ControlContext {
    * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
   constructor(logger) {
-    super('root', null, logger);
+    super('root', null);
 
     this.#rootLogger = logger;
   }

--- a/src/compote/export/RootControlContext.js
+++ b/src/compote/export/RootControlContext.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { TreePathMap, TreePathKey } from '@this/collections';
 import { IntfLogger } from '@this/loggy-intf';
 import { AskIf, MustBe } from '@this/typey';
 
@@ -14,6 +15,8 @@ import { ThisModule } from '#p/ThisModule';
  * hierarchy.
  */
 export class RootControlContext extends ControlContext {
+  #contextTree = new TreePathMap();
+
   /**
    * For each context which represents a _named_ component, a mapping from its
    * name to the context. This represents a subset of all descendants.
@@ -38,16 +41,24 @@ export class RootControlContext extends ControlContext {
     super('root', null, logger);
   }
 
+  /**
+   * @returns {TreePathMap} The full tree of all descendant contexts.
+   */
+  get [ThisModule.SYM_contextTree]() {
+    return this.#contextTree;
+  }
+
   /** @override */
-  getComponentOrNull(name, ...classes) {
-    if ((name === null) || (name === undefined)) {
+  getComponentOrNull(path, ...classes) {
+    path = Names.parsePathOrNull(path);
+
+    if (!path) {
       return null;
     }
 
-    MustBe.string(name);
     MustBe.arrayOf(classes, AskIf.constructorFunction);
 
-    const found = this.#components.get(name)?.associate;
+    const found = this.#contextTree.get(path)?.associate;
 
     if (!found) {
       return null;
@@ -57,11 +68,12 @@ export class RootControlContext extends ControlContext {
       const ifaces = found.implementedInterfaces;
       for (const cls of classes) {
         if (!((found instanceof cls) || ifaces.includes(cls))) {
+          const errPrefix = `Component \`${Names.pathStringFrom(path)}\` not of expected`;
           if (classes.length === 1) {
-            throw new Error(`Component \`${name}\` not of expected class: ${classes[0].name}`);
+            throw new Error(`${errPrefix} class: ${classes[0].name}`);
           } else {
             const names = `[${classes.map((c) => c.name).join(', ')}]`;
-            throw new Error(`Component \`${name}\` not of expected classes: ${names}`);
+            throw new Error(`${errPrefix} classes: ${names}`);
           }
         }
       }

--- a/src/compote/export/RootControlContext.js
+++ b/src/compote/export/RootControlContext.js
@@ -16,6 +16,14 @@ import { ThisModule } from '#p/ThisModule';
  */
 export class RootControlContext extends ControlContext {
   /**
+   * The "root" logger to use, or `null` if the hierarchy isn't doing logging at
+   * all.
+   *
+   * @type {?IntfLogger}
+   */
+  #rootLogger;
+
+  /**
    * Tree which maps each component path to its context instance.
    *
    * @type {TreePathMap<ControlContext>}
@@ -29,6 +37,17 @@ export class RootControlContext extends ControlContext {
    */
   constructor(logger) {
     super('root', null, logger);
+
+    this.#rootLogger = logger;
+  }
+
+  /**
+   * @returns {?IntfLogger} The "root" logger to use, that is, the logger from
+   * which all loggers in this hierarchy derive, or `null` if this whole
+   * hierarchy is _not_ doing logging at all.
+   */
+  get rootLogger() {
+    return this.#rootLogger;
   }
 
   /**

--- a/src/compote/export/RootControlContext.js
+++ b/src/compote/export/RootControlContext.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathMap, TreePathKey } from '@this/collections';
+import { TreePathMap } from '@this/collections';
 import { IntfLogger } from '@this/loggy-intf';
 import { AskIf, MustBe } from '@this/typey';
 

--- a/src/compote/export/RootControlContext.js
+++ b/src/compote/export/RootControlContext.js
@@ -77,7 +77,7 @@ export class RootControlContext extends ControlContext {
    */
   [ThisModule.SYM_addDescendant](descendant) {
     if (this.#descendants.has(descendant)) {
-      throw new Error('Cannot register same descendant twice.');
+      throw new Error('Cannot register same component twice.');
     }
 
     const associate = descendant.associate;
@@ -86,7 +86,7 @@ export class RootControlContext extends ControlContext {
     if (name !== null) {
       Names.checkName(name);
       if (this.#components.has(name)) {
-        throw new Error('Cannot register two different components with the same name.');
+        throw new Error(`Cannot register two components with the same name: ${name}`);
       }
       this.#components.set(name, descendant);
     }

--- a/src/compote/private/ThisModule.js
+++ b/src/compote/private/ThisModule.js
@@ -7,13 +7,6 @@
  */
 export class ThisModule {
   /**
-   * Symbol used for the module-private method `addDescendant`.
-   *
-   * @type {symbol}
-   */
-  static SYM_addDescendant = Symbol('compote.addDescendant');
-
-  /**
    * Symbol used for the module-private getter `contextTree`.
    *
    * @type {symbol}

--- a/src/compote/private/ThisModule.js
+++ b/src/compote/private/ThisModule.js
@@ -14,6 +14,13 @@ export class ThisModule {
   static SYM_addDescendant = Symbol('compote.addDescendant');
 
   /**
+   * Symbol used for the module-private getter `contextTree`.
+   *
+   * @type {symbol}
+   */
+  static SYM_contextTree = Symbol('compote.contextTree');
+
+  /**
    * Symbol used for the module-private method `linkRoot`.
    *
    * @type {symbol}

--- a/src/webapp-builtins/export/EventFan.js
+++ b/src/webapp-builtins/export/EventFan.js
@@ -78,7 +78,7 @@ export class EventFan extends BaseService {
     const services = [];
 
     for (const name of this.config.services) {
-      const service = context.getComponent(name, BaseService);
+      const service = context.getComponent(['service', name], BaseService);
       services.push(service);
     }
 

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -63,7 +63,7 @@ export class HostRouter extends BaseApplication {
     const routeTree = new TreePathMap();
 
     for (const [host, name] of this.config.routeTree) {
-      const app = context.getComponent(name, BaseApplication);
+      const app = context.getComponent(['application', name], BaseApplication);
       routeTree.add(host, app);
     }
 

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -69,7 +69,7 @@ export class PathRouter extends BaseApplication {
     const routeTree = new TreePathMap();
 
     for (const [path, name] of this.config.routeTree) {
-      const app = context.getComponent(name, BaseApplication);
+      const app = context.getComponent(['application', name], BaseApplication);
       routeTree.add(path, app);
     }
 

--- a/src/webapp-builtins/export/SerialRouter.js
+++ b/src/webapp-builtins/export/SerialRouter.js
@@ -53,7 +53,7 @@ export class SerialRouter extends BaseApplication {
     const routeList = [];
 
     for (const name of this.config.routeList) {
-      const app = context.getComponent(name, BaseApplication);
+      const app = context.getComponent(['application', name], BaseApplication);
       routeList.push(app);
     }
 

--- a/src/webapp-builtins/tests/PathRouter.test.js
+++ b/src/webapp-builtins/tests/PathRouter.test.js
@@ -158,13 +158,13 @@ describe('_impl_handleRequest()', () => {
       if (handlerFunc) {
         app.mockHandler = handlerFunc;
       }
-      await app.init(new ControlContext(app, root, null));
+      await app.init(new ControlContext(app, root));
       await app.start();
     }
 
     const pr = new PathRouter({ name: 'myRouter', paths });
 
-    await pr.init(new ControlContext(pr, root, null));
+    await pr.init(new ControlContext(pr, root));
     await pr.start();
 
     return pr;

--- a/src/webapp-core/export/ComponentManager.js
+++ b/src/webapp-core/export/ComponentManager.js
@@ -50,10 +50,10 @@ export class ComponentManager extends BaseComponent {
     const {
       baseClass = null,
       baseSublogger = null,
-      logTag
+      name
     } = options;
 
-    super({ logTag });
+    super({ name });
 
     this.#baseClass = (baseClass === null)
       ? BaseComponent

--- a/src/webapp-core/export/ComponentManager.js
+++ b/src/webapp-core/export/ComponentManager.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BaseComponent, BaseConfig, ControlContext } from '@this/compote';
-import { IntfLogger } from '@this/loggy-intf';
 import { AskIf, MustBe } from '@this/typey';
 
 

--- a/src/webapp-core/export/ComponentManager.js
+++ b/src/webapp-core/export/ComponentManager.js
@@ -21,14 +21,6 @@ export class ComponentManager extends BaseComponent {
   #baseClass;
 
   /**
-   * Base sublogger to use for instantiated components, or `null` not to do any
-   * logging.
-   *
-   * @type {?IntfLogger}
-   */
-  #baseSublogger;
-
-  /**
    * Map from each bound name to the corresponding instance.
    *
    * @type {Map<string, BaseComponent>}
@@ -43,13 +35,11 @@ export class ComponentManager extends BaseComponent {
    * @param {?function(new:BaseComponent)} [options.baseClass] Base class of all
    *   components to be managed by this instance. `null` (the default) is the
    *   same as passing `BaseComponent`.
-   * @param {?IntfLogger} [options.baseSublogger] Base sublogger to use for
-   *   instantiated components, or `null` not to do any logging.
+   * @param {string} [options.name] Name of this instance, as a component.
    */
   constructor(instances, options) {
     const {
       baseClass = null,
-      baseSublogger = null,
       name
     } = options;
 
@@ -58,9 +48,6 @@ export class ComponentManager extends BaseComponent {
     this.#baseClass = (baseClass === null)
       ? BaseComponent
       : MustBe.subclassOf(baseClass, BaseComponent);
-    this.#baseSublogger = (baseSublogger === null)
-      ? null
-      : MustBe.instanceOf(baseSublogger, IntfLogger);
 
     MustBe.array(instances);
     for (const instance of instances) {
@@ -105,8 +92,7 @@ export class ComponentManager extends BaseComponent {
     const instances = this.getAll();
 
     const results = instances.map((c) => {
-      const logger  = this.#baseSublogger[c.name];
-      const context = new ControlContext(c, this, logger);
+      const context = new ControlContext(c, this);
       return c.init(context, isReload);
     });
 

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -43,7 +43,7 @@ export class HostManager extends BaseComponent {
    * @param {Array<NetworkHost>} [hosts] Host handler objects.
    */
   constructor(hosts = []) {
-    super({ name: 'hosts' });
+    super({ name: 'host' });
 
     this.#allHosts = hosts;
 

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -38,13 +38,6 @@ export class HostManager extends BaseComponent {
   #items = new TreePathMap(HostUtil.hostnameStringFrom);
 
   /**
-   * Logger for this class, or `null` not to do any logging.
-   *
-   * @type {?IntfLogger}
-   */
-  #logger = ThisModule.subsystemLogger('hosts');
-
-  /**
    * Constructs an instance.
    *
    * @param {Array<NetworkHost>} [hosts] Host handler objects.
@@ -133,8 +126,7 @@ export class HostManager extends BaseComponent {
     const hosts = this.getAll();
 
     const results = hosts.map((h) => {
-      const logger  = ThisModule.cohortLogger('host')?.[h.name];
-      const context = new ControlContext(h, this, logger);
+      const context = new ControlContext(h, this);
       return h.init(context, isReload);
     });
 
@@ -171,7 +163,7 @@ export class HostManager extends BaseComponent {
       }
 
       this.#items.add(key, host);
-      this.#logger?.bound(name);
+      this.logger?.bound(name);
     }
   }
 
@@ -189,7 +181,7 @@ export class HostManager extends BaseComponent {
     const key = HostUtil.parseHostnameOrNull(name, allowWildcard);
 
     if (key === null) {
-      this.#logger?.invalidHostname(name);
+      this.logger?.invalidHostname(name);
       return null;
     }
 
@@ -216,16 +208,16 @@ export class HostManager extends BaseComponent {
     let   foundCtx = null;
 
     if (found) {
-      this.#logger?.found(serverName, found.config.hostnames);
+      this.logger?.found(serverName, found.config.hostnames);
       foundCtx = found.getSecureContext();
     } else {
-      this.#logger?.notFound(serverName);
+      this.logger?.notFound(serverName);
     }
 
     try {
       callback(null, foundCtx);
     } catch (e) {
-      this.#logger?.errorDuringCallback(e);
+      this.logger?.errorDuringCallback(e);
       callback(e, null);
     }
   }

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -5,12 +5,10 @@ import { SecureContext } from 'node:tls';
 
 import { TreePathMap } from '@this/collections';
 import { BaseComponent, BaseConfig, ControlContext } from '@this/compote';
-import { IntfLogger } from '@this/loggy-intf';
 import { IntfHostManager } from '@this/net-protocol';
 import { HostUtil } from '@this/net-util';
 
 import { NetworkHost } from '#x/NetworkHost';
-import { ThisModule } from '#p/ThisModule';
 
 
 /**

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -50,11 +50,7 @@ export class HostManager extends BaseComponent {
    * @param {Array<NetworkHost>} [hosts] Host handler objects.
    */
   constructor(hosts = []) {
-    // TODO: The `name` is probably too ad-hoc.
-    super({
-      name:   'hostManager',
-      logTag: 'hosts'
-    });
+    super({ name: 'hosts' });
 
     this.#allHosts = hosts;
 

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -106,7 +106,7 @@ export class NetworkEndpoint extends BaseComponent {
 
     const hmOpt = {};
     if (this.config.requiresCertificates()) {
-      const hostManager = this.context.getComponent('hostManager');
+      const hostManager = this.context.getComponent('root').hostManager;
       hmOpt.hostManager = hostManager.makeSubset(hostnames);
     }
 

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -101,12 +101,16 @@ export class NetworkEndpoint extends BaseComponent {
       }
     } = this.config;
 
-    const rateLimiter = context.getComponentOrNull(rateLimiterName, BaseService, IntfRateLimiter);
-    const accessLog   = context.getComponentOrNull(accessLogName,   BaseService, IntfAccessLog);
+    const rateLimiter = rateLimiterName
+      ? context.getComponent(['service', rateLimiterName], BaseService, IntfRateLimiter)
+      : null;
+    const accessLog = accessLogName
+      ? context.getComponent(['service', accessLogName], BaseService, IntfAccessLog)
+      : null;
 
     const hmOpt = {};
     if (this.config.requiresCertificates()) {
-      const hostManager = this.context.getComponent('root').hostManager;
+      const hostManager = this.context.root.associate.hostManager;
       hmOpt.hostManager = hostManager.makeSubset(hostnames);
     }
 
@@ -119,7 +123,7 @@ export class NetworkEndpoint extends BaseComponent {
       ...hmOpt
     };
 
-    this.#application = context.getComponent(application, BaseApplication);
+    this.#application = context.getComponent(['application', application], BaseApplication);
     this.#wrangler    = ProtocolWranglers.make(wranglerOptions);
 
     await this.#wrangler.init(this.logger, isReload);

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -110,7 +110,7 @@ export class NetworkEndpoint extends BaseComponent {
 
     const hmOpt = {};
     if (this.config.requiresCertificates()) {
-      const hostManager = this.context.root.associate.hostManager;
+      const hostManager = this.root.hostManager;
       hmOpt.hostManager = hostManager.makeSubset(hostnames);
     }
 

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -75,19 +75,19 @@ export class WebappRoot extends BaseComponent {
     this.#applicationManager = new ComponentManager(applications, {
       baseClass:     BaseApplication,
       baseSublogger: ThisModule.cohortLogger('app'),
-      logTag:        'apps'
+      name:          'application'
     });
 
     this.#serviceManager = new ComponentManager(services, {
       baseClass:     BaseService,
       baseSublogger: ThisModule.cohortLogger('service'),
-      logTag:        'services'
+      name:          'service'
     });
 
     this.#endpointManager = new ComponentManager(endpoints, {
       baseClass:     NetworkEndpoint,
       baseSublogger: ThisModule.cohortLogger('endpoint'),
-      logTag:        'endpoints'
+      name:          'endpoint'
     });
 
     this.#hostManager = new HostManager(hosts);

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -63,7 +63,12 @@ export class WebappRoot extends BaseComponent {
   constructor(rawConfig) {
     // Note: `super()` is called with a second argument exactly because this
     // instance is the root of its hierarchy.
-    super(rawConfig, new RootControlContext(ThisModule.subsystemLogger('root')));
+    super(
+      {
+        ...rawConfig,
+        name: 'root'
+      },
+      new RootControlContext(ThisModule.subsystemLogger('root')));
 
     const { applications, endpoints, hosts, services } = this.config;
 

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -68,7 +68,7 @@ export class WebappRoot extends BaseComponent {
         ...rawConfig,
         name: 'root'
       },
-      new RootControlContext(ThisModule.subsystemLogger('root')));
+      new RootControlContext(ThisModule.logger));
 
     const { applications, endpoints, hosts, services } = this.config;
 

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -73,21 +73,18 @@ export class WebappRoot extends BaseComponent {
     const { applications, endpoints, hosts, services } = this.config;
 
     this.#applicationManager = new ComponentManager(applications, {
-      baseClass:     BaseApplication,
-      baseSublogger: ThisModule.cohortLogger('app'),
-      name:          'application'
+      baseClass: BaseApplication,
+      name:      'application'
     });
 
     this.#serviceManager = new ComponentManager(services, {
-      baseClass:     BaseService,
-      baseSublogger: ThisModule.cohortLogger('service'),
-      name:          'service'
+      baseClass: BaseService,
+      name:      'service'
     });
 
     this.#endpointManager = new ComponentManager(endpoints, {
-      baseClass:     NetworkEndpoint,
-      baseSublogger: ThisModule.cohortLogger('endpoint'),
-      name:          'endpoint'
+      baseClass: NetworkEndpoint,
+      name:      'endpoint'
     });
 
     this.#hostManager = new HostManager(hosts);

--- a/src/webapp-core/private/ThisModule.js
+++ b/src/webapp-core/private/ThisModule.js
@@ -11,13 +11,6 @@ import { MustBe } from '@this/typey';
  */
 export class ThisModule {
   /**
-   * Map of all loggers returned from {@link #loggerFor}.
-   *
-   * @type {Map<string, IntfLogger>}
-   */
-  static #loggers = new Map();
-
-  /**
    * Base logger for this module's subsystems, or `null` not to do any logging.
    *
    * @type {?IntfLogger}
@@ -30,56 +23,5 @@ export class ThisModule {
    */
   static get logger() {
     return this.#logger;
-  }
-
-  /**
-   * Gets a logger for a particular cohort. A "cohort" is a set of similar items
-   * of some sort, e.g. "applications" or "services."
-   *
-   * @param {string} name Name of the cohort.
-   * @returns {?IntfLogger} Logger for the cohort, or `null` if it is not to be
-   *   logged.
-   */
-  static cohortLogger(name) {
-    return this.#loggerFor(name, true);
-  }
-
-  /**
-   * Gets a logger for a particular subsystem.
-   *
-   * @param {string} name Name of the subsystem or cohort.
-   * @returns {?IntfLogger} Logger for the subsystem, or `null` if it is not to
-   *   be logged.
-   */
-  static subsystemLogger(name) {
-    return this.#loggerFor(name, false);
-  }
-
-  /**
-   * Gets a logger for a particular subsystem or cohort. (A "cohort" is a set of
-   * loggers for similar items, e.g. "applications" or "services.")
-   *
-   * @param {string} name Name of the subsystem or cohort.
-   * @param {boolean} isCohort Is this a cohort?
-   * @returns {?IntfLogger} Logger for the subsystem or cohort, or `null` if it
-   *   is not to be logged.
-   */
-  static #loggerFor(name, isCohort) {
-    MustBe.string(name);
-
-    const mapKey  = `${name}-${isCohort}`;
-    const already = this.#loggers.get(mapKey);
-
-    if (already) {
-      return already;
-    }
-
-    const result = isCohort
-      ? Loggy.loggerFor(name)
-      : this.#logger?.[name];
-
-    this.#loggers.set(mapKey, result);
-
-    return result;
   }
 }

--- a/src/webapp-core/private/ThisModule.js
+++ b/src/webapp-core/private/ThisModule.js
@@ -3,7 +3,6 @@
 
 import { Loggy } from '@this/loggy';
 import { IntfLogger } from '@this/loggy-intf';
-import { MustBe } from '@this/typey';
 
 
 /**

--- a/src/webapp-core/private/ThisModule.js
+++ b/src/webapp-core/private/ThisModule.js
@@ -25,6 +25,14 @@ export class ThisModule {
   static #logger = Loggy.loggerFor('webapp');
 
   /**
+   * @returns {?IntfLogger} Root logger for this module's component hierarchies,
+   * or `null` not to do any logging.
+   */
+  static get logger() {
+    return this.#logger;
+  }
+
+  /**
    * Gets a logger for a particular cohort. A "cohort" is a set of similar items
    * of some sort, e.g. "applications" or "services."
    *


### PR DESCRIPTION
This PR simplifies how things work in `compote` in terms of naming and logging: Components now consistently get names (if a component doesn't have one, it gets a synthesized one when it's attached to a hierarchy), and the logging tags always match the name-path from the component root to the component being logged. With that done, there was no more need for a `logTag` configuration (which was only barely ever used anyway), and it became possible to drop the `logger` argument from the `ControlContext` constructor.