### PR TITLE
`SuffixRouter` application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Other notable changes:
 * `webapp-builtins`:
   * New application `SuffixRouter`.
 
+**Note:** v0.7.0 wasn't announced widely, because it was a "rebrand" of v0.6.16.
+
 ### v0.7.0 -- 2024-04-22
 
 This is the same source tree as v0.6.16, other than the CHANGELOG file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Breaking changes:
 * None.
 
 Other notable changes:
-* None.
+* `webapp-builtins`:
+  * New application `SuffixRouter`.
 
 ### v0.7.0 -- 2024-04-22
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ applications.
     to HTTPS for clients that can't do HTTP2.)
 * JS-based configuration file format, which isn't actually that awful!
 * Several built-in applications, including:
-  * Four request routing and filtering applications, to cover most routing
+  * Five request routing and filtering applications, to cover most routing
     needs.
   * Three "leaf" applications, for regular content responses and redirection.
   * More to come!

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -456,8 +456,68 @@ reasonable demand:
 * The bodies of error and other non-content responses, other than `404`s, are
   not configurable.
 * No files under the `siteDirectory` are filtered out and treated as not found.
-  Notably, dotfiles &mdsah; that is, paths where the final component starts with
+  Notably, dotfiles &mdash; that is, paths where the final component starts with
   a dot (`.`) &mdash; are served when corresponding files are found.
