### PR TITLE
`isReload`: RELETED

### DIFF
--- a/doc/configuration/3-built-in-services.md
+++ b/doc/configuration/3-built-in-services.md
@@ -33,10 +33,8 @@ following bindings:
 * `maxOldCount` &mdash; How many old (post-rotation) files should be allowed, or
   `null` not to have a limit. The oldest files over the limit get deleted after
    a rotation. Optional, and defaults to `null`.
-* `onReload` &mdash; If `true`, rotates when the system is reloaded (restarted
-  in-process). Optional, and defaults to `false`.
-* `onStart` &mdash; If `true`, rotates when the system is first started.
-  Optional, and defaults to `false`.
+* `onStart` &mdash; If `true`, rotates when the system is first started or
+  reloaded (restarted in-process). Optional, and defaults to `false`.
 * `onStop` &mdash; If `true`, rotates when the system is about to be stopped.
   Optional, and defaults to `false`.
 
@@ -50,7 +48,6 @@ the ones that are used by `save`:
 
 * `maxOldBytes`
 * `maxOldCount`
-* `onReload`
 * `onStart`
 * `onStop`
 

--- a/doc/configuration/3-built-in-services.md
+++ b/doc/configuration/3-built-in-services.md
@@ -35,8 +35,8 @@ following bindings:
    a rotation. Optional, and defaults to `null`.
 * `onStart` &mdash; If `true`, rotates when the system is first started or
   reloaded (restarted in-process). Optional, and defaults to `false`.
-* `onStop` &mdash; If `true`, rotates when the system is about to be stopped.
-  Optional, and defaults to `false`.
+* `onStop` &mdash; If `true`, rotates when the system is about to be stopped or
+  reloaded (restarted in-process). Optional, and defaults to `false`.
 
 #### `save`
 

--- a/doc/quick-start/code/index.mjs
+++ b/doc/quick-start/code/index.mjs
@@ -29,7 +29,7 @@ class UsualSystem extends BaseSystem {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     return new WebappRoot(CONFIG);
   }
 

--- a/doc/quick-start/code/index.mjs
+++ b/doc/quick-start/code/index.mjs
@@ -34,9 +34,9 @@ class UsualSystem extends BaseSystem {
   }
 
   /** @override */
