### PR TITLE
New app `RequestDelay`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Other notable changes:
 * `data-values`:
   * Added comparison methods to `UnitQuantity`.
 * `webapp-builtins`:
+  * New application `RequestDelay`.
   * New application `SuffixRouter`.
 
 **Note:** v0.7.0 wasn't announced widely, because it was a "rebrand" of v0.6.16.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Breaking changes:
 * None.
 
 Other notable changes:
+* `clocks`:
+  * Added `waitFor()` to the interface `IntfTimeSource`.
+  * Extracted `MockTimeSource` from `TokenBucket.test.js`, for use throughout
+    the system.
+* `data-values`:
+  * Added comparison methods to `UnitQuantity`.
 * `webapp-builtins`:
   * New application `SuffixRouter`.
 

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -192,6 +192,35 @@ const applications = [
 ];
 ```
 
+## `RequestDelay`
+
+An application which simply causes a time delay. It never handles requests, but
+when asked to handle one, it delays before answering that it won't handle it.
+This is useful to place in the route list for a [`SerialRouter`](#serialrouter).
+
+* `delay` &mdash; The amount of time to delay every response, specified
+  as a duration value as described in
+  [Durations](./2-common-configuration.md#durations), or `null` if `minDelay`
+  and `maxDelay` will instead be specified.
+* `minDelay`, `maxDelay` &mdash; The minimum and maximum amount of time to delay
+  a response, inclusive on both ends, specified as duration values as described
+  in [Durations](./2-common-configuration.md#durations), or `null` if `delay` is
+  instead being specified. When used, the actual delay time of any given request
+  is picked randomly, quantized to milliseconds.
+* `timeSource` &mdash; An optional time source object. This is mainly useful for
+  testing.
+
+```js
+import { RequestDelay } from '@lactoserv/webapp-builtins';
+
+const applications = [
+  {
+    name:  'myDelay',
+    class: RequestDelay,
+    delay: '250 msec'
+];
+```
+
 ## `RequestFilter`
 
 An application which filters requests that match particular criteria, either by

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -5,8 +5,8 @@ import * as fs from 'node:fs/promises';
 
 import { AccessLogToFile, AccessLogToSyslog, EventFan, HostRouter,
   MemoryMonitor, PathRouter, ProcessIdFile, ProcessInfoFile, RateLimiter,
-  Redirector, RequestFilter, SerialRouter, SimpleResponse, StaticFiles,
-  SyslogToFile }
+  Redirector, RequestDelay, RequestFilter, SerialRouter, SimpleResponse,
+  StaticFiles, SuffixRouter, SyslogToFile }
   from '@lactoserv/webapp-builtins';
 
 
@@ -172,9 +172,23 @@ const applications = [
     maxQueryLength: 0
   },
   {
+    name: 'slowPoke',
+    class: RequestDelay,
+    minDelay: '0.5 sec',
+    maxDelay: '1 sec'
+  },
+  {
+    name: 'bonkers',
+    class: SuffixRouter,
+    suffixes: {
+      '*.bonk': 'slowPoke'
+    }
+  },
+  {
     name:  'mySeries',
     class: SerialRouter,
     applications: [
+      'bonkers',
       'myFilter',
       'myStaticFunNo404',
       'responseNotFound'

--- a/src/async/export/TokenBucket.js
+++ b/src/async/export/TokenBucket.js
@@ -156,7 +156,7 @@ export class TokenBucket {
       maxQueueGrantSize = null,
       maxQueueSize      = null,
       partialTokens     = false,
-      timeSource        = TokenBucket.#DEFAULT_TIME_SOURCE
+      timeSource        = StdTimeSource.INSTANCE
     } = options;
 
     this.#flowRate = MustBe.instanceOf(flowRate, Frequency);
@@ -199,7 +199,7 @@ export class TokenBucket {
       ? null
       : this.#maxQueueSize;
 
-    const timeSource = (this.#timeSource === TokenBucket.#DEFAULT_TIME_SOURCE)
+    const timeSource = (this.#timeSource === StdTimeSource.INSTANCE)
       ? null
       : this.#timeSource;
 
@@ -627,16 +627,4 @@ export class TokenBucket {
       await this.#timeSource.waitUntil(time);
     }
   }
-
-
-  //
-  // Static members
-  //
-
-  /**
-   * Default time source.
-   *
-   * @type {StdTimeSource}
-   */
-  static #DEFAULT_TIME_SOURCE = StdTimeSource.INSTANCE;
 }

--- a/src/clocks/export/IntfTimeSource.js
+++ b/src/clocks/export/IntfTimeSource.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { Moment } from '@this/data-values';
+import { Duration, Moment } from '@this/data-values';
 import { Methods } from '@this/typey';
 
 
@@ -21,6 +21,24 @@ export class IntfTimeSource {
    */
   now() {
     return Methods.abstract();
+  }
+
+  /**
+   * Async-returns `null` after a specified amount of time, with the hope that
+   * the actual time waited will be reasonably close to the request.
+   *
+   * **Note:** This is meant to be a time-source-specific replacement for the
+   * various versions and bindings of `setTimeout()` provided by Node.
+   *
+   * @param {Duration} dur How much time to wait before this method is to
+   *   async-return. If zero or negative, this method simply does not wait
+   *   before returning.
+   * @param {object} [options] Timeout options. This is the same as with
+   *   `node:timers/promises.setTimeout()`.
+   * @returns {null} `null`, always.
+   */
+  static async waitFor(dur, options = undefined) {
+    return Methods.abstract(dur, options);
   }
 
   /**

--- a/src/clocks/export/MockTimeSource.js
+++ b/src/clocks/export/MockTimeSource.js
@@ -57,6 +57,15 @@ export class MockTimeSource extends IntfTimeSource {
   }
 
   /** @override */
+  async waitFor(dur, opts = undefined) {
+    if (opts !== undefined) {
+      throw new Error('Options not supported. Sorry!');
+    }
+
+    return this.waitUntil(this.#now.add(dur));
+  }
+
+  /** @override */
   async waitUntil(time) {
     if (this.#ended) {
       throw new Error(`MockTimeSource ended! (Time was ${this.#now.atSec}.)`);

--- a/src/clocks/export/MockTimeSource.js
+++ b/src/clocks/export/MockTimeSource.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ManualPromise } from '@this/async';
-import { Moment } from '@this/data-values';
+import { Duration, Moment } from '@this/data-values';
 
 import { IntfTimeSource } from '#x/IntfTimeSource';
 
@@ -35,6 +35,13 @@ export class MockTimeSource extends IntfTimeSource {
   #ended = false;
 
   /**
+   * Result for {@link #_lastWaitFor}.
+   *
+   * @type {?Duration}
+   */
+  #lastWaitFor = null;
+
+  /**
    * Constructs an instance.
    *
    * @param {number|Moment} firstNow Initial seconds-value for {@link #now}.
@@ -61,6 +68,8 @@ export class MockTimeSource extends IntfTimeSource {
     if (opts !== undefined) {
       throw new Error('Options not supported. Sorry!');
     }
+
+    this.#lastWaitFor = dur;
 
     return this.waitUntil(this.#now.add(dur));
   }
@@ -94,6 +103,15 @@ export class MockTimeSource extends IntfTimeSource {
     }
 
     this.#ended = true;
+  }
+
+  /**
+   * Mock control: Returns the most recent duration value passed to `waitFor()`.
+   *
+   * @returns {Duration} The duration.
+   */
+  _lastWaitFor() {
+    return this.#lastWaitFor;
   }
 
   /**

--- a/src/clocks/export/MockTimeSource.js
+++ b/src/clocks/export/MockTimeSource.js
@@ -1,0 +1,120 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { ManualPromise } from '@this/async';
+import { Moment } from '@this/data-values';
+
+import { IntfTimeSource } from '#x/IntfTimeSource';
+
+
+/**
+ * Mock implementation of `IntfTimeSource`, for help with testing.
+ *
+ * @implements {IntfTimeSource}
+ */
+export class MockTimeSource extends IntfTimeSource {
+  /**
+   * Current time.
+   *
+   * @type {Moment}
+   */
+  #now;
+
+  /**
+   * Array of pendning timeouts.
+   *
+   * @type {Array<{ atSec: number, resolve: function() }>}
+   */
+  #timeouts = [];
+
+  /**
+   * Has this instance been "ended?"
+   *
+   * @type {boolean}
+   */
+  #ended = false;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {number|Moment} firstNow Initial seconds-value for {@link #now}.
+   */
+  constructor(firstNow = 0) {
+    super();
+
+    this.#now = (firstNow instanceof Moment)
+      ? firstNow
+      : new Moment(firstNow);
+  }
+
+  /** @override */
+  now() {
+    if (this.#ended) {
+      throw new Error(`MockTimeSource ended! (Time was ${this.#now.atSec}.)`);
+    }
+
+    return this.#now;
+  }
+
+  /** @override */
+  async waitUntil(time) {
+    if (this.#ended) {
+      throw new Error(`MockTimeSource ended! (Time was ${this.#now.atSec}.)`);
+    }
+
+    if (time.atSec <= this.#now.atSec) {
+      return;
+    }
+
+    const mp = new ManualPromise();
+    this.#timeouts.push({
+      atSec:   time.atSec,
+      resolve: () => mp.resolve()
+    });
+
+    await mp.promise;
+  }
+
+  /**
+   * Mock control: "Ends" the instance. This resolves any pending `wait()`s and
+   * prevents new ones from being added.
+   */
+  _end() {
+    for (const t of this.#timeouts) {
+      t.resolve();
+    }
+
+    this.#ended = true;
+  }
+
+  /**
+   * Mock control: Sets the current time. This can cause pending `wait()`s to
+   * resolve.
+   *
+   * @param {number|Moment} newNow New seconds-value for {@link #now}.
+   */
+  _setTime(newNow) {
+    if (!(newNow instanceof Moment)) {
+      newNow = new Moment(newNow);
+    }
+
+    if (newNow.isBefore(this.#now)) {
+      throw new Error('Cannot run time in reverse!');
+    }
+
+    this.#now = newNow;
+
+    this.#timeouts.sort((a, b) => {
+      if (a.atSec < b.atSec) return -1;
+      if (a.atSec > b.atSec) return 1;
+      return 0;
+    });
+
+    const nowSec = newNow.atSec;
+
+    while (this.#timeouts[0]?.atSec <= nowSec) {
+      this.#timeouts[0].resolve();
+      this.#timeouts.shift();
+    }
+  }
+}

