### PR TITLE
`maxUrlLength`

### DIFF
--- a/doc/configuration/3-built-in-services.md
+++ b/doc/configuration/3-built-in-services.md
@@ -65,6 +65,11 @@ _not_ configurable. It accepts the following configuration bindings:
   before writing them to the file, specified as a duration value as described in
   [Durations](./2-common-configuration.md#durations), or `null` to indicate
   "do not buffer." Optional and defaults to `null`.
+* `maxUrlLength` &mdash; Maximum length of a URL to log, or `null` to have no
+  upper bound. Anything longer than the maximum is represented as a prefix and
+  suffix concatenated together with `...` in the middle. Because it makes little
+  sense to have a very-small maximum, when non-`null` this must be at least
+  `20`.
 * `path` &mdash; Path to the log file(s) to write. When rotation is performed, a
   date stamp and (if necessary) sequence number are "infixed" into the final
   path component.

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -90,10 +90,11 @@ const services = [
     }
   },
   {
-    name:  'accessFile',
-    class: AccessLogToFile,
-    path:  `${LOG_DIR}/access-log.txt`,
+    name:         'accessFile',
+    class:        AccessLogToFile,
+    path:         `${LOG_DIR}/access-log.txt`,
     bufferPeriod: '0.25 sec',
+    maxUrlLength: 120,
     rotate: {
       atSize:       10000,
       maxOldCount:  10,


### PR DESCRIPTION
Inspired by production logs, this PR adds a `maxUrlLength` configuration to the `AccessLogToFile` service.