+
+## `SuffixRouter`
+
+An application which can route requests to another application, based on the
+suffix of the final file or directory name in a request path. This application
+accepts the following configuration bindings:
+
+* `handleDirectories` &mdash; Boolean indicating whether directory paths should
+  be routed by this application. If `false`, this will not respond for directory
+  paths. Defaults to `false`.
+* `handleFiles` &mdash; Boolean indicating whether file (non-directory) paths
+  should be routed by this application. If `false`, this will not respond for
+  file paths. Defaults to `true`.
+* `suffixes` &mdash; A plain object with suffix specs as keys, and the _names_
+  of other applications as values.
+
+Allowed suffix specs are as follows:
+
+* `*` &mdash; Just a plain star, to indicate a full wildcard match. Use this if
+  you want to have the application always route to _something_. If not present
+  and a given request has no matching suffix, then the application will simply
+  not respond.
+* `*.suffix`, `*-suffix`, `*_suffix`, `*+suffix` &mdash; These all match the
+  given suffix literally, including the four characters that are allowed to
+  match the start of a suffix. The rest of the `suffix` is limited to being
+  ASCII alphanumerics or those same special characters (`.`, `-`, `_`, or `+`).
+
+**Note:** Unlike `PathRouter`, this application does not do fallback to
+less-and-less specific routes; it just finds (at most) one to route to.
+
+**Note:** The suffix spec syntax is intentionally on the more restrictive side.
+If there is reasonable demand, the syntax can be loosened up.
+
+```js
+import { SuffixRouter } from '@lactoserv/webapp-builtins';
+
+const applications = [
+  {
+    name:  'mySuffixes',
+    class: SuffixRouter,
+    hosts: {
+      '*':     'myCatchAllApp',
+      '*.xyz': 'myXyzApp',
+      '*.pdq': 'myPdqApp'
+    }
+  },
+  {
+    name: 'myCatchallApp',
+    // ... more ...
+  },
+  {
+    name: 'myXyzApp',
+    // ... more ...
+  },
+  {
+    name: 'myPdqApp',
+    // ... more ...
+  }
+];
+```
 
 - - - - - - - - - -
 ```

--- a/scripts/lib/bashy-node/node-project/fix-package-json
+++ b/scripts/lib/bashy-node/node-project/fix-package-json
@@ -113,16 +113,17 @@ function do-fix {
     pkg="$(jval <"${filePath}" --input=read \
         deps:json="${finalDeps}" '
     {
-        name: .name,
+        name:    .name,
         version: .version,
-        type: "module",
+        type:    "module",
         private: true,
         license: (.license // "UNLICENSED"),
         BLANK_LINE_1: "",
         exports: "./index.js",
         imports: {
-          "#x/*": "./export/*.js",
-          "#p/*": "./private/*.js"
+          "#x/*":    "./export/*.js",
+          "#p/*":    "./private/*.js",
+          "#test/*": "./tests/*.js"
         }
     }
     |

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -91,6 +91,34 @@ export class DispatchInfo {
   }
 
   /**
+   * @returns {?string} The last path component of the combination of
+   * `<base>/<extra>` if it is non-empty, the second-to-last if the last is
+   * empty, or `null` if neither of the previous two conditions are meaningful
+   * (becuase the total path length is less than `2`). The idea is that this is
+   * the "file name" of this instance, whether it represents a regular file _or_
+   * a directory.
+   */
+  get lastName() {
+    const length = this.fullPathLength;
+
+    switch (length) {
+      case 0: {
+        return null;
+      }
+      case 1: {
+        const name = this.getFullPathComponent(0);
+        return (name === '') ? null : name;
+      }
+      default: {
+        const last = this.getFullPathComponent(length - 1);
+        return (last === '')
+          ? this.getFullPathComponent(length - 2)
+          : last;
+      }
+    }
+  }
+
+  /**
    * @returns {object} Contents of this instance as a plain object with simple
    * data properties, suitable for logging. The result is slightly ambiguous in
    * the face of unusual input, because paths are rendered as slash-separated

--- a/src/webapp-builtins/export/SuffixRouter.js
+++ b/src/webapp-builtins/export/SuffixRouter.js
@@ -108,7 +108,7 @@ export class SuffixRouter extends BaseApplication {
     /**
      * Regular expression which matches the longest handled suffix of a given
      * file name. This ends up having a form along the lines of
-     * `/(?:(?:[.]bar)|(?:[.]baz)|(?:-bar[.]baz)|(?:))$/`.
+     * `/(?<!^)(?:(?:[.]bar)|(?:[.]baz)|(?:-bar[.]baz)|(?:))$/`.
      *
      * @type {RegExp}
      */
@@ -160,7 +160,7 @@ export class SuffixRouter extends BaseApplication {
       }
 
       this.#routeMap      = routeMap;
-      this.#suffixMatcher = new RegExp(`(?:${regexParts.join('|')})$`);
+      this.#suffixMatcher = new RegExp(`(?<!^)(?:${regexParts.join('|')})$`);
     }
 
     /**

--- a/src/webapp-builtins/export/SuffixRouter.js
+++ b/src/webapp-builtins/export/SuffixRouter.js
@@ -42,7 +42,7 @@ export class SuffixRouter extends BaseApplication {
       return null;
     }
 
-    const application = this.#routeMap(suffix);
+    const application = this.#routeMap.get(suffix);
 
     request.logger?.dispatchingSuffix({
       application: application.name,
@@ -73,7 +73,7 @@ export class SuffixRouter extends BaseApplication {
 
     for (const [suffix, name] of this.config.routeMap) {
       const app = appManager.get(name);
-      routeMap.add(suffix, app);
+      routeMap.set(suffix, app);
     }
 
     this.#routeMap = routeMap;
@@ -155,7 +155,7 @@ export class SuffixRouter extends BaseApplication {
         if (routeMap.has(text)) {
           throw new Error(`Duplicate suffix spec: ${suffix}`);
         }
-        routeMap.add(text, name);
+        routeMap.set(text, name);
         regexParts.push(regex);
       }
 

--- a/src/webapp-builtins/export/SuffixRouter.js
+++ b/src/webapp-builtins/export/SuffixRouter.js
@@ -1,0 +1,238 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { IntfRequestHandler } from '@this/net-util';
+import { MustBe } from '@this/typey';
+import { BaseApplication } from '@this/webapp-core';
+
+
+/**
+ * Application that routes requests based on the suffix of the file path, to one
+ * or more of a set of configured sub-apps. See docs for configuration object
+ * details.
+ */
+export class FileSuffixRouter extends BaseApplication {
+  /**
+   * Map which goes from a file name suffix (the actual suffix text, not the
+   * spec with `*` prefix) to the handler (typically a {@link BaseApplication})
+   * which should handle that suffix. Gets set in {@link #_impl_start}.
+   *
+   * @type {?Map<string, IntfRequestHandler>}
+   */
+  #routeMap = null;
+
+  // @defaultConstructor
+
+  /** @override */
+  async _impl_handleRequest(request, dispatch) {
+    if (dispatch.isDirectory()) {
+      if (!this.config.handleDirectories) {
+        return null;
+      }
+    } else {
+      if (!this.config.handleFiles) {
+        return null;
+      }
+    }
+
+    const name   = dispatch.lastName;
+    const suffix = name.match(this.config.suffixMatcher)?.[0] ?? null;
+
+    if (suffix === null) {
+      return null;
+    }
+
+    const application = this.#routeMap(suffix);
+
+    request.logger?.dispatchingSuffix({
+      application: application.name,
+      suffix
+    });
+
+    return application.handleRequest(request, dispatch);
+  }
+
+  /** @override */
+  async _impl_init() {
+    const routes = {};
+    for (const [suffix, name] of this.config.routeMap) {
+      routes[`*${suffix}`] = name;
+    }
+
+    this.logger?.routes(routes);
+  }
+
+  /** @override */
+  async _impl_start() {
+    // Note: We can't do this setup in `_impl_init()` because it might not be
+    // the case that all of the referenced apps have already been added when
+    // that runs.
+
+    const appManager = this.root.applicationManager;
+    const routeMap   = new Map();
+
+    for (const [suffix, name] of this.config.routeMap) {
+      const app = appManager.get(name);
+      routeMap.add(suffix, app);
+    }
+
+    this.#routeMap = routeMap;
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // @emptyBlock
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @override */
+  static _impl_configClass() {
+    return this.#Config;
+  }
+
+  /**
+   * Configuration item subclass for this (outer) class.
+   */
+  static #Config = class Config extends BaseApplication.Config {
+    /**
+     * Like the outer `routeMap` except with names instead of handler instances.
+     *
+     * @type {Map<string, string>}
+     */
+    #routeMap;
+
+    /**
+     * Regular expression which matches the longest handled suffix of a given
+     * file name. This ends up having a form along the lines of
+     * `/(?:(?:[.]bar)|(?:[.]baz)|(?:-bar[.]baz)|(?:))$/`.
+     *
+     * @type {RegExp}
+     */
+    #suffixMatcher;
+
+    /**
+     * Should directory paths get matched?
+     *
+     * @type {boolean}
+     */
+    #handleDirectories;
+
+    /**
+     * Should file paths (non-directories) get matched?
+     *
+     * @type {boolean}
+     */
+    #handleFiles;
+
+    /**
+     * Constructs an instance.
+     *
+     * @param {object} rawConfig Raw configuration object.
+     */
+    constructor(rawConfig) {
+      super(rawConfig);
+
+      const {
+        handleDirectories = false,
+        handleFiles       = true,
+        suffixes
+      } = rawConfig;
+
+      MustBe.plainObject(suffixes);
+
+      this.#handleDirectories = MustBe.boolean(handleDirectories);
+      this.#handleFiles       = MustBe.boolean(handleFiles);
+
+      const routeMap   = new Map();
+      const regexParts = [];
+
+      for (const [suffix, name] of Object.entries(suffixes)) {
+        const { text, regex } = Config.#parseSuffix(suffix);
+        if (routeMap.has(text)) {
+          throw new Error(`Duplicate suffix spec: ${suffix}`);
+        }
+        routeMap.add(text, name);
+        regexParts.push(regex);
+      }
+
+      this.#routeMap      = routeMap;
+      this.#suffixMatcher = new RegExp(`(?:${regexParts.join('|')})$`);
+    }
+
+    /**
+     * @returns {Map<string, string>} Like the outer `routeMap` except with
+     * names instead of handler instances.
+     */
+    get routeMap() {
+      return this.#routeMap;
+    }
+
+    /**
+     * @returns {RegExp} Regular expression which matches the longest handled
+     * suffix of a given file name.
+     */
+    get suffixMatcher() {
+      return this.#suffixMatcher;
+    }
+
+    /** @returns {boolean} Should directory paths get matched? */
+    get handleDirectories() {
+      return this.#handleDirectories;
+    }
+
+    /** @returns {boolean} Should file paths (non-directories) get matched? */
+    get handleFiles() {
+      return this.#handleFiles;
+    }
+
+    /**
+     * Parses a suffix specifier.
+     *
+     * @param {string} spec The suffix specifier to parse.
+     * @returns {{ text: string, regex: string }} The parsed form, including the
+     *   pure text and regex-matching fragment.
+     */
+    static #parseSuffix(spec) {
+      if (spec === '*') {
+        // This is easier than trying to shoehorn a match of just `*` into the
+        // `spec.match(...)` below.
+        return { text: '', regex: '(?:)' };
+      }
+
+      const text = spec.match(/(?<=^[*])[-._+][-._+A-Za-z0-9]+$/)?.[0] ?? null;
+
+      if (text === null) {
+        if (text === '') {
+          throw new Error('Suffix match specs cannot be empty; maybe you mean `*`?');
+        } else if (!text.startsWith('*')) {
+          throw new Error(`Not a valid suffix match spec (must start with \`*\`): ${spec}`);
+        } else {
+          throw new Error(`Not a valid suffix match spec: ${spec}`);
+        }
+      }
+
+      const chars = [];
+      for (const c of text) {
+        switch (c) {
+          case '.':
+          case '+': {
+            // Escape regex syntax characters.
+            chars.push(`[${c}]`);
+            break;
+          }
+          default: {
+            chars.push(c);
+          }
+        }
+      }
+
+      const regex = `(?:${chars.join('')})`;
+
+      return { text, regex };
+    }
+  };
+}