--- a/src/clocks/export/MockTimeSource.js
+++ b/src/clocks/export/MockTimeSource.js
@@ -21,7 +21,7 @@ export class MockTimeSource extends IntfTimeSource {
   #now;
 
   /**
-   * Array of pendning timeouts.
+   * Array of pending timeouts.
    *
    * @type {Array<{ atSec: number, resolve: function() }>}
    */

--- a/src/clocks/export/StdTimeSource.js
+++ b/src/clocks/export/StdTimeSource.js
@@ -18,6 +18,11 @@ export class StdTimeSource extends IntfTimeSource {
   }
 
   /** @override */
+  async waitFor(dur, options = undefined) {
+    return WallClock.waitFor(dur, options);
+  }
+
+  /** @override */
   async waitUntil(time) {
     return WallClock.waitUntil(time);
   }

--- a/src/clocks/index.js
+++ b/src/clocks/index.js
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '#x/IntfTimeSource';
+export * from '#x/MockTimeSource';
 export * from '#x/StdTimeSource';
 export * from '#x/WallClock';

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -158,6 +158,36 @@ export class UnitQuantity {
   }
 
   /**
+   * Shorthand for `.compare(other) == 0`.
+   *
+   * @param {UnitQuantity} other Instance to compare to.
+   * @returns {boolean} `true` iff `other == this`.
+   */
+  eq(other) {
+    return this.compare(other) === 0;
+  }
+
+  /**
+   * Shorthand for `.compare(other) >= 0`.
+   *
+   * @param {UnitQuantity} other Instance to compare to.
+   * @returns {boolean} `true` iff `other >= this`.
+   */
+  ge(other) {
+    return this.compare(other) >= 0;
+  }
+
+  /**
+   * Shorthand for `.compare(other) > 0`.
+   *
+   * @param {UnitQuantity} other Instance to compare to.
+   * @returns {boolean} `true` iff `other > this`.
+   */
+  gt(other) {
+    return this.compare(other) > 0;
+  }
+
+  /**
    * Returns the inverse of this instance, that is, `1 / value`, with numerator
    * and denominator swapped.
    *
@@ -167,6 +197,36 @@ export class UnitQuantity {
     const resultClass = this[INVERSE_SYMBOL];
 
     return new resultClass(1 / this.#value, this.#denominatorUnit, this.#numeratorUnit);
+  }
+
+  /**
+   * Shorthand for `.compare(other) <= 0`.
+   *
+   * @param {UnitQuantity} other Instance to compare to.
+   * @returns {boolean} `true` iff `other <= this`.
+   */
+  le(other) {
+    return this.compare(other) <= 0;
+  }
+
+  /**
+   * Shorthand for `.compare(other) < 0`.
+   *
+   * @param {UnitQuantity} other Instance to compare to.
+   * @returns {boolean} `true` iff `other < this`.
+   */
+  lt(other) {
+    return this.compare(other) < 0;
+  }
+
+  /**
+   * Shorthand for `.compare(other) != 0`.
+   *
+   * @param {UnitQuantity} other Instance to compare to.
+   * @returns {boolean} `true` iff `other != this`.
+   */
+  ne(other) {
+    return this.compare(other) !== 0;
   }
 
   /**

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -126,17 +126,35 @@ export class UnitQuantity {
    * @returns {UnitQuantity} Summed result.
    */
   add(other) {
-    MustBe.instanceOf(other, UnitQuantity);
-
-    if (   (other.#numeratorUnit !== this.#numeratorUnit)
-        || (other.#denominatorUnit !== this.#denominatorUnit)) {
-      throw new Error('Mismatched units.');
-    }
+    this.#checkCompatibility(other);
 
     return new this.constructor(
       this.#value + other.#value,
       this.#numeratorUnit,
       this.#denominatorUnit);
+  }
+
+  /**
+   * Compares the value of this instance to another, returning the usual values
+   * `-1`, `0`, or `1` depending on the result of comparison. The other instance
+   * must have the same units as this one.
+   *
+   * @param {UnitQuantity} other Instance to compare to.
+   * @returns {number} Usual comparison result.
+   */
+  compare(other) {
+    this.#checkCompatibility(other);
+
+    const thisValue  = this.#value;
+    const otherValue = other.#value;
+
+    if (thisValue === otherValue) {
+      return 0;
+    } else if (thisValue < otherValue) {
+      return -1;
+    } else {
+      return 1;
+    }
   }
 
   /**
@@ -160,17 +178,28 @@ export class UnitQuantity {
    * @returns {UnitQuantity} Difference result.
    */
   subtract(other) {
-    MustBe.instanceOf(other, UnitQuantity);
-
-    if (   (other.#numeratorUnit !== this.#numeratorUnit)
-        || (other.#denominatorUnit !== this.#denominatorUnit)) {
-      throw new Error('Mismatched units.');
-    }
+    this.#checkCompatibility(other);
 
     return new this.constructor(
       this.#value - other.#value,
       this.#numeratorUnit,
       this.#denominatorUnit);
+  }
+
+  /**
+   * Throws an error if either the given value isn't an instance of this class
+   * or if its units don't match this class.
+   *
+   * @param {*} value Value in question.
+   * @throws {Error} Thrown if `value` isn't "compatible" with this instance.
+   */
+  #checkCompatibility(value) {
+    MustBe.instanceOf(value, UnitQuantity);
+
+    if (   (value.#numeratorUnit   !== this.#numeratorUnit)
+        || (value.#denominatorUnit !== this.#denominatorUnit)) {
+      throw new Error('Mismatched units.');
+    }
   }
 
   //

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -94,7 +94,10 @@ ${'subtract'}
   arg
   ${undefined}
   ${null}
+  ${false}
+  ${true}
   ${123}
+  ${123n}
   ${['x']}
   ${new Map()}
   `('throws given $arg', ({ arg }) => {

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -154,22 +154,43 @@ ${'subtract'}
   });
 });
 
-describe('compare()', () => {
-  test.each`
-  v1        | v2        | expected
-  ${0}      | ${0}      | ${0}
-  ${123.4}  | ${123.4}  | ${0}
-  ${-12}    | ${-11}    | ${-1}
-  ${7}      | ${123}    | ${-1}
-  ${7.6}    | ${5.4}    | ${1}
-  ${9999.3} | ${9999.2} | ${1}
-  `('returns $expected given ($v1, $v2)', ({ v1, v2, expected }) => {
-    const uq1    = new UnitQuantity(v1, 'x', 'y');
-    const uq2    = new UnitQuantity(v2, 'x', 'y');
-    const result = uq1.compare(uq2);
+describe.each`
+methodName
+${'compare'}
+${'eq'}
+${'ge'}
+${'gt'}
+${'le'}
+${'lt'}
+${'ne'}
+`('$methodName()', ({ methodName }) => {
+  const F = false;
+  const T = true;
 
-    expect(result).toBeNumber();
-    expect(result).toBe(expected);
+  describe.each`
+  v1        | v2        | compare | eq   | ne   | lt   | le   | gt   | ge
+  ${0}      | ${0}      | ${0}    | ${T} | ${F} | ${F} | ${T} | ${F} | ${T}
+  ${123.4}  | ${123.4}  | ${0}    | ${T} | ${F} | ${F} | ${T} | ${F} | ${T}
+  ${-12}    | ${-11}    | ${-1}   | ${F} | ${T} | ${T} | ${T} | ${F} | ${F}
+  ${7}      | ${123}    | ${-1}   | ${F} | ${T} | ${T} | ${T} | ${F} | ${F}
+  ${7.6}    | ${5.4}    | ${1}    | ${F} | ${T} | ${F} | ${F} | ${T} | ${T}
+  ${9999.3} | ${9999.2} | ${1}    | ${F} | ${T} | ${F} | ${F} | ${T} | ${T}
+  `('given ($v1, $v2)', ({ v1, v2, ...expected }) => {
+    const exp = expected[methodName];
+
+    test(`returns ${exp}`, () => {
+      const uq1    = new UnitQuantity(v1, 'x', 'y');
+      const uq2    = new UnitQuantity(v2, 'x', 'y');
+      const result = uq1[methodName](uq2);
+
+      if (typeof exp === 'boolean') {
+        expect(result).toBeBoolean();
+      } else {
+        expect(result).toBeNumber();
+      }
+
+      expect(result).toBe(exp);
+    });
   });
 });
 

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -85,9 +85,12 @@ describe('.value', () => {
   });
 });
 
+// This is for the bad-argument cases. There are separate `describe()`s for
+// success cases.
 describe.each`
 methodName
 ${'add'}
+${'compare'}
 ${'subtract'}
 `('$methodName()', ({ methodName }) => {
   test.each`
@@ -116,7 +119,13 @@ ${'subtract'}
     const uq2 = new UnitQuantity(1, 'yes', 'y');
     expect(() => uq1[methodName](uq2)).toThrow();
   });
+});
 
+describe.each`
+methodName
+${'add'}
+${'subtract'}
+`('$methodName()', ({ methodName }) => {
   test.each`
   v1     | v2    | add    | subtract
   ${100} | ${1}  | ${101} | ${99}
@@ -142,6 +151,25 @@ ${'subtract'}
     const result = uq1[methodName](uq2);
 
     expect(result).toBeInstanceOf(UqSub);
+  });
+});
+
+describe('compare()', () => {
+  test.each`
+  v1        | v2        | expected
+  ${0}      | ${0}      | ${0}
+  ${123.4}  | ${123.4}  | ${0}
+  ${-12}    | ${-11}    | ${-1}
+  ${7}      | ${123}    | ${-1}
+  ${7.6}    | ${5.4}    | ${1}
+  ${9999.3} | ${9999.2} | ${1}
+  `('returns $expected given ($v1, $v2)', ({ v1, v2, expected }) => {
+    const uq1    = new UnitQuantity(v1, 'x', 'y');
+    const uq2    = new UnitQuantity(v2, 'x', 'y');
+    const result = uq1.compare(uq2);
+
+    expect(result).toBeNumber();
+    expect(result).toBe(expected);
   });
 });
 

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -126,19 +126,27 @@ methodName
 ${'add'}
 ${'subtract'}
 `('$methodName()', ({ methodName }) => {
-  test.each`
-  v1     | v2    | add    | subtract
-  ${100} | ${1}  | ${101} | ${99}
-  ${5}   | ${20} | ${25}  | ${-15}
-  `('works for $v1 and $v2', ({ v1, v2, ...expected }) => {
-    const uq1    = new UnitQuantity(v1, 'x', 'y');
-    const uq2    = new UnitQuantity(v2, 'x', 'y');
-    const result = uq1[methodName](uq2);
+  describe.each`
+  v1       | v2       | add     | subtract
+  ${0}     | ${0}     | ${0}    | ${0}
+  ${12.25} | ${12.25} | ${24.5} | ${0}
+  ${100}   | ${1}     | ${101}  | ${99}
+  ${1}     | ${100}   | ${101}  | ${-99}
+  ${20}    | ${5}     | ${25}   | ${15}
+  ${5}     | ${20}    | ${25}   | ${-15}
+  `('given ($v1, $v2)', ({ v1, v2, ...expected }) => {
+    const exp = expected[methodName];
 
-    expect(result).toBeInstanceOf(UnitQuantity);
-    expect(result.numeratorUnit).toBe('x');
-    expect(result.denominatorUnit).toBe('y');
-    expect(result.value).toBe(expected[methodName]);
+    test(`returns ${exp}`, () => {
+      const uq1    = new UnitQuantity(v1, 'x', 'y');
+      const uq2    = new UnitQuantity(v2, 'x', 'y');
+      const result = uq1[methodName](uq2);
+
+      expect(result).toBeInstanceOf(UnitQuantity);
+      expect(result.numeratorUnit).toBe('x');
+      expect(result.denominatorUnit).toBe('y');
+      expect(result.value).toBe(expected[methodName]);
+    });
   });
 
   test('returns an instance of the same class as `this`', () => {

--- a/src/webapp-builtins/export/RequestDelay.js
+++ b/src/webapp-builtins/export/RequestDelay.js
@@ -1,0 +1,175 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { IntfTimeSource, StdTimeSource } from '@this/clocks';
+import { Duration } from '@this/data-values';
+import { MustBe } from '@this/typey';
+import { BaseApplication } from '@this/webapp-core';
+
+
+/**
+ * Application that just imposes a delay and then doesn't-handle requests.
+ * Instances of this class are usefully used in the list of apps of a
+ * `SerialRouter` (or similar). See docs for configuration object details.
+ */
+export class RequestDelay extends BaseApplication {
+  // @defaultConstructor
+
+  /** @override */
+  async _impl_handleRequest(request_unused, dispatch_unused) {
+    const { timeSource } = this.config;
+    const delay          = this.#pickDelay();
+
+    await timeSource.waitFor(delay);
+
+    return null;
+  }
+
+  /** @override */
+  async _impl_init() {
+    // @emptyBlock
+  }
+
+  /** @override */
+  async _impl_start() {
+    // @emptyBlock
+  }
+
+  /** @override */
+  async _impl_stop(willReload_unused) {
+    // @emptyBlock
+  }
+
+  /**
+   * Picks a delay for a request.
+   *
+   * @returns {Duration} The delay.
+   */
+  #pickDelay() {
+    const { maxDelay, minDelay } = this.config;
+
+    if (maxDelay === minDelay) {
+      return maxDelay;
+    } else {
+      const minVal     = minDelay.sec;
+      const range      = maxDelay.sec - minVal;
+      const resultMsec = Math.round(((Math.random() * range) + minVal) * 1000);
+
+      return new Duration(resultMsec);
+    }
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @override */
+  static _impl_configClass() {
+    return this.#Config;
+  }
+
+  /**
+   * Configuration item subclass for this (outer) class.
+   */
+  static #Config = class Config extends BaseApplication.Config {
+    /**
+     * Maximum delay time, inclusive.
+     *
+     * @type {Duration}
+     */
+    #maxDelay;
+
+    /**
+     * Minimum delay time, inclusive.
+     *
+     * @type {Duration}
+     */
+    #minDelay;
+
+    /**
+     * Time source.
+     *
+     * @type {IntfTimeSource}
+     */
+    #timeSource;
+
+    /**
+     * Constructs an instance.
+     *
+     * @param {object} rawConfig Raw configuration object.
+     */
+    constructor(rawConfig) {
+      super(rawConfig);
+
+      const {
+        delay      = null,
+        minDelay   = null,
+        maxDelay   = null,
+        timeSource = null
+      } = rawConfig;
+
+      if (delay !== null) {
+        if ((maxDelay !== null) || (minDelay !== null)) {
+          throw new Error('Must specify either `delay` or both `minDelay` and `maxDelay`.');
+        }
+        this.#maxDelay = Config.#parseDelay(delay);
+        this.#minDelay = this.#maxDelay;
+      } else if ((maxDelay !== null) && (minDelay !== null)) {
+        this.#maxDelay = Config.#parseDelay(maxDelay);
+        this.#minDelay = Config.#parseDelay(minDelay);
+        if (this.#minDelay.gt(this.#maxDelay)) {
+          throw new Error('`minDelay` must not be greater than `maxDelay`.');
+        } else if (this.#minDelay.eq(this.#maxDelay)) {
+          // Allow a literal `===` comparison in the handler.
+          this.#minDelay = this.#maxDelay;
+        }
+      } else {
+        throw new Error('Must specify either `delay` or both `minDelay` and `maxDelay`.');
+      }
+
+      if (timeSource === null) {
+        this.#timeSource = StdTimeSource.INSTANCE;
+      } else {
+        // TODO: Check that it actually implements `IntfTimeSource`.
+        this.#timeSource = MustBe.object(timeSource);
+      }
+    }
+
+    /**
+     * @returns {Duration} Maximum delay time, inclusive.
+     */
+    get maxDelay() {
+      return this.#maxDelay;
+    }
+
+    /**
+     * @returns {Duration} Minimum delay time, inclusive.
+     */
+    get minDelay() {
+      return this.#minDelay;
+    }
+
+    /**
+     * @returns {IntfTimeSource} Time source.
+     */
+    get timeSource() {
+      return this.#timeSource;
+    }
+
+
+    //
+    // Static members
+    //
+
+    /**
+     * Parses and checks a delay value for validity.
+     *
+     * @param {string|Duration} value The delay value.
+     * @returns {Duration} The parsed value.
+     */
+    static #parseDelay(value) {
+      return Duration.parse(value, { minInclusive: 0 });
+    }
+  };
+}

--- a/src/webapp-builtins/export/RequestDelay.js
+++ b/src/webapp-builtins/export/RequestDelay.js
@@ -55,7 +55,7 @@ export class RequestDelay extends BaseApplication {
       const range      = maxDelay.sec - minVal;
       const resultMsec = Math.round(((Math.random() * range) + minVal) * 1000);
 
-      return new Duration(resultMsec);
+      return new Duration(resultMsec / 1000);
     }
   }
 

--- a/src/webapp-builtins/index.js
+++ b/src/webapp-builtins/index.js
@@ -11,6 +11,7 @@ export * from '#x/ProcessIdFile';
 export * from '#x/ProcessInfoFile';
 export * from '#x/RateLimiter';
 export * from '#x/Redirector';
+export * from '#x/RequestDelay';
 export * from '#x/RequestFilter';
 export * from '#x/SerialRouter';
 export * from '#x/SimpleResponse';

--- a/src/webapp-builtins/tests/RequestDelay.test.js
+++ b/src/webapp-builtins/tests/RequestDelay.test.js
@@ -1,0 +1,84 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { setImmediate } from 'node:timers/promises';
+
+import { PromiseState } from '@this/async';
+import { MockTimeSource } from '@this/clocks';
+import { TreePathKey } from '@this/collections';
+import { RootControlContext } from '@this/compy';
+import { Duration } from '@this/data-values';
+import { DispatchInfo } from '@this/net-util';
+import { RequestDelay } from '@this/webapp-builtins';
+
+import { RequestUtil } from '#test/RequestUtil';
+
+
+describe('constructor', () => {
+  test('accepts valid `delay`', () => {
+    expect(() => new RequestDelay({ name: 'x', delay: '5_sec' })).not.toThrow();
+    expect(() => new RequestDelay({ name: 'x', delay: new Duration(12.34) })).not.toThrow();
+  });
+
+  test('accepts valid `minDelay` and `maxDelay`', () => {
+    expect(() => new RequestDelay({
+      name:     'x',
+      minDelay: '1_sec',
+      maxDelay: '2_sec'
+    })).not.toThrow();
+    expect(() => new RequestDelay({
+      name:     'x',
+      minDelay: new Duration(1),
+      maxDelay: new Duration(2)
+    })).not.toThrow();
+  });
+
+  test('rejects `maxDelay` without `minDelay`', () => {
+    expect(() => new RequestDelay({ maxDelay: '1_sec' })).toThrow();
+  });
+
+  test('rejects `minDelay` without `maxDelay`', () => {
+    expect(() => new RequestDelay({ minDelay: '1_sec' })).toThrow();
+  });
+
+  test('rejects `delay` with either `minDelay` or `maxDelay`', () => {
+    expect(() => new RequestDelay({ delay: '2_sec', minDelay: '1_sec' })).toThrow();
+    expect(() => new RequestDelay({ delay: '1_sec', maxDelay: '2_sec' })).toThrow();
+  });
+});
+
+describe('_impl_handleRequest()', () => {
+  let timeSource;
+
+  async function makeInstance(opts) {
+    opts = { name: 'theOne', timeSource, ...opts };
+    const rf = new RequestDelay(opts, new RootControlContext(null));
+    await rf.start();
+
+    return rf;
+  }
+
+  beforeEach(() => {
+    timeSource = new MockTimeSource(10000);
+  });
+
+  test('delays by the configured `delay` amount', async () => {
+    const rd = await makeInstance({ delay: '1234_sec' });
+
+    const request = RequestUtil.makeGet('/florp');
+    const result  = rd.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
+
+    await setImmediate();
+    expect(PromiseState.isPending(result)).toBeTrue();
+    timeSource._setTime(11233.999);
+
+    await setImmediate();
+    expect(PromiseState.isPending(result)).toBeTrue();
+    timeSource._setTime(11234);
+
+    await setImmediate();
+    expect(PromiseState.isFulfilled(result)).toBeTrue();
+
+    timeSource._end();
+  });
+});


### PR DESCRIPTION
This PR adds a new application, `RequestDelay`, which simply causes a delay in any response. It doesn't ever respond itself; it merely waits a configured amount (or range of amounts) of time before reporting "request not handled." It is most usefully used as an element of a `SerialRouter`, where it will cause response delays for any applications which come after it in the `SerialRouter`'s applications list.