-  async _impl_start(isReload, initValue) {
+  async _impl_start(initValue) {
     this.#webapp = initValue;
-    await this.#webapp.start(isReload);
+    await this.#webapp.start();
   }
 
   /** @override */

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -83,7 +83,6 @@ const services = [
     rotate: {
       atSize:      2 * 1024 * 1024,
       onStart:     true,
-      onReload:    true,
       onStop:      true,
       maxOldBytes: 10 * 1024 * 1024,
       maxOldCount: 10,

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -188,9 +188,8 @@ export class BaseComponent {
   }
 
   /** @override */
-  async init(context, isReload = false) {
+  async init(context) {
     MustBe.instanceOf(context, ControlContext);
-    MustBe.boolean(isReload);
 
     if (this.#initialized) {
       throw new Error('Already initialized.');
@@ -201,7 +200,7 @@ export class BaseComponent {
     this.#context = context;
 
     BaseComponent.logInitializing(this.logger);
-    await this._impl_init(isReload);
+    await this._impl_init();
     BaseComponent.logInitialized(this.logger);
   }
 
@@ -232,15 +231,15 @@ export class BaseComponent {
       if (this.#context === null) {
         throw new Error('No context was set up in constructor or `init()`.');
       }
-      await this.init(this.#context.nascentRoot, isReload);
+      await this.init(this.#context.nascentRoot);
     } else if (this.state !== 'stopped') {
       throw new Error('Already running.');
     }
 
-    BaseComponent.logStarting(this.logger, isReload);
+    BaseComponent.logStarting(this.logger);
     await this._impl_start(isReload);
     this.#context[ThisModule.SYM_setState]('running');
-    BaseComponent.logStarted(this.logger, isReload);
+    BaseComponent.logStarted(this.logger);
   }
 
   /** @override */
@@ -276,10 +275,9 @@ export class BaseComponent {
    * connection) beyond "sensing" (e.g., reading a file).
    *
    * @abstract
-   * @param {boolean} isReload Is this action due to an in-process reload?
    */
-  async _impl_init(isReload) {
-    Methods.abstract(isReload);
+  async _impl_init() {
+    Methods.abstract();
   }
 
   /**
@@ -320,7 +318,7 @@ export class BaseComponent {
     }
 
     const context = new ControlContext(child, this);
-    await child.init(context, isReload);
+    await child.init(context);
 
     if (this.state === 'running') {
       // Get the child running, so as to match the parent.
@@ -427,20 +425,18 @@ export class BaseComponent {
    * action.
    *
    * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
-   * @param {boolean} isReload Is this a system reload (vs. first-time init)?
    */
-  static logInitialized(logger, isReload) {
-    logger?.initialized(isReload ? 'reload' : 'boot');
+  static logInitialized(logger) {
+    logger?.initialized();
   }
 
   /**
    * Logs a message about an item (component, etc.) starting an `init()` action.
    *
    * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
-   * @param {boolean} isReload Is this a system reload (vs. first-time init)?
    */
-  static logInitializing(logger, isReload) {
-    logger?.initializing(isReload ? 'reload' : 'boot');
+  static logInitializing(logger) {
+    logger?.initializing();
   }
 
   /**
@@ -448,10 +444,9 @@ export class BaseComponent {
    * action.
    *
    * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
-   * @param {boolean} isReload Is this a system reload (vs. first-time init)?
    */
-  static logStarted(logger, isReload) {
-    logger?.started(isReload ? 'reload' : 'boot');
+  static logStarted(logger) {
+    logger?.started();
   }
 
   /**
@@ -459,10 +454,9 @@ export class BaseComponent {
    * action.
    *
    * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
-   * @param {boolean} isReload Is this a system reload (vs. first-time init)?
    */
-  static logStarting(logger, isReload) {
-    logger?.starting(isReload ? 'reload' : 'boot');
+  static logStarting(logger) {
+    logger?.starting();
   }
 
   /**

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -224,9 +224,7 @@ export class BaseComponent {
   }
 
   /** @override */
-  async start(isReload = false) {
-    MustBe.boolean(isReload);
-
+  async start() {
     if (!this.#initialized) {
       if (this.#context === null) {
         throw new Error('No context was set up in constructor or `init()`.');
@@ -237,7 +235,7 @@ export class BaseComponent {
     }
 
     BaseComponent.logStarting(this.logger);
-    await this._impl_start(isReload);
+    await this._impl_start();
     this.#context[ThisModule.SYM_setState]('running');
     BaseComponent.logStarted(this.logger);
   }
@@ -284,10 +282,9 @@ export class BaseComponent {
    * Subclass-specific implementation of {@link #start}.
    *
    * @abstract
-   * @param {boolean} isReload Is this action due to an in-process reload?
    */
-  async _impl_start(isReload) {
-    Methods.abstract(isReload);
+  async _impl_start() {
+    Methods.abstract();
   }
 
   /**
@@ -322,7 +319,7 @@ export class BaseComponent {
 
     if (this.state === 'running') {
       // Get the child running, so as to match the parent.
-      await child.start(isReload);
+      await child.start();
     }
   }
 

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -303,9 +303,8 @@ export class BaseComponent {
    * to only be called by an instance to modify itself.
    *
    * @param {BaseComponent} child Child component to add.
-   * @param {boolean} [isReload] Is the system being reloaded?
    */
-  async _prot_addChild(child, isReload = false) {
+  async _prot_addChild(child) {
     MustBe.instanceOf(child, BaseComponent);
 
     if (!this.#initialized) {

--- a/src/compy/export/IntfComponent.js
+++ b/src/compy/export/IntfComponent.js
@@ -102,10 +102,9 @@ export class IntfComponent {
    * @abstract
    * @param {ControlContext} context Context that indicates this instance's
    *   active environment.
-   * @param {boolean} [isReload] Is this action due to an in-process reload?
    */
-  async init(context, isReload = false) {
-    Methods.abstract(context, isReload);
+  async init(context) {
+    Methods.abstract(context);
   }
 
   /**

--- a/src/compy/export/IntfComponent.js
+++ b/src/compy/export/IntfComponent.js
@@ -129,9 +129,8 @@ export class IntfComponent {
    * also only valid to call this method if the instance is not already running.
    *
    * @abstract
-   * @param {boolean} [isReload] Is this action due to an in-process reload?
    */
-  async start(isReload = false) {
+  async start() {
     Methods.abstract(isReload);
   }
 

--- a/src/compy/export/IntfComponent.js
+++ b/src/compy/export/IntfComponent.js
@@ -131,7 +131,7 @@ export class IntfComponent {
    * @abstract
    */
   async start() {
-    Methods.abstract(isReload);
+    Methods.abstract();
   }
 
   /**

--- a/src/compy/export/ThreadlikeComponent.js
+++ b/src/compy/export/ThreadlikeComponent.js
@@ -15,12 +15,12 @@ export class ThreadlikeComponent extends BaseComponent {
   // @defaultConstructor
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     await this.config.threadlet.start();
   }
 

--- a/src/compy/tests/ControlContext.test.js
+++ b/src/compy/tests/ControlContext.test.js
@@ -10,12 +10,12 @@ import { BaseAggregateComponent, BaseConfig, RootControlContext }
  */
 class MockComponent extends BaseAggregateComponent {
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     // @emptyBlock
   }
 

--- a/src/main-lactoserv/private/UsualSystem.js
+++ b/src/main-lactoserv/private/UsualSystem.js
@@ -44,9 +44,9 @@ export class UsualSystem extends BaseSystem {
   }
 
   /** @override */
-  async _impl_start(isReload, initValue) {
+  async _impl_start(initValue) {
     this.#webapp = initValue;
-    await this.#webapp.start(isReload);
+    await this.#webapp.start();
   }
 
   /** @override */

--- a/src/main-lactoserv/private/UsualSystem.js
+++ b/src/main-lactoserv/private/UsualSystem.js
@@ -39,7 +39,7 @@ export class UsualSystem extends BaseSystem {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     return await this.#args.webappMaker.make();
   }
 

--- a/src/net-protocol/private/AsyncServerSocket.js
+++ b/src/net-protocol/private/AsyncServerSocket.js
@@ -138,6 +138,10 @@ export class AsyncServerSocket {
     // instance which is already set up the same way as what is being requested.
     const found = AsyncServerSocket.#unstashInstance(this.#interface);
 
+    if (found) {
+      this.#logger?.unstashed();
+    }
+
     if (found?.#serverSocket) {
       // Inherit the "guts" of the now-unstashed instance.
       this.#serverSocket = found.#serverSocket;
@@ -466,7 +470,6 @@ export class AsyncServerSocket {
 
     if (found) {
       this.#stashedInstances.delete(found);
-      found.#logger?.unstashed();
     }
 
     return found;

--- a/src/net-protocol/private/AsyncServerSocket.js
+++ b/src/net-protocol/private/AsyncServerSocket.js
@@ -129,11 +129,8 @@ export class AsyncServerSocket {
 
   /**
    * Starts this instance.
-   *
-   * @param {boolean} isReload_unused Is this action due to an in-process
-   *   reload?
    */
-  async start(isReload_unused) {
+  async start() {
     // To handle the case of an in-process system reload, look for a stashed
     // instance which is already set up the same way as what is being requested.
     const found = AsyncServerSocket.#unstashInstance(this.#interface);

--- a/src/net-protocol/private/AsyncServerSocket.js
+++ b/src/net-protocol/private/AsyncServerSocket.js
@@ -130,16 +130,13 @@ export class AsyncServerSocket {
   /**
    * Starts this instance.
    *
-   * @param {boolean} isReload Is this action due to an in-process reload?
+   * @param {boolean} isReload_unused Is this action due to an in-process
+   *   reload?
    */
-  async start(isReload) {
-    MustBe.boolean(isReload);
-
-    // In case of a reload, look for a stashed instance which is already set up
-    // the same way.
-    const found = isReload
-      ? AsyncServerSocket.#unstashInstance(this.#interface)
-      : null;
+  async start(isReload_unused) {
+    // To handle the case of an in-process system reload, look for a stashed
+    // instance which is already set up the same way as what is being requested.
+    const found = AsyncServerSocket.#unstashInstance(this.#interface);
 
     if (found?.#serverSocket) {
       // Inherit the "guts" of the now-unstashed instance.

--- a/src/net-protocol/private/Http2Wrangler.js
+++ b/src/net-protocol/private/Http2Wrangler.js
@@ -79,7 +79,7 @@ export class Http2Wrangler extends TcpWrangler {
   }
 
   /** @override */
-  async _impl_serverStart(isReload_unused) {
+  async _impl_serverStart() {
     this.#runner.run();
   }
 

--- a/src/net-protocol/private/HttpWrangler.js
+++ b/src/net-protocol/private/HttpWrangler.js
@@ -34,7 +34,7 @@ export class HttpWrangler extends TcpWrangler {
   }
 
   /** @override */
-  async _impl_serverStart(isReload_unused) {
+  async _impl_serverStart() {
     // @emptyBlock
   }
 

--- a/src/net-protocol/private/HttpsWrangler.js
+++ b/src/net-protocol/private/HttpsWrangler.js
@@ -40,7 +40,7 @@ export class HttpsWrangler extends TcpWrangler {
   }
 
   /** @override */
-  async _impl_serverStart(isReload_unused) {
+  async _impl_serverStart() {
     // @emptyBlock
   }
 

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -76,7 +76,7 @@ export class TcpWrangler extends ProtocolWrangler {
 
   /** @override */
   async init(logger, isReload) {
-    this.#asyncServer = new AsyncServerSocket(...this.#asyncServerArgs, this.logger);
+    this.#asyncServer = new AsyncServerSocket(...this.#asyncServerArgs, logger);
 
     await super.init(logger, isReload);
   }

--- a/src/net-protocol/private/TcpWrangler.js
+++ b/src/net-protocol/private/TcpWrangler.js
@@ -75,10 +75,10 @@ export class TcpWrangler extends ProtocolWrangler {
   }
 
   /** @override */
-  async init(logger, isReload) {
+  async init(logger) {
     this.#asyncServer = new AsyncServerSocket(...this.#asyncServerArgs, logger);
 
-    await super.init(logger, isReload);
+    await super.init(logger);
   }
 
   /** @override */
@@ -100,9 +100,9 @@ export class TcpWrangler extends ProtocolWrangler {
   }
 
   /** @override */
-  async _impl_socketStart(isReload) {
+  async _impl_socketStart() {
     await this.#runner.start();
-    await this.#asyncServer.start(isReload);
+    await this.#asyncServer.start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/AccessLogToFile.js
+++ b/src/webapp-builtins/export/AccessLogToFile.js
@@ -122,7 +122,7 @@ export class AccessLogToFile extends BaseFileService {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     const { config } = this;
     const { bufferPeriod, path, rotate } = config;
 

--- a/src/webapp-builtins/export/AccessLogToFile.js
+++ b/src/webapp-builtins/export/AccessLogToFile.js
@@ -131,10 +131,10 @@ export class AccessLogToFile extends BaseFileService {
   }
 
   /** @override */
-  async _impl_start(isReload) {
+  async _impl_start() {
     await this._prot_createDirectoryIfNecessary();
     await this._prot_touchPath();
-    await this.#rotator?.start(isReload);
+    await this.#rotator?.start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/AccessLogToSyslog.js
+++ b/src/webapp-builtins/export/AccessLogToSyslog.js
@@ -47,12 +47,12 @@ export class AccessLogToSyslog extends BaseService {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     // @emptyBlock
   }
 

--- a/src/webapp-builtins/export/EventFan.js
+++ b/src/webapp-builtins/export/EventFan.js
@@ -64,12 +64,12 @@ export class EventFan extends BaseService {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     this.logger?.targets(this.config.services);
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     // Note: We can't do this setup in `_impl_init()` because it might not be
     // the case that all of the referenced services have already been added when
     // that runs.

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -44,7 +44,7 @@ export class HostRouter extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     const routes = {};
     for (const [host, name] of this.config.routeTree) {
       routes[HostUtil.hostnameStringFrom(host)] = name;
@@ -54,7 +54,7 @@ export class HostRouter extends BaseApplication {
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     // Note: We can't do this setup in `_impl_init()` because it might not be
     // the case that all of the referenced apps have already been added when
     // that runs.

--- a/src/webapp-builtins/export/MemoryMonitor.js
+++ b/src/webapp-builtins/export/MemoryMonitor.js
@@ -37,12 +37,12 @@ export class MemoryMonitor extends BaseService {
   // @defaultConstructor
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     await this.#runner.start();
   }
 

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -50,7 +50,7 @@ export class PathRouter extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     const routes = {};
     for (const [path, name] of this.config.routeTree) {
       routes[UriUtil.pathStringFrom(path)] = name;
@@ -60,7 +60,7 @@ export class PathRouter extends BaseApplication {
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     // Note: We can't do this setup in `_impl_init()` because it might not be
     // the case that all of the referenced apps have already been added when
     // that runs.

--- a/src/webapp-builtins/export/ProcessIdFile.js
+++ b/src/webapp-builtins/export/ProcessIdFile.js
@@ -34,12 +34,12 @@ export class ProcessIdFile extends BaseFileService {
   // @defaultConstructor
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     await this.#runner.start();
   }
 

--- a/src/webapp-builtins/export/ProcessInfoFile.js
+++ b/src/webapp-builtins/export/ProcessInfoFile.js
@@ -127,7 +127,7 @@ export class ProcessInfoFile extends BaseFileService {
       ...ProcessInfo.allInfo,
       disposition: {
         running: true
-      },
+      }
     };
 
     delete contents.uptime; // Ends up in `disposition`.
@@ -146,9 +146,9 @@ export class ProcessInfoFile extends BaseFileService {
         contents.earlierRuns = [fileContents];
       }
     } else if (this.#contents?.earlierRuns) {
-     // **Note:** `this.#contents` is only possibly non-empty if this instance
-     // was configured with `onStart: true` or `onStop: true`.
-     contents.earlierRuns = this.#contents.earlierRuns;
+      // **Note:** `this.#contents` is only possibly non-empty if this instance
+      // was configured with `onStart: true` or `onStop: true`.
+      contents.earlierRuns = this.#contents.earlierRuns;
     }
 
     if (contents.earlierRuns) {

--- a/src/webapp-builtins/export/ProcessInfoFile.js
+++ b/src/webapp-builtins/export/ProcessInfoFile.js
@@ -46,7 +46,7 @@ export class ProcessInfoFile extends BaseFileService {
   // @defaultConstructor
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     const { config } = this;
     this.#saver = config.save ? new Saver(config, this.logger) : null;
   }

--- a/src/webapp-builtins/export/RateLimiter.js
+++ b/src/webapp-builtins/export/RateLimiter.js
@@ -80,12 +80,12 @@ export class RateLimiter extends BaseService {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     // @emptyBlock
   }
 

--- a/src/webapp-builtins/export/Redirector.js
+++ b/src/webapp-builtins/export/Redirector.js
@@ -62,12 +62,12 @@ export class Redirector extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     // @emptyBlock
   }
 

--- a/src/webapp-builtins/export/RequestFilter.js
+++ b/src/webapp-builtins/export/RequestFilter.js
@@ -82,12 +82,12 @@ export class RequestFilter extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     // @emptyBlock
   }
 

--- a/src/webapp-builtins/export/SerialRouter.js
+++ b/src/webapp-builtins/export/SerialRouter.js
@@ -40,7 +40,7 @@ export class SerialRouter extends BaseApplication {
 
   /** @override */
   async _impl_init(isReload_unused) {
-    this.logger?.routes(this.config.routes);
+    this.logger?.routes(this.config.routeList);
   }
 
   /** @override */

--- a/src/webapp-builtins/export/SerialRouter.js
+++ b/src/webapp-builtins/export/SerialRouter.js
@@ -39,12 +39,12 @@ export class SerialRouter extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     this.logger?.routes(this.config.routeList);
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     // Note: We can't do this setup in `_impl_init()` because it might not be
     // the case that all of the referenced apps have already been added when
     // that runs.

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -44,12 +44,12 @@ export class SimpleResponse extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     if (this.#response) {
       return;
     }

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -119,12 +119,12 @@ export class StaticFiles extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     const siteDirectory = this.#siteDirectory;
 
     if (!await Statter.directoryExists(siteDirectory)) {

--- a/src/webapp-builtins/export/SyslogToFile.js
+++ b/src/webapp-builtins/export/SyslogToFile.js
@@ -32,7 +32,7 @@ export class SyslogToFile extends BaseFileService {
   // @defaultConstructor
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // Having a logger available is optional for most classes, but for this one
     // it is essential!
     if (!this.logger) {

--- a/src/webapp-builtins/export/SyslogToFile.js
+++ b/src/webapp-builtins/export/SyslogToFile.js
@@ -44,10 +44,10 @@ export class SyslogToFile extends BaseFileService {
   }
 
   /** @override */
-  async _impl_start(isReload) {
+  async _impl_start() {
     await this._prot_createDirectoryIfNecessary();
     await this._prot_touchPath();
-    await this.#rotator?.start(isReload);
+    await this.#rotator?.start();
 
     const { bufferPeriod, format, name, path } = this.config;
     const earliestEvent = this.#findEarliestEventToLog(name);

--- a/src/webapp-builtins/tests/PathRouter.test.js
+++ b/src/webapp-builtins/tests/PathRouter.test.js
@@ -22,12 +22,12 @@ export class NopComponent extends BaseAggregateComponent {
   // @defaultConstructor
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     // @emptyBlock
   }
 
@@ -74,12 +74,12 @@ class MockApp extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     // @emptyBlock
   }
 

--- a/src/webapp-core/export/ComponentManager.js
+++ b/src/webapp-core/export/ComponentManager.js
@@ -66,9 +66,9 @@ export class ComponentManager extends BaseAggregateComponent {
   }
 
   /** @override */
-  async _impl_start(isReload) {
+  async _impl_start() {
     const instances = [...this.children()];
-    const results   = instances.map((c) => c.start(isReload));
+    const results   = instances.map((c) => c.start());
 
     await Promise.all(results);
   }

--- a/src/webapp-core/export/ComponentManager.js
+++ b/src/webapp-core/export/ComponentManager.js
@@ -61,7 +61,7 @@ export class ComponentManager extends BaseAggregateComponent {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -63,11 +63,11 @@ export class HostManager extends BaseAggregateComponent {
   }
 
   /** @override */
-  async _impl_start(isReload) {
+  async _impl_start() {
     this.#hostMap.logHostMap();
 
     const hosts   = [...this.children()];
-    const results = hosts.map((h) => h.start(isReload));
+    const results = hosts.map((h) => h.start());
 
     await Promise.all(results);
   }

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -58,7 +58,7 @@ export class HostManager extends BaseAggregateComponent {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     this.#hostMap = new HostManager.HostMap(this.logger);
   }
 

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -71,7 +71,7 @@ export class NetworkEndpoint extends BaseComponent {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     const {
       application,
       interface: iface,
@@ -86,7 +86,7 @@ export class NetworkEndpoint extends BaseComponent {
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     const appManager     = this.root.applicationManager;
     const serviceManager = this.root.serviceManager;
 

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -86,7 +86,7 @@ export class NetworkEndpoint extends BaseComponent {
   }
 
   /** @override */
-  async _impl_start(isReload) {
+  async _impl_start(isReload_unused) {
     const appManager     = this.root.applicationManager;
     const serviceManager = this.root.serviceManager;
 
@@ -126,8 +126,8 @@ export class NetworkEndpoint extends BaseComponent {
     this.#application = appManager.get(application);
     this.#wrangler    = ProtocolWranglers.make(wranglerOptions);
 
-    await this.#wrangler.init(this.logger, isReload);
-    await this.#wrangler.start(isReload);
+    await this.#wrangler.init(this.logger);
+    await this.#wrangler.start();
   }
 
   /**

--- a/src/webapp-core/export/NetworkHost.js
+++ b/src/webapp-core/export/NetworkHost.js
@@ -97,12 +97,12 @@ export class NetworkHost extends BaseComponent {
   }
 
   /** @override */
-  async _impl_init(isReload_unused) {
+  async _impl_init() {
     // @emptyBlock
   }
 
   /** @override */
-  async _impl_start(isReload_unused) {
+  async _impl_start() {
     const { config } = this;
     const { selfSigned } = config;
 

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -131,11 +131,11 @@ export class WebappRoot extends BaseComponent {
   }
 
   /** @override */
-  async _impl_start(isReload) {
-    await this.#hostManager.start(isReload);
-    await this.#serviceManager.start(isReload);
-    await this.#applicationManager.start(isReload);
-    await this.#endpointManager.start(isReload);
+  async _impl_start() {
+    await this.#hostManager.start();
+    await this.#serviceManager.start();
+    await this.#applicationManager.start();
+    await this.#endpointManager.start();
   }
 
   /** @override */

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -112,12 +112,12 @@ export class WebappRoot extends BaseComponent {
   }
 
   /** @override */
-  async _impl_init(isReload) {
+  async _impl_init() {
     const results = [
-      this._prot_addChild(this.#serviceManager,     isReload),
-      this._prot_addChild(this.#applicationManager, isReload),
-      this._prot_addChild(this.#hostManager,        isReload),
-      this._prot_addChild(this.#endpointManager,    isReload)
+      this._prot_addChild(this.#serviceManager),
+      this._prot_addChild(this.#applicationManager),
+      this._prot_addChild(this.#hostManager),
+      this._prot_addChild(this.#endpointManager)
     ];
 
     await Promise.all(results);

--- a/src/webapp-util/export/BaseFileService.js
+++ b/src/webapp-util/export/BaseFileService.js
@@ -196,13 +196,6 @@ export class BaseFileService extends BaseService {
     #maxOldCount;
 
     /**
-     * Rotate when reloading the system?
-     *
-     * @type {boolean}
-     */
-    #onReload;
-
-    /**
      * Rotate when starting the system?
      *
      * @type {boolean}
@@ -227,7 +220,6 @@ export class BaseFileService extends BaseService {
       const {
         maxOldBytes = null,
         maxOldCount = null,
-        onReload    = false,
         onStart     = false,
         onStop      = false
       } = rawConfig;
@@ -238,7 +230,6 @@ export class BaseFileService extends BaseService {
       this.#maxOldCount = (maxOldCount === null)
         ? null
         : MustBe.number(maxOldCount, { finite: true, minInclusive: 1 });
-      this.#onReload = MustBe.boolean(onReload);
       this.#onStart  = MustBe.boolean(onStart);
       this.#onStop   = MustBe.boolean(onStop);
     }
@@ -257,11 +248,6 @@ export class BaseFileService extends BaseService {
      */
     get maxOldCount() {
       return this.#maxOldCount;
-    }
-
-    /** @returns {boolean} Rotate when reloading the system? */
-    get onReload() {
-      return this.#onReload;
     }
 
     /** @returns {boolean} Rotate when starting the system? */

--- a/src/webapp-util/export/BaseSystem.js
+++ b/src/webapp-util/export/BaseSystem.js
@@ -144,7 +144,7 @@ export class BaseSystem extends BaseExposedThreadlet {
 
     this.#initValue     = this.#nextInitValue;
     this.#nextInitValue = null;
-    await this._impl_start(isReload, this.#initValue);
+    await this._impl_start(this.#initValue);
 
     this.#logger?.started(logArg);
   }
@@ -187,11 +187,10 @@ export class BaseSystem extends BaseExposedThreadlet {
   /**
    * Starts the system, in a subclass-specific way.
    *
-   * @param {boolean} isReload Is the system being reloaded?
    * @param {*} initValue Value previously returned from {@link #_impl_init}.
    */
-  async _impl_start(isReload, initValue) {
-    Methods.abstract(isReload, initValue);
+  async _impl_start(initValue) {
+    Methods.abstract(initValue);
   }
 
   /**

--- a/src/webapp-util/export/BaseSystem.js
+++ b/src/webapp-util/export/BaseSystem.js
@@ -171,10 +171,10 @@ export class BaseSystem extends BaseExposedThreadlet {
 
   /**
    * Initializes any concrete-subclass-related bits, in preparation for running
-   * the system. If `isReload` is passed as `true`, the system is _already_
-   * running, and care should be taken not to disturb that. In particular, this
-   * method is allowed to throw, and that will cause reloading to fail while
-   * leaving the already-running system alone.
+   * the system. Note that the system might be in the process of _reloading_,
+   * and care should be taken not to disturb that. In particular, this method is
+   * allowed to throw, and that will cause reloading to fail while leaving the
+   * already-running system alone.
    *
    * @abstract
    * @returns {*} Value to pass to {@link #_impl_start}, once it is time to

--- a/src/webapp-util/export/BaseSystem.js
+++ b/src/webapp-util/export/BaseSystem.js
@@ -177,12 +177,11 @@ export class BaseSystem extends BaseExposedThreadlet {
    * leaving the already-running system alone.
    *
    * @abstract
-   * @param {boolean} isReload Is the system being reloaded?
    * @returns {*} Value to pass to {@link #_impl_start}, once it is time to
    *   (re-)start the system.
    */
-  async _impl_init(isReload) {
-    Methods.abstract(isReload);
+  async _impl_init() {
+    Methods.abstract();
   }
 
   /**

--- a/src/webapp-util/private/BaseFilePreserver.js
+++ b/src/webapp-util/private/BaseFilePreserver.js
@@ -86,26 +86,16 @@ export class BaseFilePreserver {
    * Starts this instance. If this instance is configured to take any start-time
    * actions (e.g. and especially preserving an existing file), this method does
    * not async-return until those actions are complete.
-   *
-   * @param {boolean} isReload Is this action due to an in-process reload?
    */
-  async start(isReload) {
+  async start() {
     this.#runner.start();
 
-    if (isReload) {
-      if (this.#config.save.onReload) {
-        this.#saveNow.value = true;
-        await this.#saveNow.whenFalse();
-      }
-    } else {
-      if (this.#config.save.onStart) {
-        this.#saveNow.value = true;
-        await this.#saveNow.whenFalse();
-      }
+    if (this.#config.save.onStart) {
+      this.#saveNow.value = true;
+      await this.#saveNow.whenFalse();
     }
 
-    const logArgs = isReload ? ['reload'] : [];
-    this.#logger?.started(...logArgs);
+    this.#logger?.started();
   }
 
   /**
@@ -115,7 +105,7 @@ export class BaseFilePreserver {
    *   being requested?
    */
   async stop(willReload) {
-    if (this.#config.save.onStop && !willReload) {
+    if (this.#config.save.onStop) {
       this.#saveNow.value = true;
       await this.#saveNow.whenFalse();
     }


### PR DESCRIPTION
The `isReload` argument which got passed around when initializing and starting the system was making more problems than it was solving. It's now gone.

That said, the `willReload` argument on the various `stop()`-ish method remains for now, as it _does_ solve at least one problem that's not easily solved in another way (specifically, preserving open sockets across a reload).