--- a/src/webapp-builtins/export/SuffixRouter.js
+++ b/src/webapp-builtins/export/SuffixRouter.js
@@ -11,7 +11,7 @@ import { BaseApplication } from '@this/webapp-core';
  * or more of a set of configured sub-apps. See docs for configuration object
  * details.
  */
-export class FileSuffixRouter extends BaseApplication {
+export class SuffixRouter extends BaseApplication {
   /**
    * Map which goes from a file name suffix (the actual suffix text, not the
    * spec with `*` prefix) to the handler (typically a {@link BaseApplication})

--- a/src/webapp-builtins/index.js
+++ b/src/webapp-builtins/index.js
@@ -15,4 +15,5 @@ export * from '#x/RequestFilter';
 export * from '#x/SerialRouter';
 export * from '#x/SimpleResponse';
 export * from '#x/StaticFiles';
+export * from '#x/SuffixRouter';
 export * from '#x/SyslogToFile';

--- a/src/webapp-builtins/package.json
+++ b/src/webapp-builtins/package.json
@@ -8,7 +8,8 @@
   "exports": "./index.js",
   "imports": {
     "#x/*": "./export/*.js",
-    "#p/*": "./private/*.js"
+    "#p/*": "./private/*.js",
+    "#test/*": "./tests/*.js"
   },
 
   "dependencies": {

--- a/src/webapp-builtins/tests/MockApp.js
+++ b/src/webapp-builtins/tests/MockApp.js
@@ -1,0 +1,65 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { BaseConfig } from '@this/compy';
+import { FullResponse, IntfRequestHandler } from '@this/net-util';
+import { BaseApplication } from '@this/webapp-core';
+
+
+/**
+ * @implements {IntfRequestHandler}
+ */
+export class MockApp extends BaseApplication {
+  static mockCalls = [];
+
+  // @defaultConstructor
+
+  /** @override */
+  async _impl_handleRequest(request, dispatch) {
+    let succeed = true;
+
+    const callInfo = { application: this, request, dispatch };
+    MockApp.mockCalls.push(callInfo);
+
+    if (this.mockHandler) {
+      const handlerResult = this.mockHandler(callInfo);
+      if (typeof handlerResult !== 'boolean') {
+        return handlerResult;
+      }
+      succeed = handlerResult;
+    }
+
+    if (succeed) {
+      const result = new FullResponse();
+      result.mockInfo = callInfo;
+      return result;
+    } else {
+      return null;
+    }
+  }
+
+  /** @override */
+  async _impl_init() {
+    // @emptyBlock
+  }
+
+  /** @override */
+  async _impl_start() {
+    // @emptyBlock
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // @emptyBlock
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @override */
+  static _impl_configClass() {
+    return BaseConfig;
+  }
+}

--- a/src/webapp-builtins/tests/NopComponent.js
+++ b/src/webapp-builtins/tests/NopComponent.js
@@ -1,0 +1,38 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { BaseAggregateComponent, BaseConfig } from '@this/compy';
+
+
+/**
+ * Minimal concrete component class, which has no-op implementations for all
+ * `_impl_*` methods.
+ */
+export class NopComponent extends BaseAggregateComponent {
+  // @defaultConstructor
+
+  /** @override */
+  async _impl_init() {
+    // @emptyBlock
+  }
+
+  /** @override */
+  async _impl_start() {
+    // @emptyBlock
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // @emptyBlock
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @override */
+  static _impl_configClass() {
+    return BaseConfig;
+  }
+}

--- a/src/webapp-builtins/tests/PathRouter.test.js
+++ b/src/webapp-builtins/tests/PathRouter.test.js
@@ -3,31 +3,13 @@
 
 import { TreePathKey } from '@this/collections';
 import { RootControlContext } from '@this/compy';
-import { DispatchInfo, HttpHeaders, IncomingRequest, RequestContext }
-  from '@this/net-util';
+import { DispatchInfo } from '@this/net-util';
 import { PathRouter } from '@this/webapp-builtins';
 
 import { MockApp } from '#test/MockApp';
 import { NopComponent } from '#test/NopComponent';
+import { RequestUtil } from '#test/RequestUtil';
 
-
-function makeRequest(path) {
-  return new IncomingRequest({
-    context: new RequestContext(
-      Object.freeze({ address: 'localhost', port: 12345 }),
-      Object.freeze({ address: 'awayhost',  port: 54321 })),
-    headers: new HttpHeaders({
-      'some-header': 'something'
-    }),
-    protocolName: 'http-2',
-    pseudoHeaders: new HttpHeaders({
-      authority: 'your.host',
-      method:    'get',
-      path,
-      scheme:    'https'
-    })
-  });
-}
 
 describe('constructor', () => {
   test('accepts some syntactically valid `paths`', () => {
@@ -171,7 +153,7 @@ describe('_impl_handleRequest()', () => {
         { appName: 'mockApp1', basePath: [],              extraPath: ['x', 'y', 'z'] }
       ]}
       `('calls correct handler chain for $label', async ({ requestPath, expectInfo }) => {
-        const request = makeRequest(requestPath);
+        const request = RequestUtil.makeGet(requestPath);
         const result  = await pr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
 
         // Fill in the `reqPathStr` for the expectation.
@@ -233,7 +215,7 @@ describe('_impl_handleRequest()', () => {
         { appName: 'mockApp2', basePath: ['x'],           extraPath: ['y', 'z'] }
       ]}
       `('calls correct handler chain for $label', async ({ requestPath, expectInfo }) => {
-        const request = makeRequest(requestPath);
+        const request = RequestUtil.makeGet(requestPath);
         const result  = await pr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
 
         // Fill in the `reqPathStr` for the expectation.
@@ -260,7 +242,7 @@ describe('_impl_handleRequest()', () => {
 
     MockApp.mockCalls = [];
 
-    const request = makeRequest('/x/y/z');
+    const request = RequestUtil.makeGet('/x/y/z');
     const result  = await pr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
 
     expect(result).not.toBeNull();
@@ -272,7 +254,7 @@ describe('_impl_handleRequest()', () => {
 
   test('matches on `dispatch.extra` (not `request.pathname`)', async () => {
     const pr      = await makeInstance({ '/florp/floop/*': 'mockApp1' });
-    const request = makeRequest('/x/y/z');
+    const request = RequestUtil.makeGet('/x/y/z');
     const result  = await pr.handleRequest(request,
       new DispatchInfo(TreePathKey.EMPTY, new TreePathKey(['florp', 'floop', 'bop'], false)));
 
@@ -287,7 +269,7 @@ describe('_impl_handleRequest()', () => {
 
   test('forms new `dispatch` by shifting items from `extra` to `base`', async () => {
     const pr      = await makeInstance({ '/zonk/*': 'mockApp1' });
-    const request = makeRequest('/x/y/z');
+    const request = RequestUtil.makeGet('/x/y/z');
     const result  = await pr.handleRequest(request,
       new DispatchInfo(
         new TreePathKey(['beep'], false),

--- a/src/webapp-builtins/tests/PathRouter.test.js
+++ b/src/webapp-builtins/tests/PathRouter.test.js
@@ -2,69 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TreePathKey } from '@this/collections';
-import { BaseConfig, RootControlContext } from '@this/compy';
-import { DispatchInfo, FullResponse, HttpHeaders, IncomingRequest,
-  IntfRequestHandler, RequestContext }
+import { RootControlContext } from '@this/compy';
+import { DispatchInfo, HttpHeaders, IncomingRequest, RequestContext }
   from '@this/net-util';
 import { PathRouter } from '@this/webapp-builtins';
-import { BaseApplication } from '@this/webapp-core';
 
+import { MockApp } from '#test/MockApp';
 import { NopComponent } from '#test/NopComponent';
 
-// TODO: This file contains a lot of mock implementation that should be
-// extracted for reuse.
-
-/**
- * @implements {IntfRequestHandler}
- */
-class MockApp extends BaseApplication {
-  static mockCalls = [];
-
-  // @defaultConstructor
-
-  /** @override */
-  async _impl_handleRequest(request, dispatch) {
-    let succeed = true;
-
-    const callInfo = { application: this, request, dispatch };
-    MockApp.mockCalls.push(callInfo);
-
-    if (this.mockHandler) {
-      const handlerResult = this.mockHandler(callInfo);
-      if (typeof handlerResult !== 'boolean') {
-        return handlerResult;
-      }
-      succeed = handlerResult;
-    }
-
-    if (succeed) {
-      const result = new FullResponse();
-      result.mockInfo = callInfo;
-      return result;
-    } else {
-      return null;
-    }
-  }
-
-  /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
-  static _impl_configClass() {
-    return BaseConfig;
-  }
-}
 
 function makeRequest(path) {
   return new IncomingRequest({

--- a/src/webapp-builtins/tests/PathRouter.test.js
+++ b/src/webapp-builtins/tests/PathRouter.test.js
@@ -49,7 +49,7 @@ describe('constructor', () => {
   `('throws given path `$path`', ({ path }) => {
     const paths = {
       '/a': 'a',
-      ...path,
+      ...{ path },
       '/z': 'z'
     };
     expect(() => new PathRouter({ name: 'x', paths })).toThrow();

--- a/src/webapp-builtins/tests/PathRouter.test.js
+++ b/src/webapp-builtins/tests/PathRouter.test.js
@@ -2,44 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { TreePathKey } from '@this/collections';
-import { BaseAggregateComponent, BaseConfig, RootControlContext }
-  from '@this/compy';
+import { BaseConfig, RootControlContext } from '@this/compy';
 import { DispatchInfo, FullResponse, HttpHeaders, IncomingRequest,
   IntfRequestHandler, RequestContext }
   from '@this/net-util';
 import { PathRouter } from '@this/webapp-builtins';
 import { BaseApplication } from '@this/webapp-core';
 
+import { NopComponent } from '#test/NopComponent';
 
 // TODO: This file contains a lot of mock implementation that should be
 // extracted for reuse.
-
-/**
- * Minimal concrete component class, which has no-op implementations for all
- * `_impl_*` methods.
- */
-export class NopComponent extends BaseAggregateComponent {
-  // @defaultConstructor
-
-  /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
-  static _impl_configClass() {
-    return BaseConfig;
-  }
-}
 
 /**
  * @implements {IntfRequestHandler}

--- a/src/webapp-builtins/tests/RequestFilter.test.js
+++ b/src/webapp-builtins/tests/RequestFilter.test.js
@@ -8,26 +8,8 @@ import { DispatchInfo, HttpHeaders, IncomingRequest, RequestContext,
   from '@this/net-util';
 import { RequestFilter } from '@this/webapp-builtins';
 
+import { RequestUtil } from '#test/RequestUtil';
 
-// TODO: Extract this function, which also has a variant in
-// `PathRouter.test.js`.
-function makeRequest(method, path) {
-  return new IncomingRequest({
-    context: new RequestContext(
-      Object.freeze({ address: 'localhost', port: 12345 }),
-      Object.freeze({ address: 'awayhost',  port: 54321 })),
-    headers: new HttpHeaders({
-      'some-header': 'something'
-    }),
-    protocolName: 'http-2',
-    pseudoHeaders: new HttpHeaders({
-      authority: 'your.host',
-      method,
-      path,
-      scheme:    'https'
-    })
-  });
-}
 
 describe('constructor', () => {
   test('accepts an omnibus valid set of options', () => {
@@ -96,7 +78,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 599
       });
 
-      const req    = makeRequest('get', '/florp');
+      const req    = RequestUtil.makeRequest('post', '/florp');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
@@ -109,7 +91,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 599
       });
 
-      const req    = makeRequest('get', '/florp');
+      const req    = RequestUtil.makeGet('/florp');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
@@ -125,7 +107,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 599
       });
 
-      const req    = makeRequest('get', '/florp/flop');
+      const req    = RequestUtil.makeGet('/florp/flop');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
@@ -138,7 +120,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 599
       });
 
-      const req    = makeRequest('get', '/florp/flop/');
+      const req    = RequestUtil.makeGet('/florp/flop/');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
@@ -151,7 +133,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 501
       });
 
-      const req    = makeRequest('get', '/florp/flop/oopsie');
+      const req    = RequestUtil.makeGet('/florp/flop/oopsie');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
@@ -165,7 +147,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 501
       });
 
-      const req    = makeRequest('get', '/florp/flop/oopsie/');
+      const req    = RequestUtil.makeGet('/florp/flop/oopsie/');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
@@ -181,7 +163,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 400
       });
 
-      const req    = makeRequest('get', '/23456/8901/34/67890');
+      const req    = RequestUtil.makeGet('/23456/8901/34/67890');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
@@ -194,7 +176,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 400
       });
 
-      const req    = makeRequest('get', '/23456/8901/34/6789/');
+      const req    = RequestUtil.makeGet('/23456/8901/34/6789/');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
@@ -207,7 +189,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 400
       });
 
-      const req    = makeRequest('get', '/23456/8901/34/678901');
+      const req    = RequestUtil.makeGet('/23456/8901/34/678901');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
@@ -221,7 +203,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 400
       });
 
-      const req    = makeRequest('get', '/23456/8901/34/67890/');
+      const req    = RequestUtil.makeGet('/23456/8901/34/67890/');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
@@ -237,7 +219,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 420
       });
 
-      const req    = makeRequest('get', '/beep/boop/bop/biff?abcd=ef');
+      const req    = RequestUtil.makeGet('/beep/boop/bop/biff?abcd=ef');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
@@ -250,7 +232,7 @@ describe('_impl_handleRequest()', () => {
         filterResponseStatus: 420
       });
 
-      const req    = makeRequest('get', '/beep/boop/bop/biff?abcd=efg');
+      const req    = RequestUtil.makeGet('/beep/boop/bop/biff?abcd=efg');
       const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 

--- a/src/webapp-builtins/tests/RequestFilter.test.js
+++ b/src/webapp-builtins/tests/RequestFilter.test.js
@@ -3,9 +3,7 @@
 
 import { TreePathKey } from '@this/collections';
 import { RootControlContext } from '@this/compy';
-import { DispatchInfo, HttpHeaders, IncomingRequest, RequestContext,
-  StatusResponse }
-  from '@this/net-util';
+import { DispatchInfo, StatusResponse } from '@this/net-util';
 import { RequestFilter } from '@this/webapp-builtins';
 
 import { RequestUtil } from '#test/RequestUtil';

--- a/src/webapp-builtins/tests/RequestUtil.js
+++ b/src/webapp-builtins/tests/RequestUtil.js
@@ -1,0 +1,35 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { HttpHeaders, IncomingRequest, RequestContext } from '@this/net-util';
+
+
+/**
+ * Utility class to construct {@link IncomingRequest} instances suitable for use
+ * when testing the classes in this module.
+ */
+export class RequestUtil {
+  /**
+   * Makes a `GET` request with the given path.
+   *
+   * @param {string} path The path.
+   * @returns {IncomingRequest} Corresponding request instance.
+   */
+  static makeGet(path) {
+    return new IncomingRequest({
+      context: new RequestContext(
+        Object.freeze({ address: 'localhost', port: 12345 }),
+        Object.freeze({ address: 'awayhost',  port: 54321 })),
+      headers: new HttpHeaders({
+        'some-header': 'something'
+      }),
+      protocolName: 'http-2',
+      pseudoHeaders: new HttpHeaders({
+        authority: 'your.host',
+        method:    'get',
+        path,
+        scheme:    'https'
+      })
+    });
+  }
+}

--- a/src/webapp-builtins/tests/RequestUtil.js
+++ b/src/webapp-builtins/tests/RequestUtil.js
@@ -32,4 +32,29 @@ export class RequestUtil {
       })
     });
   }
+
+  /**
+   * Makes a request with the given request method and path.
+   *
+   * @param {string} method The request method.
+   * @param {string} path The path.
+   * @returns {IncomingRequest} Corresponding request instance.
+   */
+  static makeRequest(method, path) {
+    return new IncomingRequest({
+      context: new RequestContext(
+        Object.freeze({ address: 'localhost', port: 12345 }),
+        Object.freeze({ address: 'awayhost',  port: 54321 })),
+      headers: new HttpHeaders({
+        'some-header': 'something'
+      }),
+      protocolName: 'http-2',
+      pseudoHeaders: new HttpHeaders({
+        authority: 'your.host',
+        method,
+        path,
+        scheme:    'https'
+      })
+    });
+  }
 }

--- a/src/webapp-builtins/tests/RequestUtil.js
+++ b/src/webapp-builtins/tests/RequestUtil.js
@@ -16,21 +16,7 @@ export class RequestUtil {
    * @returns {IncomingRequest} Corresponding request instance.
    */
   static makeGet(path) {
-    return new IncomingRequest({
-      context: new RequestContext(
-        Object.freeze({ address: 'localhost', port: 12345 }),
-        Object.freeze({ address: 'awayhost',  port: 54321 })),
-      headers: new HttpHeaders({
-        'some-header': 'something'
-      }),
-      protocolName: 'http-2',
-      pseudoHeaders: new HttpHeaders({
-        authority: 'your.host',
-        method:    'get',
-        path,
-        scheme:    'https'
-      })
-    });
+    return this.makeRequest('get', path);
   }
 
   /**

--- a/src/webapp-builtins/tests/SuffixRouter.test.js
+++ b/src/webapp-builtins/tests/SuffixRouter.test.js
@@ -1,0 +1,189 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { TreePathKey } from '@this/collections';
+import { RootControlContext } from '@this/compy';
+import { DispatchInfo, FullResponse } from '@this/net-util';
+import { SuffixRouter } from '@this/webapp-builtins';
+
+import { MockApp } from '#test/MockApp';
+import { NopComponent } from '#test/NopComponent';
+import { RequestUtil } from '#test/RequestUtil';
+
+
+describe('constructor', () => {
+  test('accepts some syntactically valid `suffixes`', () => {
+    const suffixes = {
+      '*':         'a',
+      '*.w':       'b',
+      '*-x':       'c',
+      '*_y':       'd',
+      '*+z':       'e',
+      '*.x.y':     'f',
+      '*.foo-bar': 'g',
+      '*._bonk':   'h'
+    };
+    expect(() => new SuffixRouter({ name: 'x', suffixes })).not.toThrow();
+  });
+
+  test.each`
+  suffix
+  ${''}        // Can't be totally empty.
+  ${'.xyz'}    // Must start with a star.
+  ${'x.*'}
+  ${'y.*.z'}
+  ${'*X'}      // Cannot use alphanumeric immediately after star.
+  ${'*x'}
+  ${'*0'}
+  ${'*x'}
+  ${'*.x.*.y'} // No extra stars.
+  ${'*-a$b'}   // Just alphanumerics and the couple special chars in the suffix.
+  ${'*.a:b'}
+  ${'*.a@b'}
+  ${'*.a%12b'}
+  ${'*.a\u{1234}b'}
+  `('throws given suffix spec `$suffix`', ({ suffix }) => {
+    const suffixes = {
+      '*.beep': 'a',
+      ...{ suffix },
+      '*.boop': 'z'
+    };
+    expect(() => new SuffixRouter({ name: 'x', suffixes })).toThrow();
+  });
+});
+
+describe('_impl_handleRequest()', () => {
+  async function makeInstance(opts, { appCount = 1, handlerFunc = null } = {}) {
+    const root = new NopComponent({ name: 'root' }, new RootControlContext(null));
+    await root.start();
+
+    root.applicationManager = {
+      get(name) {
+        return root.context.getComponent(['application', name]);
+      }
+    };
+
+    const apps = new NopComponent({ name: 'application' });
+    await root.addChildren(apps);
+
+    for (let i = 1; i <= appCount; i++) {
+      const app = new MockApp({ name: `mockApp${i}` });
+      if (handlerFunc) {
+        app.mockHandler = handlerFunc;
+      }
+      await apps.addChildren(app);
+    }
+
+    const sr = new SuffixRouter({ name: 'myRouter', ...opts });
+
+    await apps.addChildren(sr);
+
+    return sr;
+  }
+
+  beforeEach(() => {
+    MockApp.mockCalls = [];
+  });
+
+  test('handles regular file (non-directory) paths by default', async () => {
+    const sr = await makeInstance({ suffixes: {} });
+
+    expect(sr.config.handleFiles).toBeTrue();
+  });
+
+  test('does not handle directory paths by default', async () => {
+    const sr = await makeInstance({ suffixes: {} });
+
+    expect(sr.config.handleDirectories).toBeFalse();
+  });
+
+  test('handles regular file (non-directory) paths when so configured', async () => {
+    const sr = await makeInstance({
+      handleDirectories: false,
+      handleFiles:       true,
+      suffixes: {
+        '*.beep': 'mockApp1'
+      }
+    });
+
+    const request1 = RequestUtil.makeGet('/boop.beep');
+    const result1  = await sr.handleRequest(request1, new DispatchInfo(TreePathKey.EMPTY, request1.pathname));
+    expect(result1).toBeInstanceOf(FullResponse);
+
+    const request2 = RequestUtil.makeGet('/zonk/florp.beep');
+    const result2  = await sr.handleRequest(request2, new DispatchInfo(TreePathKey.EMPTY, request2.pathname));
+    expect(result2).toBeInstanceOf(FullResponse);
+  });
+
+  test('handles directory paths when so configured', async () => {
+    const sr = await makeInstance({
+      handleDirectories: true,
+      handleFiles:       false,
+      suffixes: {
+        '*.beep': 'mockApp1'
+      }
+    });
+
+    const request1 = RequestUtil.makeGet('/boop.beep/');
+    const result1  = await sr.handleRequest(request1, new DispatchInfo(TreePathKey.EMPTY, request1.pathname));
+    expect(result1).toBeInstanceOf(FullResponse);
+
+    const request2 = RequestUtil.makeGet('/zonk/florp.beep/');
+    const result2  = await sr.handleRequest(request2, new DispatchInfo(TreePathKey.EMPTY, request2.pathname));
+    expect(result2).toBeInstanceOf(FullResponse);
+  });
+
+  test('handles both directories and files when so configured', async () => {
+    const sr = await makeInstance({
+      handleDirectories: true,
+      handleFiles:       true,
+      suffixes: {
+        '*.xyz': 'mockApp1'
+      }
+    });
+
+    const request1 = RequestUtil.makeGet('/abc.xyz');
+    const result1  = await sr.handleRequest(request1, new DispatchInfo(TreePathKey.EMPTY, request1.pathname));
+    expect(result1).toBeInstanceOf(FullResponse);
+
+    const request2 = RequestUtil.makeGet('/zonk/pdq.xyz/');
+    const result2  = await sr.handleRequest(request2, new DispatchInfo(TreePathKey.EMPTY, request2.pathname));
+    expect(result2).toBeInstanceOf(FullResponse);
+  });
+
+  test('does not handle files when so configured', async () => {
+    const sr = await makeInstance({
+      handleDirectories: true,
+      handleFiles:       false,
+      suffixes: {
+        '*.oof': 'mockApp1'
+      }
+    });
+
+    const request1 = RequestUtil.makeGet('/boop.oof');
+    const result1  = await sr.handleRequest(request1, new DispatchInfo(TreePathKey.EMPTY, request1.pathname));
+    expect(result1).toBeNull();
+
+    const request2 = RequestUtil.makeGet('/zonk/florp.oof');
+    const result2  = await sr.handleRequest(request2, new DispatchInfo(TreePathKey.EMPTY, request2.pathname));
+    expect(result2).toBeNull();
+  });
+
+  test('does not handle directories when so configured', async () => {
+    const sr = await makeInstance({
+      handleDirectories: false,
+      handleFiles:       true,
+      suffixes: {
+        '*.oof': 'mockApp1'
+      }
+    });
+
+    const request1 = RequestUtil.makeGet('/boop.oof/');
+    const result1  = await sr.handleRequest(request1, new DispatchInfo(TreePathKey.EMPTY, request1.pathname));
+    expect(result1).toBeNull();
+
+    const request2 = RequestUtil.makeGet('/zonk/florp.oof/');
+    const result2  = await sr.handleRequest(request2, new DispatchInfo(TreePathKey.EMPTY, request2.pathname));
+    expect(result2).toBeNull();
+  });
+});

--- a/src/webapp-builtins/tests/SuffixRouter.test.js
+++ b/src/webapp-builtins/tests/SuffixRouter.test.js
@@ -93,6 +93,17 @@ describe('_impl_handleRequest()', () => {
     expect(calls[0].application.name).toBe(appName);
   }
 
+  async function expectNull(sr, path) {
+    MockApp.mockCalls = [];
+
+    const request = RequestUtil.makeGet(path);
+    const result  = await sr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
+    expect(result).toBeNull();
+
+    const calls = MockApp.mockCalls;
+    expect(calls.length).toBe(0);
+  }
+
   beforeEach(() => {
     MockApp.mockCalls = [];
   });
@@ -159,13 +170,8 @@ describe('_impl_handleRequest()', () => {
       }
     });
 
-    const request1 = RequestUtil.makeGet('/boop.oof');
-    const result1  = await sr.handleRequest(request1, new DispatchInfo(TreePathKey.EMPTY, request1.pathname));
-    expect(result1).toBeNull();
-
-    const request2 = RequestUtil.makeGet('/zonk/florp.oof');
-    const result2  = await sr.handleRequest(request2, new DispatchInfo(TreePathKey.EMPTY, request2.pathname));
-    expect(result2).toBeNull();
+    await expectNull(sr, '/boop.oof');
+    await expectNull(sr, '/zonk/florp.oof');
   });
 
   test('does not handle directories when so configured', async () => {
@@ -177,13 +183,8 @@ describe('_impl_handleRequest()', () => {
       }
     });
 
-    const request1 = RequestUtil.makeGet('/boop.oof/');
-    const result1  = await sr.handleRequest(request1, new DispatchInfo(TreePathKey.EMPTY, request1.pathname));
-    expect(result1).toBeNull();
-
-    const request2 = RequestUtil.makeGet('/zonk/florp.oof/');
-    const result2  = await sr.handleRequest(request2, new DispatchInfo(TreePathKey.EMPTY, request2.pathname));
-    expect(result2).toBeNull();
+    await expectNull(sr, '/boop.oof/');
+    await expectNull(sr, '/zonk/florp.oof/');
   });
 
   test('routes to the full-wildcard when no other suffix matches', async () => {
@@ -200,6 +201,7 @@ describe('_impl_handleRequest()', () => {
     await expectApp(sr, '/zonk',       'mockApp1');
     await expectApp(sr, '/a/b/c/zonk', 'mockApp1');
     await expectApp(sr, '/.bleep',     'mockApp1');
+    await expectApp(sr, '/bleepy',     'mockApp1');
   });
 
   test('returns `null` when no suffix matches and there is no full-wildcard', async () => {
@@ -211,9 +213,8 @@ describe('_impl_handleRequest()', () => {
       }
     });
 
-    const request = RequestUtil.makeGet('/boop.bop');
-    const result  = await sr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
-    expect(result).toBeNull();
+    await expectNull(sr, '/boop.bop');
+    await expectNull(sr, '/floop/flop');
   });
 
   test('routes to the longest matching suffix when more than one matches', async () => {

--- a/src/webapp-builtins/tests/SuffixRouter.test.js
+++ b/src/webapp-builtins/tests/SuffixRouter.test.js
@@ -250,4 +250,18 @@ describe('_impl_handleRequest()', () => {
     await expectApp(sr, '/zyx/zip_florp4',   'mockApp4');
     await expectApp(sr, '/ab/cd/ef/gh+num5', 'mockApp5');
   });
+
+  test('does not treat a just-a-suffix file name (no prefix) as a match', async () => {
+    const sr = await makeInstance({
+      handleFiles: true,
+      suffixes: {
+        '*.zorch': 'mockApp1'
+      }
+    });
+
+    await expectNull(sr, '/.zorch');
+    await expectNull(sr, '/x/.zorch');
+    await expectNull(sr, '/bip/bop/.zorch');
+    await expectNull(sr, '/flip/flop/floop/.zorch');
+  });
 });

--- a/src/webapp-builtins/tests/SuffixRouter.test.js
+++ b/src/webapp-builtins/tests/SuffixRouter.test.js
@@ -277,7 +277,7 @@ describe('_impl_handleRequest()', () => {
         '*':       'mockApp1',
         '*.z':     'mockApp2',
         '*.y.z':   'mockApp3',
-        '*.x.y.z': 'mockApp4',
+        '*.x.y.z': 'mockApp4'
       }
     }, { appCount: 4, handlerFunc });
 


### PR DESCRIPTION
This PR adds a new app, `SuffixRouter`, which (hopefully unsurprisingly) routes based on requests' directory/file name suffix, e.g. route all `.jpg` files or what-have-you.