### PR TITLE
`collections` class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
+* `collections`:
+  * Renamed classes to be more sensible: `TreePathMap` -> `TreeMap`, and
+    `TreePathKey` -> `PathKey`.
 * `data-values`:
   * Filled out the comparison methods in `Moment`, and made them match the ones
     added to `UnitQuantity` (see below).

--- a/src/async/tests/TokenBucket.test.js
+++ b/src/async/tests/TokenBucket.test.js
@@ -4,7 +4,8 @@
 import { setImmediate } from 'node:timers/promises';
 
 import { PromiseState, TokenBucket } from '@this/async';
-import { IntfTimeSource, MockTimeSource, StdTimeSource } from '@this/clocks';
+import { IntfTimeSource, MockTimeSource, StdTimeSource }
+  from '@this/clocks';
 import { Duration, Frequency, Moment } from '@this/data-values';
 
 

--- a/src/collections/export/PathKey.js
+++ b/src/collections/export/PathKey.js
@@ -13,7 +13,7 @@ import { TreePathMap } from '#x/TreePathMap';
  * Key for use with {@link TreePathMap}. Instances are immutable, and contents
  * are strongly type-checked.
  */
-export class TreePathKey {
+export class PathKey {
   /**
    * Path portion of the key.
    *
@@ -46,7 +46,7 @@ export class TreePathKey {
    *   related) things, depending on the context in which an instance is used.
    */
   constructor(path, wildcard) {
-    TreePathKey.checkArguments(path, wildcard);
+    PathKey.checkArguments(path, wildcard);
 
     this.#path     = Object.isFrozen(path) ? path : Object.freeze([...path]);
     this.#wildcard = wildcard;
@@ -106,7 +106,7 @@ export class TreePathKey {
    * @returns {Struct} The encoded form.
    */
   [BaseConverter.ENCODE]() {
-    return new Struct(TreePathKey, null, this.#path, this.#wildcard);
+    return new Struct(PathKey, null, this.#path, this.#wildcard);
   }
 
   /**
@@ -115,9 +115,9 @@ export class TreePathKey {
    * as this one. If all of the given arguments are empty, this method returns
    * `this`.
    *
-   * @param {Array<string|Array<string>|TreePathKey>} others Values to
+   * @param {Array<string|Array<string>|PathKey>} others Values to
    *   concatenate to `this`.
-   * @returns {TreePathKey} Instance with all of `others` concatenated.
+   * @returns {PathKey} Instance with all of `others` concatenated.
    */
   concat(...others) {
     const path = [...this.#path];
@@ -127,7 +127,7 @@ export class TreePathKey {
         path.push(o);
       } else if (Array.isArray(o)) {
         path.push(...o);
-      } else if (o instanceof TreePathKey) {
+      } else if (o instanceof PathKey) {
         path.push(...o.#path);
       } else {
         throw new Error('Invalid `other` argument.');
@@ -136,7 +136,7 @@ export class TreePathKey {
 
     return (path.length === this.#path.length)
       ? this
-      : new TreePathKey(Object.freeze(path), this.#wildcard);
+      : new PathKey(Object.freeze(path), this.#wildcard);
   }
 
   /**
@@ -177,7 +177,7 @@ export class TreePathKey {
    *
    * @param {number} start Start index, inclusive.
    * @param {number} [end] End index, exclusive. Defaults to {@link #length}.
-   * @returns {TreePathKey} The sliced-out value.
+   * @returns {PathKey} The sliced-out value.
    */
   slice(start, end = null) {
     const path   = this.#path;
@@ -190,7 +190,7 @@ export class TreePathKey {
 
     return ((start === 0) && (end === length) && !this.#wildcard)
       ? this
-      : new TreePathKey(Object.freeze(path.slice(start, end)), false);
+      : new PathKey(Object.freeze(path.slice(start, end)), false);
   }
 
   /**
@@ -255,7 +255,7 @@ export class TreePathKey {
    * this method returns this instance.
    *
    * @param {boolean} wildcard Value for `wildcard`.
-   * @returns {TreePathKey} An appropriately-constructed instance.
+   * @returns {PathKey} An appropriately-constructed instance.
    */
   withWildcard(wildcard) {
     MustBe.boolean(wildcard);
@@ -264,7 +264,7 @@ export class TreePathKey {
       return this;
     }
 
-    const result = new TreePathKey(this.#path, wildcard);
+    const result = new PathKey(this.#path, wildcard);
 
     // Avoid recalculating `charLength` if already known on the original.
     result.#charLength = this.#charLength;
@@ -280,11 +280,11 @@ export class TreePathKey {
   /**
    * A non-wildcard empty-path instance.
    *
-   * @type {TreePathKey}
+   * @type {PathKey}
    */
-  static #EMPTY = Object.freeze(new TreePathKey(Object.freeze([]), false));
+  static #EMPTY = Object.freeze(new PathKey(Object.freeze([]), false));
 
-  /** @returns {TreePathKey} A non-wildcard empty-path instance. */
+  /** @returns {PathKey} A non-wildcard empty-path instance. */
   static get EMPTY() {
     return this.#EMPTY;
   }
@@ -297,7 +297,7 @@ export class TreePathKey {
    * @param {*} path The alleged key path.
    * @param {*} wildcard The alleged wildcard flag.
    * @throws {Error} Thrown iff the two arguments could not have been
-   *   successfully used to construct a {@link TreePathKey}.
+   *   successfully used to construct a {@link PathKey}.
    */
   static checkArguments(path, wildcard) {
     MustBe.arrayOfString(path);

--- a/src/collections/export/PathKey.js
+++ b/src/collections/export/PathKey.js
@@ -10,8 +10,8 @@ import { TreeMap } from '#x/TreeMap';
 
 
 /**
- * Key for use with {@link TreeMap}. Instances are immutable, and contents
- * are strongly type-checked.
+ * Key for use with {@link TreeMap}. Instances are immutable, and contents are
+ * strongly type-checked.
  */
 export class PathKey {
   /**
@@ -115,8 +115,8 @@ export class PathKey {
    * as this one. If all of the given arguments are empty, this method returns
    * `this`.
    *
-   * @param {Array<string|Array<string>|PathKey>} others Values to
-   *   concatenate to `this`.
+   * @param {Array<string|Array<string>|PathKey>} others Values to concatenate
+   *   to `this`.
    * @returns {PathKey} Instance with all of `others` concatenated.
    */
   concat(...others) {

--- a/src/collections/export/PathKey.js
+++ b/src/collections/export/PathKey.js
@@ -6,11 +6,11 @@ import * as util from 'node:util';
 import { BaseConverter, Struct } from '@this/data-values';
 import { MustBe } from '@this/typey';
 
-import { TreePathMap } from '#x/TreePathMap';
+import { TreeMap } from '#x/TreeMap';
 
 
 /**
- * Key for use with {@link TreePathMap}. Instances are immutable, and contents
+ * Key for use with {@link TreeMap}. Instances are immutable, and contents
  * are strongly type-checked.
  */
 export class PathKey {

--- a/src/collections/export/TreeMap.js
+++ b/src/collections/export/TreeMap.js
@@ -17,7 +17,7 @@ import { TypePathKey } from '#x/TypePathKey';
  * This class implements several of the usual collection / map methods, in an
  * attempt to provide a useful and familiar interface.
  */
-export class TreePathMap {
+export class TreeMap {
   /**
    * The actual tree structure.
    *
@@ -141,10 +141,10 @@ export class TreePathMap {
    * bindings with keys at or under that path.
    *
    * @param {TypePathKey} key Key to search for.
-   * @returns {TreePathMap} Map of matched bindings.
+   * @returns {TreeMap} Map of matched bindings.
    */
   findSubtree(key) {
-    const result = new TreePathMap(this.#keyStringFunc);
+    const result = new TreeMap(this.#keyStringFunc);
 
     this.#rootNode.addSubtree(key, result);
 

--- a/src/collections/export/TreeMap.js
+++ b/src/collections/export/TreeMap.js
@@ -44,9 +44,9 @@ export class TreeMap {
   /**
    * Constructs an empty instance.
    *
-   * @param {?function(PathKey): string} [keyStringFunc] The function to use
-   *   to render keys into strings. If `null`, this uses {@link
-   *   PathKey#toString} with no arguments.
+   * @param {?function(PathKey): string} [keyStringFunc] The function to use to
+   *   render keys into strings. If `null`, this uses {@link PathKey#toString}
+   *   with no arguments.
    */
   constructor(keyStringFunc = null) {
     this.#keyStringFunc = keyStringFunc
@@ -97,9 +97,9 @@ export class TreeMap {
   /**
    * Gets an iterator over the entries of this instance, analogously to the
    * standard JavaScript `Map.entries()` method. The keys are all instances of
-   * {@link PathKey}, more specifically the same instances that were used to
-   * add mappings to this instance. The result is both an iterator and an
-   * iterable (which, as with `Map.entries()`, returns itself).
+   * {@link PathKey}, more specifically the same instances that were used to add
+   * mappings to this instance. The result is both an iterator and an iterable
+   * (which, as with `Map.entries()`, returns itself).
    *
    * Unlike `Map`, this method does _not_ return an iterator which yields keys
    * in insertion order. Instead, iteration order is always preorder
@@ -118,8 +118,8 @@ export class TreeMap {
    * are no matching bindings.
    *
    * @param {TypePathKey} key Key to search for.
-   * @returns {?{key: PathKey, keyRemainder: PathKey, value: *}} The
-   *   most specific match, or `null` if there was no match at all.
+   * @returns {?{key: PathKey, keyRemainder: PathKey, value: *}} The most
+   *   specific match, or `null` if there was no match at all.
    */
   find(key) {
     return this.#rootNode.find(key);
@@ -161,10 +161,10 @@ export class TreeMap {
    * @param {TypePathKey} key Key to search for. If `.wildcard` is `true`, then
    *   this method will only find bindings which are wildcards, though they
    *   might be more general than the `.path` being looked for.
-   * @yields {{key: PathKey, keyRemainder: PathKey, value: *}} One
-   *   result of the search.
-   *   * `{PathKey} key` -- The key that was matched; this is a wildcard key
-   *     if the match was in fact a wildcard match, and likewise it is a
+   * @yields {{key: PathKey, keyRemainder: PathKey, value: *}} One result of the
+   *   search.
+   *   * `{PathKey} key` -- The key that was matched; this is a wildcard key if
+   *     the match was in fact a wildcard match, and likewise it is a
    *     non-wildcard key for an exact match. Furthermore, this is an object
    *     that was `add()`ed to this instance (and not, e.g., a "reconstructed"
    *     key).

--- a/src/collections/export/TreeMap.js
+++ b/src/collections/export/TreeMap.js
@@ -4,7 +4,7 @@
 import { MustBe } from '@this/typey';
 
 import { PathKey } from '#x/PathKey';
-import { TreePathNode } from '#p/TreePathNode';
+import { TreeMapNode } from '#p/TreeMapNode';
 import { TypePathKey } from '#x/TypePathKey';
 
 
@@ -21,13 +21,13 @@ export class TreeMap {
   /**
    * The actual tree structure.
    *
-   * @type {TreePathNode}
+   * @type {TreeMapNode}
    */
-  #rootNode = new TreePathNode();
+  #rootNode = new TreeMapNode();
 
   /**
    * Total number of bindings. This defined here instead of on {@link
-   * TreePathNode}, because internal nodes don't need to keep track of their
+   * TreeMapNode}, because internal nodes don't need to keep track of their
    * overall size.
    *
    * @type {number}

--- a/src/collections/export/TreePathMap.js
+++ b/src/collections/export/TreePathMap.js
@@ -3,7 +3,7 @@
 
 import { MustBe } from '@this/typey';
 
-import { TreePathKey } from '#x/TreePathKey';
+import { PathKey } from '#x/PathKey';
 import { TreePathNode } from '#p/TreePathNode';
 import { TypePathKey } from '#x/TypePathKey';
 
@@ -37,16 +37,16 @@ export class TreePathMap {
   /**
    * Function which renders keys into strings.
    *
-   * @type {function(TreePathKey): string}
+   * @type {function(PathKey): string}
    */
   #keyStringFunc;
 
   /**
    * Constructs an empty instance.
    *
-   * @param {?function(TreePathKey): string} [keyStringFunc] The function to use
+   * @param {?function(PathKey): string} [keyStringFunc] The function to use
    *   to render keys into strings. If `null`, this uses {@link
-   *   TreePathKey#toString} with no arguments.
+   *   PathKey#toString} with no arguments.
    */
   constructor(keyStringFunc = null) {
     this.#keyStringFunc = keyStringFunc
@@ -97,7 +97,7 @@ export class TreePathMap {
   /**
    * Gets an iterator over the entries of this instance, analogously to the
    * standard JavaScript `Map.entries()` method. The keys are all instances of
-   * {@link TreePathKey}, more specifically the same instances that were used to
+   * {@link PathKey}, more specifically the same instances that were used to
    * add mappings to this instance. The result is both an iterator and an
    * iterable (which, as with `Map.entries()`, returns itself).
    *
@@ -118,7 +118,7 @@ export class TreePathMap {
    * are no matching bindings.
    *
    * @param {TypePathKey} key Key to search for.
-   * @returns {?{key: TreePathKey, keyRemainder: TreePathKey, value: *}} The
+   * @returns {?{key: PathKey, keyRemainder: PathKey, value: *}} The
    *   most specific match, or `null` if there was no match at all.
    */
   find(key) {
@@ -161,14 +161,14 @@ export class TreePathMap {
    * @param {TypePathKey} key Key to search for. If `.wildcard` is `true`, then
    *   this method will only find bindings which are wildcards, though they
    *   might be more general than the `.path` being looked for.
-   * @yields {{key: TreePathKey, keyRemainder: TreePathKey, value: *}} One
+   * @yields {{key: PathKey, keyRemainder: PathKey, value: *}} One
    *   result of the search.
-   *   * `{TreePathKey} key` -- The key that was matched; this is a wildcard key
+   *   * `{PathKey} key` -- The key that was matched; this is a wildcard key
    *     if the match was in fact a wildcard match, and likewise it is a
    *     non-wildcard key for an exact match. Furthermore, this is an object
    *     that was `add()`ed to this instance (and not, e.g., a "reconstructed"
    *     key).
-   *   * `{TreePathKey} keyRemainder` -- The portion of the originally-given
+   *   * `{PathKey} keyRemainder` -- The portion of the originally-given
    *     `key.path` that was matched by the wildcard portion of the key, if this
    *     was in fact a wildcard match, in the form of a non-wildcard key. For
    *     non-wildcard matches, this is always an empty-path key.
@@ -212,7 +212,7 @@ export class TreePathMap {
    * Gets the string form of a key, as defined by the `keyStringFunc` passed in
    * (or implied by) the constructor call that created this instance.
    *
-   * @param {TreePathKey} key The key.
+   * @param {PathKey} key The key.
    * @returns {string} The string form.
    */
   stringFromKey(key) {
@@ -223,7 +223,7 @@ export class TreePathMap {
    * Returns an `Error` with a composed message, suitable for `throw`ing.
    *
    * @param {string} msg Basic message.
-   * @param {TreePathKey} key Key in question.
+   * @param {PathKey} key Key in question.
    * @returns {Error} `Error` instance with composed.
    */
   #makeError(msg, key) {

--- a/src/collections/export/TypePathKey.js
+++ b/src/collections/export/TypePathKey.js
@@ -6,10 +6,10 @@ import { TreeMap } from '#x/TreeMap';
 
 
 /**
- * Type for key parameters passed to methods of {@link TreeMap}. Instances
- * of {@link PathKey} per se are used internally and are what is returned,
- * but it is generally okay to pass in plain objects with the expected
- * properties. This type covers both possibilities.
+ * Type for key parameters passed to methods of {@link TreeMap}. Instances of
+ * {@link PathKey} per se are used internally and are what is returned, but it
+ * is generally okay to pass in plain objects with the expected properties. This
+ * type covers both possibilities.
  *
  * @typedef {PathKey|{ path: Array<string>, wildcard: boolean }} TypePathKey
  */

--- a/src/collections/export/TypePathKey.js
+++ b/src/collections/export/TypePathKey.js
@@ -1,16 +1,16 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '#x/TreePathKey';
+import { PathKey } from '#x/PathKey';
 import { TreePathMap } from '#x/TreePathMap';
 
 
 /**
  * Type for key parameters passed to methods of {@link TreePathMap}. Instances
- * of {@link TreePathKey} per se are used internally and are what is returned,
+ * of {@link PathKey} per se are used internally and are what is returned,
  * but it is generally okay to pass in plain objects with the expected
  * properties. This type covers both possibilities.
  *
- * @typedef {TreePathKey|{ path: Array<string>, wildcard: boolean }} TypePathKey
+ * @typedef {PathKey|{ path: Array<string>, wildcard: boolean }} TypePathKey
  */
 export const TypePathKey = Symbol('TypePathKey');

--- a/src/collections/export/TypePathKey.js
+++ b/src/collections/export/TypePathKey.js
@@ -9,7 +9,7 @@ import { TreePathMap } from '#x/TreePathMap';
  * Type for key parameters passed to methods of {@link TreePathMap}. Instances
  * of {@link TreePathKey} per se are used internally and are what is returned,
  * but it is generally okay to pass in plain objects with the expected
- * properties.
+ * properties. This type covers both possibilities.
  *
  * @typedef {TreePathKey|{ path: Array<string>, wildcard: boolean }} TypePathKey
  */

--- a/src/collections/export/TypePathKey.js
+++ b/src/collections/export/TypePathKey.js
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PathKey } from '#x/PathKey';
-import { TreePathMap } from '#x/TreePathMap';
+import { TreeMap } from '#x/TreeMap';
 
 
 /**
- * Type for key parameters passed to methods of {@link TreePathMap}. Instances
+ * Type for key parameters passed to methods of {@link TreeMap}. Instances
  * of {@link PathKey} per se are used internally and are what is returned,
  * but it is generally okay to pass in plain objects with the expected
  * properties. This type covers both possibilities.

--- a/src/collections/index.js
+++ b/src/collections/index.js
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '#x/PathKey';
-export * from '#x/TreePathMap';
+export * from '#x/TreeMap';
 export * from '#x/TypePathKey';

--- a/src/collections/index.js
+++ b/src/collections/index.js
@@ -1,6 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-export * from '#x/TreePathKey';
+export * from '#x/PathKey';
 export * from '#x/TreePathMap';
 export * from '#x/TypePathKey';

--- a/src/collections/private/TreeMapNode.js
+++ b/src/collections/private/TreeMapNode.js
@@ -12,12 +12,12 @@ import { TypePathKey } from '#x/TypePathKey';
  * Node within a {@link TreeMap}. This class contains practically all of the
  * main tree manipulation and access logic for that class.
  */
-export class TreePathNode {
+export class TreeMapNode {
   /**
-   * Bindings from each initial path component to a {@link TreePathNode} which
+   * Bindings from each initial path component to a {@link TreeMapNode} which
    * contains mappings for that component.
    *
-   * @type {Map<string, TreePathNode>}
+   * @type {Map<string, TreeMapNode>}
    */
   #subtrees = new Map();
 
@@ -78,7 +78,7 @@ export class TreePathNode {
     for (const p of path) {
       let nextSubtree = subtree.#subtrees.get(p);
       if (!nextSubtree) {
-        nextSubtree = new TreePathNode();
+        nextSubtree = new TreeMapNode();
         subtree.#subtrees.set(p, nextSubtree);
       }
       subtree = nextSubtree;

--- a/src/collections/private/TreeMapNode.js
+++ b/src/collections/private/TreeMapNode.js
@@ -54,9 +54,8 @@ export class TreeMapNode {
   // @defaultConstructor
 
   /**
-   * Underlying implementation of `TreeMap.add()`, see which for detailed
-   * docs. Note the different return-vs-throw behavior compared to the exposed
-   * method.
+   * Underlying implementation of `TreeMap.add()`, see which for detailed docs.
+   * Note the different return-vs-throw behavior compared to the exposed method.
    *
    * @param {TypePathKey} key Key to bind.
    * @param {*} value Value to bind at `key`.
@@ -107,8 +106,8 @@ export class TreeMapNode {
    * detailed docs.
    *
    * @param {TypePathKey} key Key to search for.
-   * @param {object} result Result to add to. (It's a `TreeMap`, but we
-   *   don't name the type here to avoid a circular dependency.)
+   * @param {object} result Result to add to. (It's a `TreeMap`, but we don't
+   *   name the type here to avoid a circular dependency.)
    */
   addSubtree(key, result) {
     const { path, wildcard } = key;
@@ -146,8 +145,8 @@ export class TreeMapNode {
   }
 
   /**
-   * Underlying implementation of `TreeMap.entries()`, see which for
-   * detailed docs.
+   * Underlying implementation of `TreeMap.entries()`, see which for detailed
+   * docs.
    *
    * @returns {object} Iterator over the entries of this instance.
    */
@@ -156,24 +155,22 @@ export class TreeMapNode {
   }
 
   /**
-   * Underlying implementation of `TreeMap.find()`, see which for detailed
-   * docs.
+   * Underlying implementation of `TreeMap.find()`, see which for detailed docs.
    *
    * @param {TypePathKey} key Key to search for.
-   * @returns {?{key: PathKey, keyRemainder: PathKey, value: *}} The
-   *   most specific match, or `null` if there was no match at all.
+   * @returns {?{key: PathKey, keyRemainder: PathKey, value: *}} The most
+   *   specific match, or `null` if there was no match at all.
    */
   find(key) {
     return this.findWithFallback(key).next().value ?? null;
   }
 
   /**
-   * Underlying implementation of `TreeMap.findWithFallback()`, see which
-   * for detailed docs.
+   * Underlying implementation of `TreeMap.findWithFallback()`, see which for
+   * detailed docs.
    *
    * @param {TypePathKey} keyToFind Key to search for.
-   * @yields {{key: PathKey, keyRemainder: PathKey, value: *}} One
-   *   result.
+   * @yields {{key: PathKey, keyRemainder: PathKey, value: *}} One result.
    */
   *findWithFallback(keyToFind) {
     const { path, wildcard } = keyToFind;
@@ -228,8 +225,7 @@ export class TreeMapNode {
   }
 
   /**
-   * Underlying implementation of `TreeMap.get()`, see which for detailed
-   * docs.
+   * Underlying implementation of `TreeMap.get()`, see which for detailed docs.
    *
    * @param {TypePathKey} key Key to look up.
    * @param {*} ifNotFound What to return if a binding is not found.
@@ -260,8 +256,7 @@ export class TreeMapNode {
   }
 
   /**
-   * Underlying implementation of `TreeMap.has()`, see which for detailed
-   * docs.
+   * Underlying implementation of `TreeMap.has()`, see which for detailed docs.
    *
    * @param {TypePathKey} key Key to look up.
    * @returns {boolean} `true` if this instance has a binding for `key`, or

--- a/src/collections/private/TreePathNode.js
+++ b/src/collections/private/TreePathNode.js
@@ -4,12 +4,12 @@
 import { MustBe } from '@this/typey';
 
 import { PathKey } from '#x/PathKey';
-import { TreePathMap } from '#x/TreePathMap';
+import { TreeMap } from '#x/TreeMap';
 import { TypePathKey } from '#x/TypePathKey';
 
 
 /**
- * Node within a {@link TreePathMap}. This class contains practically all of the
+ * Node within a {@link TreeMap}. This class contains practically all of the
  * main tree manipulation and access logic for that class.
  */
 export class TreePathNode {
@@ -54,7 +54,7 @@ export class TreePathNode {
   // @defaultConstructor
 
   /**
-   * Underlying implementation of `TreePathMap.add()`, see which for detailed
+   * Underlying implementation of `TreeMap.add()`, see which for detailed
    * docs. Note the different return-vs-throw behavior compared to the exposed
    * method.
    *
@@ -103,11 +103,11 @@ export class TreePathNode {
   }
 
   /**
-   * Underlying implementation of `TreePathMap.findSubtree()`, see which for
+   * Underlying implementation of `TreeMap.findSubtree()`, see which for
    * detailed docs.
    *
    * @param {TypePathKey} key Key to search for.
-   * @param {object} result Result to add to. (It's a `TreePathMap`, but we
+   * @param {object} result Result to add to. (It's a `TreeMap`, but we
    *   don't name the type here to avoid a circular dependency.)
    */
   addSubtree(key, result) {
@@ -146,7 +146,7 @@ export class TreePathNode {
   }
 
   /**
-   * Underlying implementation of `TreePathMap.entries()`, see which for
+   * Underlying implementation of `TreeMap.entries()`, see which for
    * detailed docs.
    *
    * @returns {object} Iterator over the entries of this instance.
@@ -156,7 +156,7 @@ export class TreePathNode {
   }
 
   /**
-   * Underlying implementation of `TreePathMap.find()`, see which for detailed
+   * Underlying implementation of `TreeMap.find()`, see which for detailed
    * docs.
    *
    * @param {TypePathKey} key Key to search for.
@@ -168,7 +168,7 @@ export class TreePathNode {
   }
 
   /**
-   * Underlying implementation of `TreePathMap.findWithFallback()`, see which
+   * Underlying implementation of `TreeMap.findWithFallback()`, see which
    * for detailed docs.
    *
    * @param {TypePathKey} keyToFind Key to search for.
@@ -228,7 +228,7 @@ export class TreePathNode {
   }
 
   /**
-   * Underlying implementation of `TreePathMap.get()`, see which for detailed
+   * Underlying implementation of `TreeMap.get()`, see which for detailed
    * docs.
    *
    * @param {TypePathKey} key Key to look up.
@@ -260,7 +260,7 @@ export class TreePathNode {
   }
 
   /**
-   * Underlying implementation of `TreePathMap.has()`, see which for detailed
+   * Underlying implementation of `TreeMap.has()`, see which for detailed
    * docs.
    *
    * @param {TypePathKey} key Key to look up.

--- a/src/collections/private/TreePathNode.js
+++ b/src/collections/private/TreePathNode.js
@@ -3,7 +3,7 @@
 
 import { MustBe } from '@this/typey';
 
-import { TreePathKey } from '#x/TreePathKey';
+import { PathKey } from '#x/PathKey';
 import { TreePathMap } from '#x/TreePathMap';
 import { TypePathKey } from '#x/TypePathKey';
 
@@ -25,7 +25,7 @@ export class TreePathNode {
    * Non-wildcard key (from the root), if there is an empty-path binding to this
    * instance.
    *
-   * @type {TreePathKey}
+   * @type {PathKey}
    */
   #emptyKey = null;
 
@@ -40,7 +40,7 @@ export class TreePathNode {
    * Wildcard key (from the root), if there is a wildcard binding to this
    * instance.
    *
-   * @type {TreePathKey}
+   * @type {PathKey}
    */
   #wildcardKey = null;
 
@@ -66,7 +66,7 @@ export class TreePathNode {
   add(key, value) {
     const { path, wildcard } = key;
 
-    if (!(key instanceof TreePathKey)) {
+    if (!(key instanceof PathKey)) {
       MustBe.arrayOfString(path);
       MustBe.boolean(wildcard);
     }
@@ -113,8 +113,8 @@ export class TreePathNode {
   addSubtree(key, result) {
     const { path, wildcard } = key;
 
-    if (!(key instanceof TreePathKey)) {
-      TreePathKey.checkArguments(path, wildcard);
+    if (!(key instanceof PathKey)) {
+      PathKey.checkArguments(path, wildcard);
     }
 
     if (!wildcard) {
@@ -160,7 +160,7 @@ export class TreePathNode {
    * docs.
    *
    * @param {TypePathKey} key Key to search for.
-   * @returns {?{key: TreePathKey, keyRemainder: TreePathKey, value: *}} The
+   * @returns {?{key: PathKey, keyRemainder: PathKey, value: *}} The
    *   most specific match, or `null` if there was no match at all.
    */
   find(key) {
@@ -172,14 +172,14 @@ export class TreePathNode {
    * for detailed docs.
    *
    * @param {TypePathKey} keyToFind Key to search for.
-   * @yields {{key: TreePathKey, keyRemainder: TreePathKey, value: *}} One
+   * @yields {{key: PathKey, keyRemainder: PathKey, value: *}} One
    *   result.
    */
   *findWithFallback(keyToFind) {
     const { path, wildcard } = keyToFind;
 
-    if (!(keyToFind instanceof TreePathKey)) {
-      TreePathKey.checkArguments(path, wildcard);
+    if (!(keyToFind instanceof PathKey)) {
+      PathKey.checkArguments(path, wildcard);
     }
 
     // In order to find the most-specific result, we end up having to find all
@@ -207,12 +207,12 @@ export class TreePathNode {
     if (at === path.length) {
       if (subtree.#wildcardKey) {
         // There's a matching wildcard at the end of the path.
-        addResult(subtree.#wildcardKey, subtree.#wildcardValue, TreePathKey.EMPTY);
+        addResult(subtree.#wildcardKey, subtree.#wildcardValue, PathKey.EMPTY);
       }
 
       if (subtree.#emptyKey && !wildcard) {
         // There's an exact non-wildcard match for the path.
-        addResult(subtree.#emptyKey, subtree.#emptyValue, TreePathKey.EMPTY);
+        addResult(subtree.#emptyKey, subtree.#emptyValue, PathKey.EMPTY);
       }
     }
 
@@ -221,7 +221,7 @@ export class TreePathNode {
       if (result.keyRemainder === null) {
         const foundAt       = result.key.path.length;
         const pathRemainder = Object.freeze(path.slice(foundAt));
-        result.keyRemainder = new TreePathKey(pathRemainder, false);
+        result.keyRemainder = new PathKey(pathRemainder, false);
       }
       yield result;
     }
@@ -239,8 +239,8 @@ export class TreePathNode {
   get(key, ifNotFound) {
     const { path, wildcard } = key;
 
-    if (!(key instanceof TreePathKey)) {
-      TreePathKey.checkArguments(path, wildcard);
+    if (!(key instanceof PathKey)) {
+      PathKey.checkArguments(path, wildcard);
     }
 
     let subtree = this;

--- a/src/collections/tests/PathKey.test.js
+++ b/src/collections/tests/PathKey.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 
 
 describe('constructor()', () => {
@@ -19,7 +19,7 @@ describe('constructor()', () => {
       [['some-key', [], 'some-other-key']],
       [['key', 'another', ['invalid']]]
     ])('throws given %p', (value) => {
-      expect(() => new TreePathKey(value, true)).toThrow();
+      expect(() => new PathKey(value, true)).toThrow();
     });
   });
 
@@ -33,7 +33,7 @@ describe('constructor()', () => {
       [new Set()],
       [[true]]
     ])('throws given %p', (value) => {
-      expect(() => new TreePathKey([], value)).toThrow();
+      expect(() => new PathKey([], value)).toThrow();
     });
   });
 
@@ -45,44 +45,44 @@ describe('constructor()', () => {
       [['1', '2'], true],
       [['a', 'b', 'c', 'd', 'e', 'f', 'yes!!!'], false]
     ])('succeeds given (%p, %p)', (...args) => {
-      expect(() => new TreePathKey(...args)).not.toThrow();
+      expect(() => new PathKey(...args)).not.toThrow();
     });
   });
 });
 
 describe('.charLength', () => {
   test('returns `0` for an empty no-wildcard instance', () => {
-    const key = new TreePathKey([], false);
+    const key = new PathKey([], false);
     expect(key.charLength).toBe(0);
   });
 
   test('returns `0` for an empty wildcard instance', () => {
-    const key = new TreePathKey([], true);
+    const key = new PathKey([], true);
     expect(key.charLength).toBe(0);
   });
 
   test('returns the length of the sole component of a length-1 instance', () => {
-    const key1 = new TreePathKey(['x'], false);
+    const key1 = new PathKey(['x'], false);
     expect(key1.charLength).toBe(1);
 
-    const key2 = new TreePathKey(['xyz-pdq'], true);
+    const key2 = new PathKey(['xyz-pdq'], true);
     expect(key2.charLength).toBe(7);
 
-    const key3 = new TreePathKey([''], false);
+    const key3 = new PathKey([''], false);
     expect(key3.charLength).toBe(0);
   });
 
   test('returns the total length of both components of a length-2 instance', () => {
-    const key1 = new TreePathKey(['x', 'ab'], false);
+    const key1 = new PathKey(['x', 'ab'], false);
     expect(key1.charLength).toBe(3);
 
-    const key2 = new TreePathKey(['abc', 'defgh'], true);
+    const key2 = new PathKey(['abc', 'defgh'], true);
     expect(key2.charLength).toBe(8);
   });
 
   // This is meant to verify that caching doesn't mess things up.
   test('returns the same value from repeated calls', () => {
-    const key = new TreePathKey(['ab', 'cde', 'f', 'ghijklmn'], false);
+    const key = new PathKey(['ab', 'cde', 'f', 'ghijklmn'], false);
 
     expect(key.charLength).toBe(14);
     expect(key.charLength).toBe(14);
@@ -92,7 +92,7 @@ describe('.charLength', () => {
 
 describe('.last', () => {
   test('returns `null` given an empty path', () => {
-    expect(TreePathKey.EMPTY.last).toBeNull();
+    expect(PathKey.EMPTY.last).toBeNull();
   });
 
   for (let len = 1; len < 4; len++) {
@@ -103,7 +103,7 @@ describe('.last', () => {
         const expected = `its-${len}`;
         path[len - 1] = expected;
 
-        const key = new TreePathKey(path, wildcard);
+        const key = new PathKey(path, wildcard);
         expect(key.last).toBe(expected);
       });
     }
@@ -116,7 +116,7 @@ describe('.length', () => {
       const wildcard = !!wild;
       test(`works for length ${len}, wildcard ${wildcard}`, () => {
         const path = Array(len).fill('x');
-        const key  = new TreePathKey(path, wildcard);
+        const key  = new PathKey(path, wildcard);
         expect(key.length).toBe(len);
       });
     }
@@ -126,20 +126,20 @@ describe('.length', () => {
 describe('.path', () => {
   test('is strict-equal to the `path` passed to the constructor', () => {
     const path = ['one', 'two', 'three'];
-    const key  = new TreePathKey(path, false);
+    const key  = new PathKey(path, false);
     expect(key.path).toStrictEqual(path);
   });
 
   test('is frozen even when `path` passed to the constructor is not', () => {
     const path = ['yes', 'no'];
-    const key  = new TreePathKey(path, true);
+    const key  = new PathKey(path, true);
     expect(key.path).toBeFrozen();
     expect(key).not.toBeFrozen();
   });
 
   test('is the `path` passed to the constructor when it is frozen', () => {
     const path = Object.freeze(['i', 'am', 'frozen']);
-    const key  = new TreePathKey(path, true);
+    const key  = new PathKey(path, true);
     expect(key.path).toBeFrozen();
     expect(key.path).toStrictEqual(path);
     expect(key.path).toBe(path);
@@ -148,52 +148,52 @@ describe('.path', () => {
 
 describe('.wildcard', () => {
   test('is `true` when constructed with `true`', () => {
-    const key = new TreePathKey([], true);
+    const key = new PathKey([], true);
     expect(key.wildcard).toBeTrue();
   });
 
   test('is `false` when constructed with `false`', () => {
-    const key = new TreePathKey([], false);
+    const key = new PathKey([], false);
     expect(key.wildcard).toBeFalse();
   });
 });
 
 describe('.EMPTY', () => {
   test('is an instance of the class', () => {
-    expect(TreePathKey.EMPTY).toBeInstanceOf(TreePathKey);
+    expect(PathKey.EMPTY).toBeInstanceOf(PathKey);
   });
 
   test('is frozen', () => {
-    expect(TreePathKey.EMPTY).toBeFrozen();
+    expect(PathKey.EMPTY).toBeFrozen();
   });
 
   test('has an empty path', () => {
-    expect(TreePathKey.EMPTY.path).toStrictEqual([]);
+    expect(PathKey.EMPTY.path).toStrictEqual([]);
   });
 
   test('is not a wildcard key', () => {
-    expect(TreePathKey.EMPTY.wildcard).toBeFalse();
+    expect(PathKey.EMPTY.wildcard).toBeFalse();
   });
 });
 
 describe('concat()', () => {
   test('returns `this` given no arguments', () => {
-    const key = new TreePathKey(['x'], false);
+    const key = new PathKey(['x'], false);
     expect(key.concat()).toBe(key);
   });
 
   test('returns `this` given an empty array', () => {
-    const key = new TreePathKey(['x'], false);
+    const key = new PathKey(['x'], false);
     expect(key.concat([])).toBe(key);
   });
 
   test('returns `this` given an empty key', () => {
-    const key = new TreePathKey(['x'], false);
-    expect(key.concat(new TreePathKey([], true))).toBe(key);
+    const key = new PathKey(['x'], false);
+    expect(key.concat(new PathKey([], true))).toBe(key);
   });
 
   test('concats one string', () => {
-    const key    = new TreePathKey(['x'], false);
+    const key    = new PathKey(['x'], false);
     const result = key.concat('y');
 
     expect(result.wildcard).toBe(key.wildcard);
@@ -201,7 +201,7 @@ describe('concat()', () => {
   });
 
   test('concats one array', () => {
-    const key    = new TreePathKey(['x', 'y'], true);
+    const key    = new PathKey(['x', 'y'], true);
     const result = key.concat(['z', 'a']);
 
     expect(result.wildcard).toBe(key.wildcard);
@@ -209,16 +209,16 @@ describe('concat()', () => {
   });
 
   test('concats one key', () => {
-    const key    = new TreePathKey(['x'], true);
-    const result = key.concat(new TreePathKey(['y', 'z', 'a'], false));
+    const key    = new PathKey(['x'], true);
+    const result = key.concat(new PathKey(['y', 'z', 'a'], false));
 
     expect(result.wildcard).toBe(key.wildcard);
     expect(result.path).toStrictEqual(['x', 'y', 'z', 'a']);
   });
 
   test('concats one of everything', () => {
-    const key    = new TreePathKey(['x'], true);
-    const result = key.concat('y', ['z'], new TreePathKey(['a', 'b'], false));
+    const key    = new PathKey(['x'], true);
+    const result = key.concat('y', ['z'], new PathKey(['a', 'b'], false));
 
     expect(result.wildcard).toBe(key.wildcard);
     expect(result.path).toStrictEqual(['x', 'y', 'z', 'a', 'b']);
@@ -227,35 +227,35 @@ describe('concat()', () => {
 
 describe('equals()', () => {
   test('is false given a non-key', () => {
-    const key = new TreePathKey(['foo'], false);
+    const key = new PathKey(['foo'], false);
     expect(key.equals('blort')).toBeFalse();
   });
 
   test('is false given a key with the same path but opposite wildcard', () => {
-    const key1 = new TreePathKey(['foo', 'x'], false);
-    const key2 = new TreePathKey(['foo', 'x'], true);
+    const key1 = new PathKey(['foo', 'x'], false);
+    const key2 = new PathKey(['foo', 'x'], true);
     expect(key1.equals(key2)).toBeFalse();
     expect(key2.equals(key1)).toBeFalse();
   });
 
   test('is false given a key with a shorter path', () => {
-    const key1 = new TreePathKey(['boop', 'x', 'zorch'], false);
-    const key2 = new TreePathKey(['boop', 'x'], false);
+    const key1 = new PathKey(['boop', 'x', 'zorch'], false);
+    const key2 = new PathKey(['boop', 'x'], false);
     expect(key1.equals(key2)).toBeFalse();
   });
 
   test('is false given a key with a longer path', () => {
-    const key1 = new TreePathKey(['foo', 'x'], true);
-    const key2 = new TreePathKey(['foo', 'x', 'zorch'], true);
+    const key1 = new PathKey(['foo', 'x'], true);
+    const key2 = new PathKey(['foo', 'x', 'zorch'], true);
     expect(key1.equals(key2)).toBeFalse();
   });
 
   test('is false given a key with a non-matching component', () => {
     const keys = [
-      new TreePathKey(['a', 'b', 'c'], false),
-      new TreePathKey(['X', 'b', 'c'], false),
-      new TreePathKey(['a', 'X', 'c'], false),
-      new TreePathKey(['a', 'b', 'X'], false)
+      new PathKey(['a', 'b', 'c'], false),
+      new PathKey(['X', 'b', 'c'], false),
+      new PathKey(['a', 'X', 'c'], false),
+      new PathKey(['a', 'b', 'X'], false)
     ];
 
     for (let i = 0; i < keys.length; i++) {
@@ -268,7 +268,7 @@ describe('equals()', () => {
   });
 
   test('is true given `this`', () => {
-    const key = new TreePathKey(['beep'], true);
+    const key = new PathKey(['beep'], true);
     expect(key.equals(key)).toBeTrue();
   });
 
@@ -279,10 +279,10 @@ describe('equals()', () => {
         path.push(`item${j}`);
       }
 
-      const key1 = new TreePathKey(path, false);
-      const key2 = new TreePathKey(path, false);
-      const key3 = new TreePathKey(path, true);
-      const key4 = new TreePathKey(path, true);
+      const key1 = new PathKey(path, false);
+      const key2 = new PathKey(path, false);
+      const key3 = new PathKey(path, true);
+      const key4 = new PathKey(path, true);
 
       expect(key1.equals(key2)).toBeTrue();
       expect(key3.equals(key4)).toBeTrue();
@@ -292,12 +292,12 @@ describe('equals()', () => {
 
 describe('slice()', () => {
   test('returns `this` given (0, 0) on an empty non-wildcard instance', () => {
-    const key = new TreePathKey([], false);
+    const key = new PathKey([], false);
     expect(key.slice(0, 0)).toBe(key);
   });
 
   test('returns a new empty instance given (0, 0) on an empty wildcard instance', () => {
-    const key    = new TreePathKey([], true);
+    const key    = new PathKey([], true);
     const result = key.slice(0, 0);
 
     expect(result).not.toBe(key);
@@ -306,12 +306,12 @@ describe('slice()', () => {
   });
 
   test('returns `this` given full coverage on a non-empty non-wildcard instance', () => {
-    const key = new TreePathKey(['x', 'y', 'z'], false);
+    const key = new PathKey(['x', 'y', 'z'], false);
     expect(key.slice(0, 3)).toBe(key);
   });
 
   test('returns a new instance given full coverage on a non-empty wildcard instance', () => {
-    const key    = new TreePathKey(['x', 'y', 'z'], true);
+    const key    = new PathKey(['x', 'y', 'z'], true);
     const result = key.slice(0, 3);
 
     expect(result).not.toBe(key);
@@ -320,7 +320,7 @@ describe('slice()', () => {
   });
 
   test('returns a new empty instance given (0, 0) on an empty wildcard instance', () => {
-    const key    = new TreePathKey([], true);
+    const key    = new PathKey([], true);
     const result = key.slice(0, 0);
 
     expect(result).not.toBe(key);
@@ -329,7 +329,7 @@ describe('slice()', () => {
   });
 
   test('slices elements at the start', () => {
-    const key    = new TreePathKey(['a', 'b', 'c', 'd', 'e'], true);
+    const key    = new PathKey(['a', 'b', 'c', 'd', 'e'], true);
     const result = key.slice(0, 2);
 
     expect(result.wildcard).toBeFalse();
@@ -337,7 +337,7 @@ describe('slice()', () => {
   });
 
   test('slices elements in the middle', () => {
-    const key    = new TreePathKey(['a', 'b', 'c', 'd', 'e'], true);
+    const key    = new PathKey(['a', 'b', 'c', 'd', 'e'], true);
     const result = key.slice(1, 3);
 
     expect(result.wildcard).toBeFalse();
@@ -345,7 +345,7 @@ describe('slice()', () => {
   });
 
   test('slices elements at the end, when passing `end` explicitly as `length`', () => {
-    const key    = new TreePathKey(['a', 'b', 'c', 'd', 'e'], true);
+    const key    = new PathKey(['a', 'b', 'c', 'd', 'e'], true);
     const result = key.slice(1, 5);
 
     expect(result.wildcard).toBeFalse();
@@ -353,7 +353,7 @@ describe('slice()', () => {
   });
 
   test('slices elements at the end, when not passing `end`', () => {
-    const key    = new TreePathKey(['a', 'b', 'c', 'd', 'e'], true);
+    const key    = new PathKey(['a', 'b', 'c', 'd', 'e'], true);
     const result = key.slice(2);
 
     expect(result.wildcard).toBeFalse();
@@ -361,22 +361,22 @@ describe('slice()', () => {
   });
 
   test('rejects a too-low start', () => {
-    const key = new TreePathKey(['a', 'b', 'c', 'd', 'e'], true);
+    const key = new PathKey(['a', 'b', 'c', 'd', 'e'], true);
     expect(() => key.slice(-1, 2)).toThrow();
   });
 
   test('rejects a too-high start', () => {
-    const key = new TreePathKey(['a', 'b', 'c', 'd', 'e'], true);
+    const key = new PathKey(['a', 'b', 'c', 'd', 'e'], true);
     expect(() => key.slice(6)).toThrow();
   });
 
   test('rejects a too-low end', () => {
-    const key = new TreePathKey(['a', 'b', 'c', 'd', 'e'], true);
+    const key = new PathKey(['a', 'b', 'c', 'd', 'e'], true);
     expect(() => key.slice(2, 1)).toThrow();
   });
 
   test('rejects a too-high end', () => {
-    const key = new TreePathKey(['a', 'b', 'c', 'd', 'e'], true);
+    const key = new PathKey(['a', 'b', 'c', 'd', 'e'], true);
     expect(() => key.slice(5, 6)).toThrow();
   });
 });
@@ -392,7 +392,7 @@ describe('toString()', () => {
     ${['foo', 'bar', 'baz']} | ${false} | ${'[foo, bar, baz]'}
     ${['blort', 'zorch']}    | ${true}  | ${'[blort, zorch, *]'}
     `('on { path: $path, wildcard: $wildcard }', ({ path, wildcard, expected }) => {
-      const key = new TreePathKey(path, wildcard);
+      const key = new PathKey(path, wildcard);
       expect(key.toString()).toBe(expected);
     });
   });
@@ -406,7 +406,7 @@ describe('toString()', () => {
     ${'@@@'} | ${['z']}              | ${true}  | ${'@@@z, *]'}
     ${'_:'}  | ${['aa', 'bb', 'cc']} | ${true}  | ${'_:aa, bb, cc, *]'}
     `('on { path: $path, wildcard: $wildcard }, with $prefix', ({ prefix, path, wildcard, expected }) => {
-      const key = new TreePathKey(path, wildcard);
+      const key = new PathKey(path, wildcard);
       expect(key.toString({ prefix })).toBe(expected);
     });
   });
@@ -420,7 +420,7 @@ describe('toString()', () => {
     ${'@@@'} | ${['z']}              | ${true}  | ${'[z, *@@@'}
     ${'!!'}  | ${['aa', 'bb', 'cc']} | ${true}  | ${'[aa, bb, cc, *!!'}
     `('on { path: $path, wildcard: $wildcard }, with $suffix', ({ suffix, path, wildcard, expected }) => {
-      const key = new TreePathKey(path, wildcard);
+      const key = new PathKey(path, wildcard);
       expect(key.toString({ suffix })).toBe(expected);
     });
   });
@@ -447,7 +447,7 @@ describe('toString()', () => {
     `('on { path: $path, wildcard: $wildcard }, with $separatePrefix', ({ separatePrefix, path, wildcard, expected }) => {
       // Note: We use `prefix` and `separator` options here to make sure we can
       // distinguish what's going on. We use `suffix` just for clarity.
-      const key = new TreePathKey(path, wildcard);
+      const key = new PathKey(path, wildcard);
       expect(key.toString({ separatePrefix, prefix: '#', separator: ':', suffix: '!' })).toBe(expected);
     });
   });
@@ -461,7 +461,7 @@ describe('toString()', () => {
     ${'@@@'}  | ${['a', 'z']}         | ${true}  | ${'[a@@@z@@@*]'}
     ${'!!'}   | ${['aa', 'bb', 'cc']} | ${false} | ${'[aa!!bb!!cc]'}
     `('on { path: $path, wildcard: $wildcard }, with $separator', ({ separator, path, wildcard, expected }) => {
-      const key = new TreePathKey(path, wildcard);
+      const key = new PathKey(path, wildcard);
       expect(key.toString({ separator })).toBe(expected);
     });
   });
@@ -479,7 +479,7 @@ describe('toString()', () => {
     ${'X'}   | ${['a']}              | ${true}  | ${'[a, X]'}
     ${'!!'}  | ${['aa', 'bb', 'cc']} | ${true}  | ${'[aa, bb, cc, !!]'}
     `('on { path: $path, wildcard: $keyWild }, with $wildcard', ({ wildcard, path, keyWild, expected }) => {
-      const key = new TreePathKey(path, keyWild);
+      const key = new PathKey(path, keyWild);
       expect(key.toString({ wildcard })).toBe(expected);
     });
   });
@@ -499,7 +499,7 @@ describe('toString()', () => {
     ${true}  | ${['a\'b"c', '\n']}      | ${false} | ${"[`a'b\"c`, '\\n']"}
     ${true}  | ${['a\'b"c`d']}          | ${true}  | ${"['a\\'b\"c`d', *]"}
     `('on { path: $path, wildcard: $wildcard }, with $quote', ({ quote, path, wildcard, expected }) => {
-      const key = new TreePathKey(path, wildcard);
+      const key = new PathKey(path, wildcard);
       expect(key.toString({ quote })).toBe(expected);
     });
   });
@@ -520,14 +520,14 @@ describe('toString()', () => {
     ${true}  | ${['az', 'bc']} | ${false} | ${'[bc, az]'}
     ${true}  | ${['az', 'bc']} | ${true}  | ${'[*, bc, az]'}
     `('on { path: $path, wildcard: $wildcard }, with $reverse', ({ reverse, path, wildcard, expected }) => {
-      const key = new TreePathKey(path, wildcard);
+      const key = new PathKey(path, wildcard);
       expect(key.toString({ reverse })).toBe(expected);
     });
 
     test('operates correctly with `reverse === true` as well as `prefix` and `suffix` set', () => {
       // This test helps catch problems due to possible confusion given the
       // other defaults.
-      const key = new TreePathKey(['abc', '123', 'xyz'], true);
+      const key = new PathKey(['abc', '123', 'xyz'], true);
       const str = key.toString({ reverse: true, prefix: '[[<', suffix: '>]]' });
       expect(str).toBe('[[<*, xyz, 123, abc>]]');
     });
@@ -536,21 +536,21 @@ describe('toString()', () => {
 
 describe('withWildcard()', () => {
   test('returns the given instance if `wildcard` matches', () => {
-    const key1 = new TreePathKey(['beep'], false);
+    const key1 = new PathKey(['beep'], false);
     expect(key1.withWildcard(false)).toBe(key1);
 
-    const key2 = new TreePathKey(['beep', 'boop'], true);
+    const key2 = new PathKey(['beep', 'boop'], true);
     expect(key2.withWildcard(true)).toBe(key2);
   });
 
   test('returns a new instance, with the same path, if `wildcard` does not match', () => {
-    const key1    = new TreePathKey(['beep'], false);
+    const key1    = new PathKey(['beep'], false);
     const result1 = key1.withWildcard(true);
     expect(result1).not.toBe(key1);
     expect(result1.wildcard).toBe(true);
     expect(result1.path).toBe(key1.path);
 
-    const key2    = new TreePathKey(['beep', 'boop'], true);
+    const key2    = new PathKey(['beep', 'boop'], true);
     const result2 = key2.withWildcard(false);
     expect(result2).not.toBe(key2);
     expect(result2.wildcard).toBe(false);
@@ -558,7 +558,7 @@ describe('withWildcard()', () => {
   });
 
   test('when returning a new instance, gets `charLength` right', () => {
-    const key1    = new TreePathKey(['abc', 'xyz', 'pdq'], false);
+    const key1    = new PathKey(['abc', 'xyz', 'pdq'], false);
     const clen1   = key1.charLength; // Makes sure it's cached by `key1`.
     const result1 = key1.withWildcard(true).charLength;
 
@@ -566,7 +566,7 @@ describe('withWildcard()', () => {
 
     // No initial `.charLength` so that it should get calculated separately by
     // each key.
-    const key2    = new TreePathKey(['foo', 'florp'], true);
+    const key2    = new PathKey(['foo', 'florp'], true);
     const result2 = key2.withWildcard(false).charLength;
 
     expect(result2).toBe(key2.charLength);
@@ -576,27 +576,27 @@ describe('withWildcard()', () => {
 
 describe('checkArguments()', () => {
   test('rejects `path` which is a non-array', () => {
-    expect(() => TreePathKey.checkArguments(null, false)).toThrow();
-    expect(() => TreePathKey.checkArguments({ a: 10 }, false)).toThrow();
+    expect(() => PathKey.checkArguments(null, false)).toThrow();
+    expect(() => PathKey.checkArguments({ a: 10 }, false)).toThrow();
   });
 
   test('rejects `path` which is an array of non-strings', () => {
-    expect(() => TreePathKey.checkArguments([1], false)).toThrow();
-    expect(() => TreePathKey.checkArguments(['a', 2, 'c'], false)).toThrow();
+    expect(() => PathKey.checkArguments([1], false)).toThrow();
+    expect(() => PathKey.checkArguments(['a', 2, 'c'], false)).toThrow();
   });
 
   test('rejects `wildcard` which is non-boolean', () => {
-    expect(() => TreePathKey.checkArguments(['a'], null)).toThrow();
-    expect(() => TreePathKey.checkArguments(['a'], 'false')).toThrow();
-    expect(() => TreePathKey.checkArguments(['a'], Object(false))).toThrow();
+    expect(() => PathKey.checkArguments(['a'], null)).toThrow();
+    expect(() => PathKey.checkArguments(['a'], 'false')).toThrow();
+    expect(() => PathKey.checkArguments(['a'], Object(false))).toThrow();
   });
 
   test('accepts `path` which is an empty array', () => {
-    expect(() => TreePathKey.checkArguments([], false)).not.toThrow();
+    expect(() => PathKey.checkArguments([], false)).not.toThrow();
   });
 
   test('accepts `wildcard` which is either valid boolean', () => {
-    expect(() => TreePathKey.checkArguments(['x'], false)).not.toThrow();
-    expect(() => TreePathKey.checkArguments(['x'], true)).not.toThrow();
+    expect(() => PathKey.checkArguments(['x'], false)).not.toThrow();
+    expect(() => PathKey.checkArguments(['x'], true)).not.toThrow();
   });
 });

--- a/src/collections/tests/TreeMap.test.js
+++ b/src/collections/tests/TreeMap.test.js
@@ -1,12 +1,12 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { PathKey, TreePathMap } from '@this/collections';
+import { PathKey, TreeMap } from '@this/collections';
 
 
 describe('constructor()', () => {
   test('does not throw', () => {
-    expect(() => new TreePathMap()).not.toThrow();
+    expect(() => new TreeMap()).not.toThrow();
   });
 });
 
@@ -24,7 +24,7 @@ describe('.size', () => {
 
   for (let i = 0; i < keys.length; i++) {
     test(`correctly returns ${i}`, () => {
-      const map = new TreePathMap();
+      const map = new TreeMap();
       for (let j = 0; j < i; j++) {
         map.add(keys[j], [`value-${j}`]);
       }
@@ -40,7 +40,7 @@ ${'[Symbol.iterator]'} | ${Symbol.iterator}
 ${'entries'}           | ${'entries'}
 `('$label()', ({ method }) => {
   test('returns an object with the right methods', () => {
-    const map = new TreePathMap();
+    const map = new TreeMap();
 
     const result = map[method]();
     expect(result.next).toBeFunction();
@@ -48,14 +48,14 @@ ${'entries'}           | ${'entries'}
   });
 
   test('returns an object which returns itself when asked to iterate', () => {
-    const map = new TreePathMap();
+    const map = new TreeMap();
 
     const result = map[method]();
     expect(result[Symbol.iterator]()).toBe(result);
   });
 
   test('succeeds in running a no-entry iteration', () => {
-    const map = new TreePathMap();
+    const map = new TreeMap();
 
     const result = map[method]().next();
     expect(result).toStrictEqual({ value: undefined, done: true });
@@ -64,7 +64,7 @@ ${'entries'}           | ${'entries'}
   test('succeeds in running a one-entry iteration', () => {
     const key   = new PathKey(['foo', 'bar'], false);
     const value = ['florp'];
-    const map   = new TreePathMap();
+    const map   = new TreeMap();
 
     map.add(key, value);
     const iter = map[method]();
@@ -86,7 +86,7 @@ describe('add()', () => {
     const key1  = new PathKey(['a'], true);
     const key2  = { path: ['a'], wildcard: true };
     const value = ['some value'];
-    const map   = new TreePathMap();
+    const map   = new TreeMap();
     expect(() => map.add(key1, value)).not.toThrow();
     expect(map.get(key1)).toBe(value);
     expect(map.get(key2)).toBe(value);
@@ -96,7 +96,7 @@ describe('add()', () => {
     const key1  = new PathKey(['x', 'y'], false);
     const key2  = { path: ['x', 'y'], wildcard: false };
     const value = ['some kinda value'];
-    const map   = new TreePathMap();
+    const map   = new TreeMap();
     expect(() => map.add(key2, value)).not.toThrow();
     expect(map.get(key1)).toBe(value);
     expect(map.get(key2)).toBe(value);
@@ -105,7 +105,7 @@ describe('add()', () => {
   test('allows a wildcard key to be added even when a same-path non-wildcard is already in the map', () => {
     const keyNorm = new PathKey(['yes', 'maybe'], false);
     const keyWild = new PathKey(['yes', 'maybe'], true);
-    const map     = new TreePathMap();
+    const map     = new TreeMap();
 
     map.add(keyNorm, 'x');
     expect(() => map.add(keyWild, 'x')).not.toThrow();
@@ -115,7 +115,7 @@ describe('add()', () => {
   test('allows a non-wildcard key to be added even when a same-path wildcard is already in the map', () => {
     const keyNorm = new PathKey(['yes', 'maybe'], false);
     const keyWild = new PathKey(['yes', 'maybe'], true);
-    const map     = new TreePathMap();
+    const map     = new TreeMap();
 
     map.add(keyWild, 'x');
     expect(() => map.add(keyNorm, 'x')).not.toThrow();
@@ -124,7 +124,7 @@ describe('add()', () => {
 
   test('fails to add a non-wildcard key that has already been added', () => {
     const key = new PathKey(['hey what?'], false);
-    const map = new TreePathMap();
+    const map = new TreeMap();
 
     map.add(key, 'x');
     expect(() => map.add(key, 'x')).toThrow();
@@ -133,7 +133,7 @@ describe('add()', () => {
 
   test('fails to add a wildcard key that has already been added', () => {
     const key = new PathKey(['hey what?'], true);
-    const map = new TreePathMap();
+    const map = new TreeMap();
 
     map.add(key, 'x');
     expect(() => map.add(key, 'x')).toThrow();
@@ -143,7 +143,7 @@ describe('add()', () => {
   describe('error messages', () => {
     test('have the expected initial text', () => {
       const key = new PathKey(['beep', 'boop'], true);
-      const map = new TreePathMap();
+      const map = new TreeMap();
 
       map.add(key, 'x');
       expect(() => map.add(key, 'x')).toThrow(/^Key already bound: /);
@@ -151,7 +151,7 @@ describe('add()', () => {
 
     test('uses the default key renderer when none was specified upon construction', () => {
       const key = new PathKey(['a', 'b'], false);
-      const map = new TreePathMap();
+      const map = new TreeMap();
 
       map.add(key, 'x');
       expect(() => map.add(key, 'x')).toThrow(/^[^:]+: \[a, b\]$/);
@@ -159,7 +159,7 @@ describe('add()', () => {
 
     test('uses the default key renderer when `null` was specified upon construction', () => {
       const key = new PathKey(['a', 'b'], true);
-      const map = new TreePathMap(null);
+      const map = new TreeMap(null);
 
       map.add(key, 'x');
       expect(() => map.add(key, 'x')).toThrow(/^[^:]+: \[a, b, \*\]$/);
@@ -173,7 +173,7 @@ describe('add()', () => {
       };
 
       const key = new PathKey(['blorp'], false);
-      const map = new TreePathMap(theFunc);
+      const map = new TreeMap(theFunc);
 
       map.add(key, 'x');
       expect(() => map.add(key, 'x')).toThrow(/^[^:]+: zoinks$/);
@@ -197,13 +197,13 @@ describe('entries()', () => {
       [new PathKey(['c', 'd', 'cc'], false), 'nine'],
       [new PathKey(['c', 'd', 'cc', 'd'], true), 'ten']
     ]);
-    const map = new TreePathMap();
+    const map = new TreeMap();
 
     for (const [k, v] of bindings) {
       map.add(k, v);
     }
 
-    const resultMap = new TreePathMap();
+    const resultMap = new TreeMap();
     for (const [k, v] of map.entries()) {
       expect(bindings.has(k)).toBeTrue();
       expect(bindings.get(k)).toBe(v);
@@ -220,7 +220,7 @@ describe('entries()', () => {
   });
 
   test('yields non-wildcard before wildcard keys at the same depth', () => {
-    const map1 = new TreePathMap();
+    const map1 = new TreeMap();
     map1.add(new PathKey([], true), 'wild');
     map1.add(new PathKey([], false), 'regular');
 
@@ -228,7 +228,7 @@ describe('entries()', () => {
     expect(entries1[0][1]).toBe('regular');
     expect(entries1[1][1]).toBe('wild');
 
-    const map2 = new TreePathMap();
+    const map2 = new TreeMap();
     map2.add(new PathKey(['x', 'y'], false), 'woo-regular');
     map2.add(new PathKey(['x', 'y'], true), 'woo-wild');
 
@@ -238,7 +238,7 @@ describe('entries()', () => {
   });
 
   test('yields less deep keys first', () => {
-    const map = new TreePathMap();
+    const map = new TreeMap();
     map.add(new PathKey([], false), 'one');
     map.add(new PathKey(['a'], false), 'two');
     map.add(new PathKey(['a', 'b'], false), 'three');
@@ -250,7 +250,7 @@ describe('entries()', () => {
   });
 
   test('yields siblings in sorted order', () => {
-    const map = new TreePathMap();
+    const map = new TreeMap();
     map.add(new PathKey(['c'], false), 'three');
     map.add(new PathKey(['a'], false), 'one');
     map.add(new PathKey(['b'], false), 'two');
@@ -262,7 +262,7 @@ describe('entries()', () => {
   });
 
   test('yields subtrees in their entirety without interjecting sibling entries', () => {
-    const map = new TreePathMap();
+    const map = new TreeMap();
     map.add(new PathKey(['b'], false), 'yes-1');
     map.add(new PathKey(['c'], false), 'nope');
     map.add(new PathKey(['b', '1'], false), 'yes-2');
@@ -285,7 +285,7 @@ describe('find()', () => {
     test('finds an already-added key, when an exact match is passed as a `PathKey`', () => {
       const key   = new PathKey(['1', '2', '3'], false);
       const value = ['florp'];
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key, value);
       const result = map.find(key);
@@ -299,7 +299,7 @@ describe('find()', () => {
       const key1  = new PathKey(['1', '2', '3'], false);
       const key2  = { path: ['1', '2', '3'], wildcard: false };
       const value = ['florp'];
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key1, value);
       const result = map.find(key2);
@@ -314,7 +314,7 @@ describe('find()', () => {
       const key2  = new PathKey(['one', 'two'], false);
       const key3  = new PathKey(['one', 'two', 'three'], false);
       const value = ['boop'];
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key1, value);
 
@@ -336,7 +336,7 @@ describe('find()', () => {
       const key1  = new PathKey(['i', 'love', 'muffins'], true);
       const key2  = new PathKey(['i', 'love', 'muffins'], false);
       const value = ['blueberry'];
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key1, value);
 
@@ -353,7 +353,7 @@ describe('find()', () => {
       const key2  = new PathKey(['top', 'middle'], false);
       const key3  = new PathKey(['top', 'middle', 'bottom'], false);
       const value = ['florp'];
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key1, value);
       map.add(key2, 'y');
@@ -371,7 +371,7 @@ describe('find()', () => {
       const key2  = new PathKey(['top', 'middle'], true);
       const key3  = new PathKey(['top', 'middle', 'bottom'], false);
       const value = ['florp', 'like'];
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key1, 'x');
       map.add(key2, value);
@@ -388,7 +388,7 @@ describe('find()', () => {
       const key1 = new PathKey(['top'], false);
       const key2 = new PathKey(['top', 'middle'], false);
       const key3 = new PathKey(['top', 'middle', 'bottom'], false);
-      const map  = new TreePathMap();
+      const map  = new TreeMap();
 
       map.add(key1, 'x');
       map.add(key2, 'y');
@@ -403,7 +403,7 @@ describe('find()', () => {
       const key1  = new PathKey(['one', 'two'], true);
       const key2  = new PathKey(['one', 'two', 'three'], true);
       const value = ['boop'];
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key1, value);
 
@@ -424,7 +424,7 @@ describe('find()', () => {
     test('finds an already-added wildcard, when a matching key is passed as a plain object', () => {
       const key1  = new PathKey(['a', 'b', 'c'], true);
       const value = ['boop'];
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key1, value);
 
@@ -439,7 +439,7 @@ describe('find()', () => {
       const key1 = new PathKey(['top'], false);
       const key2 = new PathKey(['top', 'middle'], false);
       const key3 = new PathKey(['top', 'middle', 'bottom'], true);
-      const map  = new TreePathMap();
+      const map  = new TreeMap();
 
       map.add(key1, 'x');
       map.add(key2, 'y');
@@ -453,7 +453,7 @@ describe('find()', () => {
       const key2  = new PathKey(['top', 'middle'], false);
       const key3  = new PathKey(['top', 'middle', 'bottom'], true);
       const value = { beep: 'boop' };
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key1, value);
       map.add(key2, 'y');
@@ -471,7 +471,7 @@ describe('find()', () => {
       const key2  = new PathKey(['top', 'middle'], true);
       const key3  = new PathKey(['top', 'middle', 'bottom'], true);
       const value = { zeep: 'zoop' };
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key1, 'x');
       map.add(key2, value);
@@ -488,7 +488,7 @@ describe('find()', () => {
       const key1  = new PathKey(['one', 'two'], false);
       const key2  = new PathKey(['one', 'two'], true);
       const value = ['beep'];
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key1, value);
       expect(map.find(key2)).toBeNull();
@@ -509,7 +509,7 @@ describe('find()', () => {
       const key2 = new PathKey(['a'], false);
 
       test('finds it when bound to a wildcard', () => {
-        const map = new TreePathMap();
+        const map = new TreeMap();
 
         map.add(key1, value);
 
@@ -523,7 +523,7 @@ describe('find()', () => {
       });
 
       test('finds it when bound to a non-wildcard', () => {
-        const map = new TreePathMap();
+        const map = new TreeMap();
 
         map.add(key2, value);
 
@@ -540,7 +540,7 @@ describe('find()', () => {
     const key3 = new PathKey(['x', 'y'], true);
     const key4 = new PathKey(['x', 'y'], false);
 
-    const map = new TreePathMap();
+    const map = new TreeMap();
     map.add(key1, 'a');
     map.add(key2, 'b');
     map.add(key3, 'c');
@@ -558,7 +558,7 @@ describe('findSubtree()', () => {
   test('returns an instance with the same `keyStringFunc`.', () => {
     const ksf    = () => 'florp';
     const key    = new PathKey(['x'], true);
-    const map    = new TreePathMap(ksf);
+    const map    = new TreeMap(ksf);
     const result = map.findSubtree(key);
 
     expect(result.stringFromKey(key)).toBe('florp');
@@ -568,7 +568,7 @@ describe('findSubtree()', () => {
     const key = new PathKey([], true);
 
     test('returns an empty (but different object) result if there are no bindings', () => {
-      const map    = new TreePathMap();
+      const map    = new TreeMap();
       const result = map.findSubtree(key);
       expect(result.size).toBe(0);
       expect(result).not.toBe(map);
@@ -577,7 +577,7 @@ describe('findSubtree()', () => {
     test('returns a single top-level non-wildcard binding, if that is what is in the map', () => {
       const key1   = new PathKey([], false);
       const value1 = ['a value'];
-      const map    = new TreePathMap();
+      const map    = new TreeMap();
 
       map.add(key1, value1);
       const result = map.findSubtree(key);
@@ -587,7 +587,7 @@ describe('findSubtree()', () => {
 
     test('returns a single top-level wildcard binding, if that is what is in the map', () => {
       const value = ['still a value'];
-      const map   = new TreePathMap();
+      const map   = new TreeMap();
 
       map.add(key, value);
       const result = map.findSubtree(key);
@@ -599,7 +599,7 @@ describe('findSubtree()', () => {
       const value1 = ['first value'];
       const key2  = new PathKey([], false);
       const value2 = ['second value'];
-      const map    = new TreePathMap();
+      const map    = new TreeMap();
 
       map.add(key, value1);
       map.add(key2, value2);
@@ -623,7 +623,7 @@ describe('findSubtree()', () => {
         [new PathKey(['a', 'b', 'cc'], false), 'nine'],
         [new PathKey(['a', 'b', 'cc', 'd'], true), 'ten']
       ]);
-      const map = new TreePathMap();
+      const map = new TreeMap();
 
       for (const [k, v] of bindings) {
         map.add(k, v);
@@ -642,7 +642,7 @@ describe('findSubtree()', () => {
   test('finds an exact non-wildcard match, given a non-wildcard key', () => {
     const key   = new PathKey(['1', '2'], false);
     const value = 'value';
-    const map   = new TreePathMap();
+    const map   = new TreeMap();
 
     map.add(key, value);
     const result = map.findSubtree(key);
@@ -654,7 +654,7 @@ describe('findSubtree()', () => {
     const key1  = new PathKey(['1', '2'], true);
     const key2  = new PathKey(['1', '2'], false);
     const value = 'some-value';
-    const map   = new TreePathMap();
+    const map   = new TreeMap();
 
     map.add(key1, value);
     const result = map.findSubtree(key2);
@@ -666,7 +666,7 @@ describe('findSubtree()', () => {
     const key1  = new PathKey(['1', '2'], true);
     const key2  = new PathKey(['1', '2', '3', '4'], false);
     const value = 'some-other-value';
-    const map   = new TreePathMap();
+    const map   = new TreeMap();
 
     map.add(key1, value);
     const result = map.findSubtree(key2);
@@ -699,7 +699,7 @@ describe('findSubtree()', () => {
       [new PathKey(['a', 'b', 'cc'], false), 'nine'],
       [new PathKey(['a', 'b', 'cc', 'd'], true), 'ten']
     ]);
-    const map = new TreePathMap();
+    const map = new TreeMap();
 
     for (const [k, v] of [...bindings, ...extraBindings]) {
       map.add(k, v);
@@ -721,7 +721,7 @@ describe('findWithFallback()', () => {
     const key3 = new PathKey(['x', 'y'], true);
     const key4 = new PathKey(['x', 'y'], false);
 
-    const map = new TreePathMap();
+    const map = new TreeMap();
     map.add(key1, 'a');
     map.add(key2, 'b');
     map.add(key3, 'c');
@@ -753,7 +753,7 @@ describe('findWithFallback()', () => {
     const key3 = new PathKey(['x', 'y'], false);
     const key4 = new PathKey(['x', 'y', 'z'], false);
 
-    const map = new TreePathMap();
+    const map = new TreeMap();
     map.add(key1, 'a');
     map.add(key2, 'b');
     map.add(key3, 'c');
@@ -772,7 +772,7 @@ describe('findWithFallback()', () => {
     const key2 = new PathKey(['x'], false);
     const key3 = new PathKey(['x', 'y'], false);
 
-    const map = new TreePathMap();
+    const map = new TreeMap();
     map.add(key1, 'a');
     map.add(key2, 'b');
 
@@ -787,7 +787,7 @@ describe('findWithFallback()', () => {
     const key2 = new PathKey(['x'], false);
     const key3 = new PathKey(['x', 'y'], true);
 
-    const map = new TreePathMap();
+    const map = new TreeMap();
     map.add(key1, 'a');
     map.add(key2, 'b');
     map.add(key3, 'c');
@@ -833,7 +833,7 @@ ${'has'}   | ${true}
     const key1  = new PathKey(['1', '2', '3'], false);
     const key2  = new PathKey(['1', '2', '3'], false);
     const value = ['yes', 'a value'];
-    const map   = new TreePathMap();
+    const map   = new TreeMap();
 
     map.add(key1, value);
     expectFound(map, key1, value);
@@ -844,7 +844,7 @@ ${'has'}   | ${true}
     const key1  = { path: ['yo', 'there'], wildcard: true };
     const key2  = { path: ['yo', 'there'], wildcard: true };
     const value = ['yeppers', 'still a value'];
-    const map   = new TreePathMap();
+    const map   = new TreeMap();
 
     map.add(key1, value);
     expectFound(map, key1, value);
@@ -855,7 +855,7 @@ ${'has'}   | ${true}
     const key1  = new PathKey(['1'], true);
     const key2  = new PathKey(['1'], false);
     const value = ['yo there'];
-    const map   = new TreePathMap();
+    const map   = new TreeMap();
 
     map.add(key1, value);
     expectNotFound(map, key2);
@@ -865,7 +865,7 @@ ${'has'}   | ${true}
     const key1  = new PathKey(['1'], true);
     const key2  = new PathKey(['1'], false);
     const value = ['yo there'];
-    const map   = new TreePathMap();
+    const map   = new TreeMap();
 
     map.add(key2, value);
     expectNotFound(map, key1);
@@ -874,12 +874,12 @@ ${'has'}   | ${true}
 
 describe('get()', () => {
   test('returns `null` when a key is not found, if `ifNotFound` was not passed', () => {
-    const map = new TreePathMap();
+    const map = new TreeMap();
     expect(map.get({ path: ['x'], wildcard: false })).toBeNull();
   });
 
   test('returns the `ifNotFound` value when a key is not found', () => {
-    const map   = new TreePathMap();
+    const map   = new TreeMap();
     const value = ['whatever'];
     expect(map.get(new PathKey([], true), value)).toBe(value);
   });
@@ -897,7 +897,7 @@ describe('get()', () => {
       const notFound = 'not-actually-there';
 
       test('finds it when bound to a wildcard', () => {
-        const map = new TreePathMap();
+        const map = new TreeMap();
         const key = new PathKey(['abc'], true);
 
         map.add(key, value);
@@ -907,7 +907,7 @@ describe('get()', () => {
       });
 
       test('finds it when bound to a non-wildcard', () => {
-        const map = new TreePathMap();
+        const map = new TreeMap();
         const key = new PathKey(['abc'], false);
 
         map.add(key, value);
@@ -931,7 +931,7 @@ describe('has()', () => {
       [{}]
     ])('for %p', (value) => {
       test('finds it when bound to a wildcard', () => {
-        const map = new TreePathMap();
+        const map = new TreeMap();
         const key = new PathKey(['abc'], true);
 
         map.add(key, value);
@@ -941,7 +941,7 @@ describe('has()', () => {
       });
 
       test('finds it when bound to a non-wildcard', () => {
-        const map = new TreePathMap();
+        const map = new TreeMap();
         const key = new PathKey(['abc'], false);
 
         map.add(key, value);
@@ -955,7 +955,7 @@ describe('has()', () => {
 
 describe('stringFromKey()', () => {
   test('uses the default function when not specified in the constructor', () => {
-    const map = new TreePathMap();
+    const map = new TreeMap();
 
     const key1 = new PathKey([], true);
     const s1   = map.stringFromKey(key1);
@@ -967,7 +967,7 @@ describe('stringFromKey()', () => {
   });
 
   test('uses the default function when `null` was specified in the constructor', () => {
-    const map = new TreePathMap(null);
+    const map = new TreeMap(null);
 
     const key1 = new PathKey(['x', 'y', 'zonk'], true);
     const s1   = map.stringFromKey(key1);
@@ -987,7 +987,7 @@ describe('stringFromKey()', () => {
 
     const key1 = new PathKey(['x'], true);
     const key2 = new PathKey(['y'], false);
-    const map = new TreePathMap(theFunc);
+    const map = new TreeMap(theFunc);
 
     const s1 = map.stringFromKey(key1);
     const s2 = map.stringFromKey(key2);

--- a/src/collections/tests/TreePathMap.test.js
+++ b/src/collections/tests/TreePathMap.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey, TreePathMap } from '@this/collections';
+import { PathKey, TreePathMap } from '@this/collections';
 
 
 describe('constructor()', () => {
@@ -12,14 +12,14 @@ describe('constructor()', () => {
 
 describe('.size', () => {
   const keys = [
-    new TreePathKey([], true),
-    new TreePathKey([], false),
-    new TreePathKey(['x'], false),
-    new TreePathKey(['x', 'y'], false),
-    new TreePathKey(['x', 'y'], true),
-    new TreePathKey(['a', 'b', 'c'], false),
-    new TreePathKey(['a', 'b', 'c', 'x'], true),
-    new TreePathKey(['a', 'b', 'c', 'x', 'y'], true)
+    new PathKey([], true),
+    new PathKey([], false),
+    new PathKey(['x'], false),
+    new PathKey(['x', 'y'], false),
+    new PathKey(['x', 'y'], true),
+    new PathKey(['a', 'b', 'c'], false),
+    new PathKey(['a', 'b', 'c', 'x'], true),
+    new PathKey(['a', 'b', 'c', 'x', 'y'], true)
   ];
 
   for (let i = 0; i < keys.length; i++) {
@@ -62,7 +62,7 @@ ${'entries'}           | ${'entries'}
   });
 
   test('succeeds in running a one-entry iteration', () => {
-    const key   = new TreePathKey(['foo', 'bar'], false);
+    const key   = new PathKey(['foo', 'bar'], false);
     const value = ['florp'];
     const map   = new TreePathMap();
 
@@ -82,8 +82,8 @@ ${'entries'}           | ${'entries'}
 });
 
 describe('add()', () => {
-  test('accepts a `TreePathKey`, which can then be found exactly', () => {
-    const key1  = new TreePathKey(['a'], true);
+  test('accepts a `PathKey`, which can then be found exactly', () => {
+    const key1  = new PathKey(['a'], true);
     const key2  = { path: ['a'], wildcard: true };
     const value = ['some value'];
     const map   = new TreePathMap();
@@ -93,7 +93,7 @@ describe('add()', () => {
   });
 
   test('accepts a key-like plain object, which can then be found exactly', () => {
-    const key1  = new TreePathKey(['x', 'y'], false);
+    const key1  = new PathKey(['x', 'y'], false);
     const key2  = { path: ['x', 'y'], wildcard: false };
     const value = ['some kinda value'];
     const map   = new TreePathMap();
@@ -103,8 +103,8 @@ describe('add()', () => {
   });
 
   test('allows a wildcard key to be added even when a same-path non-wildcard is already in the map', () => {
-    const keyNorm = new TreePathKey(['yes', 'maybe'], false);
-    const keyWild = new TreePathKey(['yes', 'maybe'], true);
+    const keyNorm = new PathKey(['yes', 'maybe'], false);
+    const keyWild = new PathKey(['yes', 'maybe'], true);
     const map     = new TreePathMap();
 
     map.add(keyNorm, 'x');
@@ -113,8 +113,8 @@ describe('add()', () => {
   });
 
   test('allows a non-wildcard key to be added even when a same-path wildcard is already in the map', () => {
-    const keyNorm = new TreePathKey(['yes', 'maybe'], false);
-    const keyWild = new TreePathKey(['yes', 'maybe'], true);
+    const keyNorm = new PathKey(['yes', 'maybe'], false);
+    const keyWild = new PathKey(['yes', 'maybe'], true);
     const map     = new TreePathMap();
 
     map.add(keyWild, 'x');
@@ -123,7 +123,7 @@ describe('add()', () => {
   });
 
   test('fails to add a non-wildcard key that has already been added', () => {
-    const key = new TreePathKey(['hey what?'], false);
+    const key = new PathKey(['hey what?'], false);
     const map = new TreePathMap();
 
     map.add(key, 'x');
@@ -132,7 +132,7 @@ describe('add()', () => {
   });
 
   test('fails to add a wildcard key that has already been added', () => {
-    const key = new TreePathKey(['hey what?'], true);
+    const key = new PathKey(['hey what?'], true);
     const map = new TreePathMap();
 
     map.add(key, 'x');
@@ -142,7 +142,7 @@ describe('add()', () => {
 
   describe('error messages', () => {
     test('have the expected initial text', () => {
-      const key = new TreePathKey(['beep', 'boop'], true);
+      const key = new PathKey(['beep', 'boop'], true);
       const map = new TreePathMap();
 
       map.add(key, 'x');
@@ -150,7 +150,7 @@ describe('add()', () => {
     });
 
     test('uses the default key renderer when none was specified upon construction', () => {
-      const key = new TreePathKey(['a', 'b'], false);
+      const key = new PathKey(['a', 'b'], false);
       const map = new TreePathMap();
 
       map.add(key, 'x');
@@ -158,7 +158,7 @@ describe('add()', () => {
     });
 
     test('uses the default key renderer when `null` was specified upon construction', () => {
-      const key = new TreePathKey(['a', 'b'], true);
+      const key = new PathKey(['a', 'b'], true);
       const map = new TreePathMap(null);
 
       map.add(key, 'x');
@@ -172,7 +172,7 @@ describe('add()', () => {
         return 'zoinks';
       };
 
-      const key = new TreePathKey(['blorp'], false);
+      const key = new PathKey(['blorp'], false);
       const map = new TreePathMap(theFunc);
 
       map.add(key, 'x');
@@ -186,16 +186,16 @@ describe('entries()', () => {
   test('handles a large-ish example', () => {
     // This is a "smokey" test.
     const bindings = new Map([
-      [new TreePathKey([], false), 'one'],
-      [new TreePathKey(['boop'], false), ['two']],
-      [new TreePathKey(['beep'], true), ['three', 3]],
-      [new TreePathKey(['z', 'y'], true), Symbol('four')],
-      [new TreePathKey(['z', 'y', 'z'], false), { five: 'five' }],
-      [new TreePathKey(['a'], true), 'six'],
-      [new TreePathKey(['a', 'b'], true), 'seven'],
-      [new TreePathKey(['c', 'd', 'c'], false), 'eight'],
-      [new TreePathKey(['c', 'd', 'cc'], false), 'nine'],
-      [new TreePathKey(['c', 'd', 'cc', 'd'], true), 'ten']
+      [new PathKey([], false), 'one'],
+      [new PathKey(['boop'], false), ['two']],
+      [new PathKey(['beep'], true), ['three', 3]],
+      [new PathKey(['z', 'y'], true), Symbol('four')],
+      [new PathKey(['z', 'y', 'z'], false), { five: 'five' }],
+      [new PathKey(['a'], true), 'six'],
+      [new PathKey(['a', 'b'], true), 'seven'],
+      [new PathKey(['c', 'd', 'c'], false), 'eight'],
+      [new PathKey(['c', 'd', 'cc'], false), 'nine'],
+      [new PathKey(['c', 'd', 'cc', 'd'], true), 'ten']
     ]);
     const map = new TreePathMap();
 
@@ -221,16 +221,16 @@ describe('entries()', () => {
 
   test('yields non-wildcard before wildcard keys at the same depth', () => {
     const map1 = new TreePathMap();
-    map1.add(new TreePathKey([], true), 'wild');
-    map1.add(new TreePathKey([], false), 'regular');
+    map1.add(new PathKey([], true), 'wild');
+    map1.add(new PathKey([], false), 'regular');
 
     const entries1 = [...map1.entries()];
     expect(entries1[0][1]).toBe('regular');
     expect(entries1[1][1]).toBe('wild');
 
     const map2 = new TreePathMap();
-    map2.add(new TreePathKey(['x', 'y'], false), 'woo-regular');
-    map2.add(new TreePathKey(['x', 'y'], true), 'woo-wild');
+    map2.add(new PathKey(['x', 'y'], false), 'woo-regular');
+    map2.add(new PathKey(['x', 'y'], true), 'woo-wild');
 
     const entries2 = [...map2.entries()];
     expect(entries2[0][1]).toBe('woo-regular');
@@ -239,9 +239,9 @@ describe('entries()', () => {
 
   test('yields less deep keys first', () => {
     const map = new TreePathMap();
-    map.add(new TreePathKey([], false), 'one');
-    map.add(new TreePathKey(['a'], false), 'two');
-    map.add(new TreePathKey(['a', 'b'], false), 'three');
+    map.add(new PathKey([], false), 'one');
+    map.add(new PathKey(['a'], false), 'two');
+    map.add(new PathKey(['a', 'b'], false), 'three');
 
     const entries = [...map.entries()];
     expect(entries[0][1]).toBe('one');
@@ -251,9 +251,9 @@ describe('entries()', () => {
 
   test('yields siblings in sorted order', () => {
     const map = new TreePathMap();
-    map.add(new TreePathKey(['c'], false), 'three');
-    map.add(new TreePathKey(['a'], false), 'one');
-    map.add(new TreePathKey(['b'], false), 'two');
+    map.add(new PathKey(['c'], false), 'three');
+    map.add(new PathKey(['a'], false), 'one');
+    map.add(new PathKey(['b'], false), 'two');
 
     const entries = [...map.entries()];
     expect(entries[0][1]).toBe('one');
@@ -263,12 +263,12 @@ describe('entries()', () => {
 
   test('yields subtrees in their entirety without interjecting sibling entries', () => {
     const map = new TreePathMap();
-    map.add(new TreePathKey(['b'], false), 'yes-1');
-    map.add(new TreePathKey(['c'], false), 'nope');
-    map.add(new TreePathKey(['b', '1'], false), 'yes-2');
-    map.add(new TreePathKey(['a'], false), 'nope');
-    map.add(new TreePathKey(['b', '2'], false), 'yes-4');
-    map.add(new TreePathKey(['b', '1', 'x'], false), 'yes-3');
+    map.add(new PathKey(['b'], false), 'yes-1');
+    map.add(new PathKey(['c'], false), 'nope');
+    map.add(new PathKey(['b', '1'], false), 'yes-2');
+    map.add(new PathKey(['a'], false), 'nope');
+    map.add(new PathKey(['b', '2'], false), 'yes-4');
+    map.add(new PathKey(['b', '1', 'x'], false), 'yes-3');
 
     const entries = [...map.entries()];
     expect(entries.length).toBe(6);
@@ -282,8 +282,8 @@ describe('entries()', () => {
 
 describe('find()', () => {
   describe('given a non-wildcard key', () => {
-    test('finds an already-added key, when an exact match is passed as a `TreePathKey`', () => {
-      const key   = new TreePathKey(['1', '2', '3'], false);
+    test('finds an already-added key, when an exact match is passed as a `PathKey`', () => {
+      const key   = new PathKey(['1', '2', '3'], false);
       const value = ['florp'];
       const map   = new TreePathMap();
 
@@ -291,12 +291,12 @@ describe('find()', () => {
       const result = map.find(key);
       expect(result).not.toBeNull();
       expect(result.key).toBe(key);
-      expect(result.keyRemainder).toBe(TreePathKey.EMPTY);
+      expect(result.keyRemainder).toBe(PathKey.EMPTY);
       expect(result.value).toBe(value);
     });
 
     test('finds an already-added key, when an exact match passed as a key-like plain object', () => {
-      const key1  = new TreePathKey(['1', '2', '3'], false);
+      const key1  = new PathKey(['1', '2', '3'], false);
       const key2  = { path: ['1', '2', '3'], wildcard: false };
       const value = ['florp'];
       const map   = new TreePathMap();
@@ -305,14 +305,14 @@ describe('find()', () => {
       const result = map.find(key2);
       expect(result).not.toBeNull();
       expect(result.key).toBe(key1);
-      expect(result.keyRemainder).toBe(TreePathKey.EMPTY);
+      expect(result.keyRemainder).toBe(PathKey.EMPTY);
       expect(result.value).toBe(value);
     });
 
     test('finds an already-added wildcard, when a matching non-wildcard key is passed', () => {
-      const key1  = new TreePathKey(['one', 'two'], true);
-      const key2  = new TreePathKey(['one', 'two'], false);
-      const key3  = new TreePathKey(['one', 'two', 'three'], false);
+      const key1  = new PathKey(['one', 'two'], true);
+      const key2  = new PathKey(['one', 'two'], false);
+      const key3  = new PathKey(['one', 'two', 'three'], false);
       const value = ['boop'];
       const map   = new TreePathMap();
 
@@ -321,7 +321,7 @@ describe('find()', () => {
       const result1 = map.find(key2);
       expect(result1).not.toBeNull();
       expect(result1.key).toBe(key1);
-      expect(result1.keyRemainder).toBe(TreePathKey.EMPTY);
+      expect(result1.keyRemainder).toBe(PathKey.EMPTY);
       expect(result1.value).toBe(value);
 
       const result2 = map.find(key3);
@@ -333,8 +333,8 @@ describe('find()', () => {
     });
 
     test('finds a wildcard binding at the exact key', () => {
-      const key1  = new TreePathKey(['i', 'love', 'muffins'], true);
-      const key2  = new TreePathKey(['i', 'love', 'muffins'], false);
+      const key1  = new PathKey(['i', 'love', 'muffins'], true);
+      const key2  = new PathKey(['i', 'love', 'muffins'], false);
       const value = ['blueberry'];
       const map   = new TreePathMap();
 
@@ -349,9 +349,9 @@ describe('find()', () => {
     });
 
     test('finds a wildcard binding "below" the key being looked up', () => {
-      const key1  = new TreePathKey(['top'], true);
-      const key2  = new TreePathKey(['top', 'middle'], false);
-      const key3  = new TreePathKey(['top', 'middle', 'bottom'], false);
+      const key1  = new PathKey(['top'], true);
+      const key2  = new PathKey(['top', 'middle'], false);
+      const key3  = new PathKey(['top', 'middle', 'bottom'], false);
       const value = ['florp'];
       const map   = new TreePathMap();
 
@@ -367,9 +367,9 @@ describe('find()', () => {
     });
 
     test('finds the most specific wildcard binding "below" the key being looked up', () => {
-      const key1  = new TreePathKey(['top'], true);
-      const key2  = new TreePathKey(['top', 'middle'], true);
-      const key3  = new TreePathKey(['top', 'middle', 'bottom'], false);
+      const key1  = new PathKey(['top'], true);
+      const key2  = new PathKey(['top', 'middle'], true);
+      const key3  = new PathKey(['top', 'middle', 'bottom'], false);
       const value = ['florp', 'like'];
       const map   = new TreePathMap();
 
@@ -385,9 +385,9 @@ describe('find()', () => {
     });
 
     test('does not find a non-wildcard binding "below" the key being looked up', () => {
-      const key1 = new TreePathKey(['top'], false);
-      const key2 = new TreePathKey(['top', 'middle'], false);
-      const key3 = new TreePathKey(['top', 'middle', 'bottom'], false);
+      const key1 = new PathKey(['top'], false);
+      const key2 = new PathKey(['top', 'middle'], false);
+      const key3 = new PathKey(['top', 'middle', 'bottom'], false);
       const map  = new TreePathMap();
 
       map.add(key1, 'x');
@@ -399,9 +399,9 @@ describe('find()', () => {
   });
 
   describe('given a wildcard key', () => {
-    test('finds an already-added wildcard, when a matching key is passed as a `TreePathKey`', () => {
-      const key1  = new TreePathKey(['one', 'two'], true);
-      const key2  = new TreePathKey(['one', 'two', 'three'], true);
+    test('finds an already-added wildcard, when a matching key is passed as a `PathKey`', () => {
+      const key1  = new PathKey(['one', 'two'], true);
+      const key2  = new PathKey(['one', 'two', 'three'], true);
       const value = ['boop'];
       const map   = new TreePathMap();
 
@@ -410,7 +410,7 @@ describe('find()', () => {
       const result1 = map.find(key1);
       expect(result1).not.toBeNull();
       expect(result1.key).toBe(key1);
-      expect(result1.keyRemainder).toBe(TreePathKey.EMPTY);
+      expect(result1.keyRemainder).toBe(PathKey.EMPTY);
       expect(result1.value).toBe(value);
 
       const result2 = map.find(key2);
@@ -422,7 +422,7 @@ describe('find()', () => {
     });
 
     test('finds an already-added wildcard, when a matching key is passed as a plain object', () => {
-      const key1  = new TreePathKey(['a', 'b', 'c'], true);
+      const key1  = new PathKey(['a', 'b', 'c'], true);
       const value = ['boop'];
       const map   = new TreePathMap();
 
@@ -431,14 +431,14 @@ describe('find()', () => {
       const result = map.find({ path: ['a', 'b', 'c'], wildcard: true });
       expect(result).not.toBeNull();
       expect(result.key).toBe(key1);
-      expect(result.keyRemainder).toBe(TreePathKey.EMPTY);
+      expect(result.keyRemainder).toBe(PathKey.EMPTY);
       expect(result.value).toBe(value);
     });
 
     test('does not find a non-wildcard binding "below" the key being looked up', () => {
-      const key1 = new TreePathKey(['top'], false);
-      const key2 = new TreePathKey(['top', 'middle'], false);
-      const key3 = new TreePathKey(['top', 'middle', 'bottom'], true);
+      const key1 = new PathKey(['top'], false);
+      const key2 = new PathKey(['top', 'middle'], false);
+      const key3 = new PathKey(['top', 'middle', 'bottom'], true);
       const map  = new TreePathMap();
 
       map.add(key1, 'x');
@@ -449,9 +449,9 @@ describe('find()', () => {
     });
 
     test('finds a wildcard binding "below" the key being looked up', () => {
-      const key1  = new TreePathKey(['top'], true);
-      const key2  = new TreePathKey(['top', 'middle'], false);
-      const key3  = new TreePathKey(['top', 'middle', 'bottom'], true);
+      const key1  = new PathKey(['top'], true);
+      const key2  = new PathKey(['top', 'middle'], false);
+      const key3  = new PathKey(['top', 'middle', 'bottom'], true);
       const value = { beep: 'boop' };
       const map   = new TreePathMap();
 
@@ -467,9 +467,9 @@ describe('find()', () => {
     });
 
     test('finds the most-specific wildcard binding "below" the key being looked up', () => {
-      const key1  = new TreePathKey(['top'], true);
-      const key2  = new TreePathKey(['top', 'middle'], true);
-      const key3  = new TreePathKey(['top', 'middle', 'bottom'], true);
+      const key1  = new PathKey(['top'], true);
+      const key2  = new PathKey(['top', 'middle'], true);
+      const key3  = new PathKey(['top', 'middle', 'bottom'], true);
       const value = { zeep: 'zoop' };
       const map   = new TreePathMap();
 
@@ -485,8 +485,8 @@ describe('find()', () => {
     });
 
     test('does not find a non-wildcard, when a would-match wildcard key is passed', () => {
-      const key1  = new TreePathKey(['one', 'two'], false);
-      const key2  = new TreePathKey(['one', 'two'], true);
+      const key1  = new PathKey(['one', 'two'], false);
+      const key2  = new PathKey(['one', 'two'], true);
       const value = ['beep'];
       const map   = new TreePathMap();
 
@@ -505,8 +505,8 @@ describe('find()', () => {
       [[]],
       [{}]
     ])('for %p', (value) => {
-      const key1 = new TreePathKey(['a'], true);
-      const key2 = new TreePathKey(['a'], false);
+      const key1 = new PathKey(['a'], true);
+      const key2 = new PathKey(['a'], false);
 
       test('finds it when bound to a wildcard', () => {
         const map = new TreePathMap();
@@ -535,10 +535,10 @@ describe('find()', () => {
   });
 
   test('does not produce a `next` even with multiple matches', () => {
-    const key1 = new TreePathKey([], true);
-    const key2 = new TreePathKey(['x'], true);
-    const key3 = new TreePathKey(['x', 'y'], true);
-    const key4 = new TreePathKey(['x', 'y'], false);
+    const key1 = new PathKey([], true);
+    const key2 = new PathKey(['x'], true);
+    const key3 = new PathKey(['x', 'y'], true);
+    const key4 = new PathKey(['x', 'y'], false);
 
     const map = new TreePathMap();
     map.add(key1, 'a');
@@ -557,7 +557,7 @@ describe('find()', () => {
 describe('findSubtree()', () => {
   test('returns an instance with the same `keyStringFunc`.', () => {
     const ksf    = () => 'florp';
-    const key    = new TreePathKey(['x'], true);
+    const key    = new PathKey(['x'], true);
     const map    = new TreePathMap(ksf);
     const result = map.findSubtree(key);
 
@@ -565,7 +565,7 @@ describe('findSubtree()', () => {
   });
 
   describe('given an empty-path wildcard key', () => {
-    const key = new TreePathKey([], true);
+    const key = new PathKey([], true);
 
     test('returns an empty (but different object) result if there are no bindings', () => {
       const map    = new TreePathMap();
@@ -575,7 +575,7 @@ describe('findSubtree()', () => {
     });
 
     test('returns a single top-level non-wildcard binding, if that is what is in the map', () => {
-      const key1   = new TreePathKey([], false);
+      const key1   = new PathKey([], false);
       const value1 = ['a value'];
       const map    = new TreePathMap();
 
@@ -597,7 +597,7 @@ describe('findSubtree()', () => {
 
     test('returns both wildcard and non-wildcard top-level bindings, if that is what is in the map', () => {
       const value1 = ['first value'];
-      const key2  = new TreePathKey([], false);
+      const key2  = new PathKey([], false);
       const value2 = ['second value'];
       const map    = new TreePathMap();
 
@@ -612,16 +612,16 @@ describe('findSubtree()', () => {
     test('returns all bindings in the map (but in a different object), generally', () => {
       // This is a "smokey" test.
       const bindings = new Map([
-        [new TreePathKey([], false), 'one'],
-        [new TreePathKey(['x'], false), 'two'],
-        [new TreePathKey(['x'], true), 'three'],
-        [new TreePathKey(['x', 'y'], true), 'four'],
-        [new TreePathKey(['x', 'y', 'z'], false), 'five'],
-        [new TreePathKey(['a'], true), 'six'],
-        [new TreePathKey(['a', 'b'], true), 'seven'],
-        [new TreePathKey(['a', 'b', 'c'], false), 'eight'],
-        [new TreePathKey(['a', 'b', 'cc'], false), 'nine'],
-        [new TreePathKey(['a', 'b', 'cc', 'd'], true), 'ten']
+        [new PathKey([], false), 'one'],
+        [new PathKey(['x'], false), 'two'],
+        [new PathKey(['x'], true), 'three'],
+        [new PathKey(['x', 'y'], true), 'four'],
+        [new PathKey(['x', 'y', 'z'], false), 'five'],
+        [new PathKey(['a'], true), 'six'],
+        [new PathKey(['a', 'b'], true), 'seven'],
+        [new PathKey(['a', 'b', 'c'], false), 'eight'],
+        [new PathKey(['a', 'b', 'cc'], false), 'nine'],
+        [new PathKey(['a', 'b', 'cc', 'd'], true), 'ten']
       ]);
       const map = new TreePathMap();
 
@@ -640,7 +640,7 @@ describe('findSubtree()', () => {
   });
 
   test('finds an exact non-wildcard match, given a non-wildcard key', () => {
-    const key   = new TreePathKey(['1', '2'], false);
+    const key   = new PathKey(['1', '2'], false);
     const value = 'value';
     const map   = new TreePathMap();
 
@@ -651,8 +651,8 @@ describe('findSubtree()', () => {
   });
 
   test('finds an exact wildcard match, given a non-wildcard key', () => {
-    const key1  = new TreePathKey(['1', '2'], true);
-    const key2  = new TreePathKey(['1', '2'], false);
+    const key1  = new PathKey(['1', '2'], true);
+    const key2  = new PathKey(['1', '2'], false);
     const value = 'some-value';
     const map   = new TreePathMap();
 
@@ -663,8 +663,8 @@ describe('findSubtree()', () => {
   });
 
   test('finds a wildcard match, given a non-wildcard key', () => {
-    const key1  = new TreePathKey(['1', '2'], true);
-    const key2  = new TreePathKey(['1', '2', '3', '4'], false);
+    const key1  = new PathKey(['1', '2'], true);
+    const key2  = new PathKey(['1', '2', '3', '4'], false);
     const value = 'some-other-value';
     const map   = new TreePathMap();
 
@@ -676,28 +676,28 @@ describe('findSubtree()', () => {
 
   test('extracts a subtree, given a wildcard key', () => {
     // This is a "smokey" test.
-    const key      = new TreePathKey(['in', 'here'], true);
+    const key      = new PathKey(['in', 'here'], true);
     const bindings = new Map([
-      [new TreePathKey(['in', 'here'], false), 'one'],
-      [new TreePathKey(['in', 'here'], true), 'two'],
-      [new TreePathKey(['in', 'here', 'x'], true), 'three'],
-      [new TreePathKey(['in', 'here', 'x', 'y'], false), 'four'],
-      [new TreePathKey(['in', 'here', 'a', 'b', 'c'], false), 'five'],
-      [new TreePathKey(['in', 'here', 'a', 'b'], true), 'six'],
-      [new TreePathKey(['in', 'here', 'a', 'x', 'y'], false), 'seven'],
-      [new TreePathKey(['in', 'here', 'a', 'z'], true), 'eight']
+      [new PathKey(['in', 'here'], false), 'one'],
+      [new PathKey(['in', 'here'], true), 'two'],
+      [new PathKey(['in', 'here', 'x'], true), 'three'],
+      [new PathKey(['in', 'here', 'x', 'y'], false), 'four'],
+      [new PathKey(['in', 'here', 'a', 'b', 'c'], false), 'five'],
+      [new PathKey(['in', 'here', 'a', 'b'], true), 'six'],
+      [new PathKey(['in', 'here', 'a', 'x', 'y'], false), 'seven'],
+      [new PathKey(['in', 'here', 'a', 'z'], true), 'eight']
     ]);
     const extraBindings = new Map([
-      [new TreePathKey([], false), 'one'],
-      [new TreePathKey(['x'], false), 'two'],
-      [new TreePathKey(['x'], true), 'three'],
-      [new TreePathKey(['x', 'y'], true), 'four'],
-      [new TreePathKey(['x', 'y', 'z'], false), 'five'],
-      [new TreePathKey(['a'], true), 'six'],
-      [new TreePathKey(['a', 'b'], true), 'seven'],
-      [new TreePathKey(['a', 'b', 'c'], false), 'eight'],
-      [new TreePathKey(['a', 'b', 'cc'], false), 'nine'],
-      [new TreePathKey(['a', 'b', 'cc', 'd'], true), 'ten']
+      [new PathKey([], false), 'one'],
+      [new PathKey(['x'], false), 'two'],
+      [new PathKey(['x'], true), 'three'],
+      [new PathKey(['x', 'y'], true), 'four'],
+      [new PathKey(['x', 'y', 'z'], false), 'five'],
+      [new PathKey(['a'], true), 'six'],
+      [new PathKey(['a', 'b'], true), 'seven'],
+      [new PathKey(['a', 'b', 'c'], false), 'eight'],
+      [new PathKey(['a', 'b', 'cc'], false), 'nine'],
+      [new PathKey(['a', 'b', 'cc', 'd'], true), 'ten']
     ]);
     const map = new TreePathMap();
 
@@ -716,10 +716,10 @@ describe('findSubtree()', () => {
 
 describe('findWithFallback()', () => {
   test('finds multiple matches in the expected order', () => {
-    const key1 = new TreePathKey([], true);
-    const key2 = new TreePathKey(['x'], true);
-    const key3 = new TreePathKey(['x', 'y'], true);
-    const key4 = new TreePathKey(['x', 'y'], false);
+    const key1 = new PathKey([], true);
+    const key2 = new PathKey(['x'], true);
+    const key3 = new PathKey(['x', 'y'], true);
+    const key4 = new PathKey(['x', 'y'], false);
 
     const map = new TreePathMap();
     map.add(key1, 'a');
@@ -748,10 +748,10 @@ describe('findWithFallback()', () => {
   });
 
   test('correctly finds a single match', () => {
-    const key1 = new TreePathKey([], false);
-    const key2 = new TreePathKey(['x'], false);
-    const key3 = new TreePathKey(['x', 'y'], false);
-    const key4 = new TreePathKey(['x', 'y', 'z'], false);
+    const key1 = new PathKey([], false);
+    const key2 = new PathKey(['x'], false);
+    const key3 = new PathKey(['x', 'y'], false);
+    const key4 = new PathKey(['x', 'y', 'z'], false);
 
     const map = new TreePathMap();
     map.add(key1, 'a');
@@ -768,9 +768,9 @@ describe('findWithFallback()', () => {
   });
 
   test('returns an immediately `done` generator if there is no match', () => {
-    const key1 = new TreePathKey([], false);
-    const key2 = new TreePathKey(['x'], false);
-    const key3 = new TreePathKey(['x', 'y'], false);
+    const key1 = new PathKey([], false);
+    const key2 = new PathKey(['x'], false);
+    const key3 = new PathKey(['x', 'y'], false);
 
     const map = new TreePathMap();
     map.add(key1, 'a');
@@ -783,9 +783,9 @@ describe('findWithFallback()', () => {
   });
 
   test('does not find a non-wildcard prefix match', () => {
-    const key1 = new TreePathKey([], true);
-    const key2 = new TreePathKey(['x'], false);
-    const key3 = new TreePathKey(['x', 'y'], true);
+    const key1 = new PathKey([], true);
+    const key2 = new PathKey(['x'], false);
+    const key3 = new PathKey(['x', 'y'], true);
 
     const map = new TreePathMap();
     map.add(key1, 'a');
@@ -829,9 +829,9 @@ ${'has'}   | ${true}
     }
   }
 
-  test('finds an already-added key, when passed as a `TreePathKey`', () => {
-    const key1  = new TreePathKey(['1', '2', '3'], false);
-    const key2  = new TreePathKey(['1', '2', '3'], false);
+  test('finds an already-added key, when passed as a `PathKey`', () => {
+    const key1  = new PathKey(['1', '2', '3'], false);
+    const key2  = new PathKey(['1', '2', '3'], false);
     const value = ['yes', 'a value'];
     const map   = new TreePathMap();
 
@@ -852,8 +852,8 @@ ${'has'}   | ${true}
   });
 
   test('does not find an added wildcard key, when passed a non-wildcard', () => {
-    const key1  = new TreePathKey(['1'], true);
-    const key2  = new TreePathKey(['1'], false);
+    const key1  = new PathKey(['1'], true);
+    const key2  = new PathKey(['1'], false);
     const value = ['yo there'];
     const map   = new TreePathMap();
 
@@ -862,8 +862,8 @@ ${'has'}   | ${true}
   });
 
   test('does not find an added non-wildcard key, when passed a wildcard', () => {
-    const key1  = new TreePathKey(['1'], true);
-    const key2  = new TreePathKey(['1'], false);
+    const key1  = new PathKey(['1'], true);
+    const key2  = new PathKey(['1'], false);
     const value = ['yo there'];
     const map   = new TreePathMap();
 
@@ -881,7 +881,7 @@ describe('get()', () => {
   test('returns the `ifNotFound` value when a key is not found', () => {
     const map   = new TreePathMap();
     const value = ['whatever'];
-    expect(map.get(new TreePathKey([], true), value)).toBe(value);
+    expect(map.get(new PathKey([], true), value)).toBe(value);
   });
 
   describe('nullish values', () => {
@@ -898,7 +898,7 @@ describe('get()', () => {
 
       test('finds it when bound to a wildcard', () => {
         const map = new TreePathMap();
-        const key = new TreePathKey(['abc'], true);
+        const key = new PathKey(['abc'], true);
 
         map.add(key, value);
 
@@ -908,7 +908,7 @@ describe('get()', () => {
 
       test('finds it when bound to a non-wildcard', () => {
         const map = new TreePathMap();
-        const key = new TreePathKey(['abc'], false);
+        const key = new PathKey(['abc'], false);
 
         map.add(key, value);
 
@@ -932,7 +932,7 @@ describe('has()', () => {
     ])('for %p', (value) => {
       test('finds it when bound to a wildcard', () => {
         const map = new TreePathMap();
-        const key = new TreePathKey(['abc'], true);
+        const key = new PathKey(['abc'], true);
 
         map.add(key, value);
 
@@ -942,7 +942,7 @@ describe('has()', () => {
 
       test('finds it when bound to a non-wildcard', () => {
         const map = new TreePathMap();
-        const key = new TreePathKey(['abc'], false);
+        const key = new PathKey(['abc'], false);
 
         map.add(key, value);
 
@@ -957,11 +957,11 @@ describe('stringFromKey()', () => {
   test('uses the default function when not specified in the constructor', () => {
     const map = new TreePathMap();
 
-    const key1 = new TreePathKey([], true);
+    const key1 = new PathKey([], true);
     const s1   = map.stringFromKey(key1);
     expect(s1).toBe(key1.toString());
 
-    const key2 = new TreePathKey(['foo', 'bar'], false);
+    const key2 = new PathKey(['foo', 'bar'], false);
     const s2   = map.stringFromKey(key2);
     expect(s2).toBe(key2.toString());
   });
@@ -969,11 +969,11 @@ describe('stringFromKey()', () => {
   test('uses the default function when `null` was specified in the constructor', () => {
     const map = new TreePathMap(null);
 
-    const key1 = new TreePathKey(['x', 'y', 'zonk'], true);
+    const key1 = new PathKey(['x', 'y', 'zonk'], true);
     const s1   = map.stringFromKey(key1);
     expect(s1).toBe(key1.toString());
 
-    const key2 = new TreePathKey(['florp'], false);
+    const key2 = new PathKey(['florp'], false);
     const s2   = map.stringFromKey(key2);
     expect(s2).toBe(key2.toString());
   });
@@ -985,8 +985,8 @@ describe('stringFromKey()', () => {
       return `yes-${gotArgs.length}`;
     };
 
-    const key1 = new TreePathKey(['x'], true);
-    const key2 = new TreePathKey(['y'], false);
+    const key1 = new PathKey(['x'], true);
+    const key2 = new PathKey(['y'], false);
     const map = new TreePathMap(theFunc);
 
     const s1 = map.stringFromKey(key1);

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { IntfLogger } from '@this/loggy-intf';
 import { AskIf, Methods, MustBe } from '@this/typey';
 
@@ -170,7 +170,7 @@ export class BaseComponent {
   }
 
   /**
-   * @returns {?TreePathKey} The absolute name-path of this instance, that is,
+   * @returns {?PathKey} The absolute name-path of this instance, that is,
    * where it is located in the hierarchy from its root component, or `null` if
    * this instance is not currently attached to a hierarchy.
    */

--- a/src/compy/export/ControlContext.js
+++ b/src/compy/export/ControlContext.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Condition } from '@this/async';
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { IntfLogger } from '@this/loggy-intf';
 import { MustBe } from '@this/typey';
 
@@ -65,7 +65,7 @@ export class ControlContext {
    * Name-path of this instance, that is, a key which indicates where this
    * instance is in the component hierarchy.
    *
-   * @type {TreePathKey}
+   * @type {PathKey}
    */
   #namePath;
 
@@ -98,7 +98,7 @@ export class ControlContext {
       this.#associate = null; // Gets set in `linkRoot()`.
       this.#parent    = null; // This will remain `null` forever.
       this.#root      = this;
-      this.#namePath  = TreePathKey.EMPTY;
+      this.#namePath  = PathKey.EMPTY;
       // Note: We can't add to `#root.contextTree` here, because we're still in
       // the middle of constructing `#root`. That gets fixed in `linkRoot()`,
       // which gets called soon after this instance is constructed.
@@ -134,7 +134,7 @@ export class ControlContext {
   }
 
   /**
-   * @returns {TreePathKey} The absolute name-path of this instance, that is,
+   * @returns {PathKey} The absolute name-path of this instance, that is,
    * where it is located in the hierarchy from its root component.
    */
   get namePath() {
@@ -200,7 +200,7 @@ export class ControlContext {
    * Gets a the component at the given path from the root of this instance,
    * which optionally must be of a specific class (including a base class).
    *
-   * @param {Array<string>|TreePathKey|string} path Absolute path to the
+   * @param {Array<string>|PathKey|string} path Absolute path to the
    *   component. If a string, must be parseable as a path by {@link
    *   Names#parsePath}.
    * @param {...function(new:BaseComponent)} [classes] List of classes and/or
@@ -230,7 +230,7 @@ export class ControlContext {
    * If there _is_ a component at the path but its class doesn't match, that's
    * still an error.
    *
-   * @param {?Array<string>|TreePathKey|string} path Absolute path to the
+   * @param {?Array<string>|PathKey|string} path Absolute path to the
    *   component, or `null`-ish to always not-find an instance. If a string,
    *   must be parseable as a path by {@link Names#parsePath}.
    * @param {...function(new:BaseComponent)} [classes] List of classes and/or
@@ -301,7 +301,7 @@ export class ControlContext {
    * synthesize one based on its class.
    *
    * @param {BaseComponent} component The will-be child component.
-   * @returns {TreePathKey} The key to use for it.
+   * @returns {PathKey} The key to use for it.
    */
   #pathKeyForChild(component) {
     const { name } = component;

--- a/src/compy/export/ControlContext.js
+++ b/src/compy/export/ControlContext.js
@@ -185,7 +185,7 @@ export class ControlContext {
     const wantLength = thisKey.length + 1;
 
     // TODO: Perhaps this can be made more efficient by adding a just-children
-    // iterator to `TreePathMap`.
+    // iterator to `TreeMap`.
 
     for (const [key, context] of ctxTree.findSubtree(matchKey)) {
       // The test is to ensure we only yield values for exactly one layer of

--- a/src/compy/export/ControlContext.js
+++ b/src/compy/export/ControlContext.js
@@ -200,9 +200,8 @@ export class ControlContext {
    * Gets a the component at the given path from the root of this instance,
    * which optionally must be of a specific class (including a base class).
    *
-   * @param {Array<string>|PathKey|string} path Absolute path to the
-   *   component. If a string, must be parseable as a path by {@link
-   *   Names#parsePath}.
+   * @param {Array<string>|PathKey|string} path Absolute path to the component.
+   *   If a string, must be parseable as a path by {@link Names#parsePath}.
    * @param {...function(new:BaseComponent)} [classes] List of classes and/or
    *   interfaces which the result must be an instance of or implement
    *   (respectively).
@@ -230,9 +229,9 @@ export class ControlContext {
    * If there _is_ a component at the path but its class doesn't match, that's
    * still an error.
    *
-   * @param {?Array<string>|PathKey|string} path Absolute path to the
-   *   component, or `null`-ish to always not-find an instance. If a string,
-   *   must be parseable as a path by {@link Names#parsePath}.
+   * @param {?Array<string>|PathKey|string} path Absolute path to the component,
+   *   or `null`-ish to always not-find an instance. If a string, must be
+   *   parseable as a path by {@link Names#parsePath}.
    * @param {...function(new:BaseComponent)} [classes] List of classes and/or
    *   interfaces which the result must be an instance of or implement
    *   (respectively).

--- a/src/compy/export/Names.js
+++ b/src/compy/export/Names.js
@@ -49,8 +49,8 @@ export class Names {
   /**
    * Parses an absolute component path into a key. This accepts all of:
    *
-   * * a `PathKey` -- Returned directly if not a wildcard, otherwise returns
-   *   the non-wildcard version. Elements are checked for validity.
+   * * a `PathKey` -- Returned directly if not a wildcard, otherwise returns the
+   *   non-wildcard version. Elements are checked for validity.
    * * an array of strings -- Contructed into a non-wildcard-key, with elements
    *   checked for validity.
    * * a string -- Parsed as a slash--separated list of elements, which must

--- a/src/compy/export/Names.js
+++ b/src/compy/export/Names.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { MustBe } from '@this/typey';
 
 
@@ -49,19 +49,19 @@ export class Names {
   /**
    * Parses an absolute component path into a key. This accepts all of:
    *
-   * * a `TreePathKey` -- Returned directly if not a wildcard, otherwise returns
+   * * a `PathKey` -- Returned directly if not a wildcard, otherwise returns
    *   the non-wildcard version. Elements are checked for validity.
    * * an array of strings -- Contructed into a non-wildcard-key, with elements
    *   checked for validity.
    * * a string -- Parsed as a slash--separated list of elements, which must
    *   begin with a slash. Elements are checked for validity.
    *
-   * @param {string|Array<string>|TreePathKey} path The absolute path to parse.
-   * @returns {TreePathKey} The parsed path.
+   * @param {string|Array<string>|PathKey} path The absolute path to parse.
+   * @returns {PathKey} The parsed path.
    */
   static parsePath(path) {
     if (Array.isArray(path)) {
-      path = new TreePathKey(path, false);
+      path = new PathKey(path, false);
     } else if (typeof path === 'string') {
       const elements = path.split('/');
       const len      = elements.length;
@@ -70,12 +70,12 @@ export class Names {
         throw new Error(`Not an absolute component path: ${path}`);
       }
 
-      // Drop the initial empty element, and freeze so `TreePathKey` can avoid
+      // Drop the initial empty element, and freeze so `PathKey` can avoid
       // making a copy.
       Object.freeze(elements.pop());
 
-      path = new TreePathKey(elements, false);
-    } else if (!(path instanceof TreePathKey)) {
+      path = new PathKey(elements, false);
+    } else if (!(path instanceof PathKey)) {
       throw new Error(`Not an absolute component path: ${path}`);
     }
 
@@ -93,8 +93,8 @@ export class Names {
    * the method to return `null`. Other invalid inputs still cause an error to
    * be thrown.
    *
-   * @param {?string|Array<string>|TreePathKey} path The absolute path to parse.
-   * @returns {?TreePathKey} The parsed path, or `null`.
+   * @param {?string|Array<string>|PathKey} path The absolute path to parse.
+   * @returns {?PathKey} The parsed path, or `null`.
    */
   static parsePathOrNull(path) {
     if ((path === null) || (path === undefined)) {
@@ -108,11 +108,11 @@ export class Names {
    * Returns the string form of an absolute name path key. That is, this is the
    * reverse of {@link #parsePath}.
    *
-   * @param {TreePathKey} key The absolute path key.
+   * @param {PathKey} key The absolute path key.
    * @returns {string} The string form.
    */
   static pathStringFrom(key) {
-    MustBe.instanceOf(key, TreePathKey);
+    MustBe.instanceOf(key, PathKey);
 
     return key.toString({
       prefix:    '/',

--- a/src/compy/export/RootControlContext.js
+++ b/src/compy/export/RootControlContext.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathMap } from '@this/collections';
+import { TreeMap } from '@this/collections';
 import { IntfLogger } from '@this/loggy-intf';
 
 import { ControlContext } from '#x/ControlContext';
@@ -25,9 +25,9 @@ export class RootControlContext extends ControlContext {
   /**
    * Tree which maps each component path to its context instance.
    *
-   * @type {TreePathMap<ControlContext>}
+   * @type {TreeMap<ControlContext>}
    */
-  #contextTree = new TreePathMap();
+  #contextTree = new TreeMap();
 
   /**
    * Constructs an instance. It initially has no `associate`.
@@ -50,7 +50,7 @@ export class RootControlContext extends ControlContext {
   }
 
   /**
-   * @returns {TreePathMap} The full tree of all descendant contexts.
+   * @returns {TreeMap} The full tree of all descendant contexts.
    */
   get [ThisModule.SYM_contextTree]() {
     return this.#contextTree;

--- a/src/host/export/BaseSystem.js
+++ b/src/host/export/BaseSystem.js
@@ -40,8 +40,8 @@ export class BaseSystem extends BaseComponent {
   #thread = new Threadlet((runnerAccess) => this.#runThread(runnerAccess));
 
   /**
-   * Current root component being managed. This is a return value from
-   * {@link #_impl_makeHierarchy}.
+   * Current root component being managed. This is a return value from {@link
+   * #_impl_makeHierarchy}.
    *
    * @type {BaseComponent}
    */

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -35,12 +35,12 @@ export class DispatchInfo {
   /**
    * Constructs an instance.
    *
-   * @param {PathKey} base The base path (that is, the path prefix) to which
-   *   the request is being dispatched. This is expected to already have `.` and
+   * @param {PathKey} base The base path (that is, the path prefix) to which the
+   *   request is being dispatched. This is expected to already have `.` and
    *   `..` components resolved away.
-   * @param {PathKey} extra The remaining suffix portion of the original
-   *   path, after removing `base`. This is expected to already have `.` and
-   *   `..` components resolved away.
+   * @param {PathKey} extra The remaining suffix portion of the original path,
+   *   after removing `base`. This is expected to already have `.` and `..`
+   *   components resolved away.
    */
   constructor(base, extra) {
     this.#base  = MustBe.instanceOf(base, PathKey);

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { BaseConverter, Struct } from '@this/data-values';
 import { MustBe } from '@this/typey';
 
@@ -21,30 +21,30 @@ export class DispatchInfo {
   /**
    * The base path.
    *
-   * @type {TreePathKey}
+   * @type {PathKey}
    */
   #base;
 
   /**
    * The remaining suffix portion of the path.
    *
-   * @type {TreePathKey}
+   * @type {PathKey}
    */
   #extra;
 
   /**
    * Constructs an instance.
    *
-   * @param {TreePathKey} base The base path (that is, the path prefix) to which
+   * @param {PathKey} base The base path (that is, the path prefix) to which
    *   the request is being dispatched. This is expected to already have `.` and
    *   `..` components resolved away.
-   * @param {TreePathKey} extra The remaining suffix portion of the original
+   * @param {PathKey} extra The remaining suffix portion of the original
    *   path, after removing `base`. This is expected to already have `.` and
    *   `..` components resolved away.
    */
   constructor(base, extra) {
-    this.#base  = MustBe.instanceOf(base, TreePathKey);
-    this.#extra = MustBe.instanceOf(extra, TreePathKey);
+    this.#base  = MustBe.instanceOf(base, PathKey);
+    this.#extra = MustBe.instanceOf(extra, PathKey);
   }
 
   /**
@@ -58,7 +58,7 @@ export class DispatchInfo {
   }
 
   /**
-   * @returns {TreePathKey} The base path (that is, the path prefix) to which
+   * @returns {PathKey} The base path (that is, the path prefix) to which
    * the request is being dispatched.
    */
   get base() {
@@ -66,7 +66,7 @@ export class DispatchInfo {
   }
 
   /**
-   * @returns {TreePathKey} The remaining suffix portion of the path, after
+   * @returns {PathKey} The remaining suffix portion of the path, after
    * removing {@link #base}.
    */
   get extra() {

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { AskIf, MustBe } from '@this/typey';
 
 import { HostUtil } from '#x/HostUtil';
@@ -43,7 +43,7 @@ export class HostInfo {
   /**
    * A path key representing {@link #nameString}.
    *
-   * @type {?TreePathKey}
+   * @type {?PathKey}
    */
   #nameKey = null;
 
@@ -71,7 +71,7 @@ export class HostInfo {
   }
 
   /**
-   * @returns {TreePathKey} A path key representing the {@link #nameString},
+   * @returns {PathKey} A path key representing the {@link #nameString},
    * parsed into components. The order of components is back-to-front (reverse
    * order from how it's written). If the hostname is actually a numeric IP
    * address, then the key just has that address as a single-component.
@@ -82,8 +82,8 @@ export class HostInfo {
         ? [this.#nameString]
         : this.#nameString.split('.').reverse();
 
-      // Freezing `parts` lets `new TreePathKey()` avoid making a copy.
-      this.#nameKey = new TreePathKey(Object.freeze(parts), false);
+      // Freezing `parts` lets `new PathKey()` avoid making a copy.
+      this.#nameKey = new PathKey(Object.freeze(parts), false);
     }
 
     return this.#nameKey;

--- a/src/net-util/export/HostUtil.js
+++ b/src/net-util/export/HostUtil.js
@@ -319,9 +319,9 @@ export class HostUtil {
   }
 
   /**
-   * Gets the string form of a {@link PathKey}, interpreted as a hostname,
-   * where the TLD is the initial path component. That is, the result renders
-   * the key in reverse.
+   * Gets the string form of a {@link PathKey}, interpreted as a hostname, where
+   * the TLD is the initial path component. That is, the result renders the key
+   * in reverse.
    *
    * @param {PathKey} key The key to convert.
    * @returns {string} The hostname string form.
@@ -338,9 +338,9 @@ export class HostUtil {
   }
 
   /**
-   * Parses a possibly-wildcarded hostname into a {@link PathKey}. This
-   * accepts both DNS names and IP addresses. In the case of an IP address, the
-   * result is a single-component path key.
+   * Parses a possibly-wildcarded hostname into a {@link PathKey}. This accepts
+   * both DNS names and IP addresses. In the case of an IP address, the result
+   * is a single-component path key.
    *
    * **Note:** Because hostname hierarchy is from right-to-left (e.g., wildcards
    * are at the front of a hostname not the back), the `.path` of the result

--- a/src/net-util/export/HostUtil.js
+++ b/src/net-util/export/HostUtil.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { AskIf, MustBe } from '@this/typey';
 
 
@@ -319,15 +319,15 @@ export class HostUtil {
   }
 
   /**
-   * Gets the string form of a {@link TreePathKey}, interpreted as a hostname,
+   * Gets the string form of a {@link PathKey}, interpreted as a hostname,
    * where the TLD is the initial path component. That is, the result renders
    * the key in reverse.
    *
-   * @param {TreePathKey} key The key to convert.
+   * @param {PathKey} key The key to convert.
    * @returns {string} The hostname string form.
    */
   static hostnameStringFrom(key) {
-    MustBe.instanceOf(key, TreePathKey);
+    MustBe.instanceOf(key, PathKey);
 
     return key.toString({
       prefix:    '',
@@ -338,7 +338,7 @@ export class HostUtil {
   }
 
   /**
-   * Parses a possibly-wildcarded hostname into a {@link TreePathKey}. This
+   * Parses a possibly-wildcarded hostname into a {@link PathKey}. This
    * accepts both DNS names and IP addresses. In the case of an IP address, the
    * result is a single-component path key.
    *
@@ -348,7 +348,7 @@ export class HostUtil {
    *
    * @param {string} name Hostname to parse.
    * @param {boolean} [allowWildcard] Is a wildcard form allowed for `name`?
-   * @returns {TreePathKey} Parsed key.
+   * @returns {PathKey} Parsed key.
    * @throws {Error} Thrown if `name` is invalid.
    */
   static parseHostname(name, allowWildcard = false) {
@@ -368,7 +368,7 @@ export class HostUtil {
    *
    * @param {string} name Hostname to parse.
    * @param {boolean} [allowWildcard] Is a wildcard form allowed for `name`?
-   * @returns {?TreePathKey} Parsed key, or `null` if `name` is invalid.
+   * @returns {?PathKey} Parsed key, or `null` if `name` is invalid.
    */
   static parseHostnameOrNull(name, allowWildcard = false) {
     MustBe.string(name);
@@ -376,7 +376,7 @@ export class HostUtil {
     // Handle IP address cases.
     const canonicalIp = this.checkIpAddressOrNull(name, false);
     if (canonicalIp) {
-      return new TreePathKey([canonicalIp], false);
+      return new PathKey([canonicalIp], false);
     }
 
     if (!AskIf.string(name, this.#HOSTNAME_PATTERN)) {
@@ -388,12 +388,12 @@ export class HostUtil {
     if (path[path.length - 1] === '*') {
       if (allowWildcard) {
         path.pop();
-        return new TreePathKey(path, true);
+        return new PathKey(path, true);
       } else {
         return null;
       }
     } else {
-      return new TreePathKey(path, false);
+      return new PathKey(path, false);
     }
   }
 

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { FormatUtils, IntfLogger } from '@this/loggy-intf';
 import { MustBe } from '@this/typey';
 
@@ -296,7 +296,7 @@ export class IncomingRequest {
   }
 
   /**
-   * @returns {?TreePathKey} Parsed path key form of {@link #pathnameString}, or
+   * @returns {?PathKey} Parsed path key form of {@link #pathnameString}, or
    * `null` if this instance doesn't represent a usual `origin` request.
    *
    * **Note:** If the original incoming pathname was just `'/'` (e.g., it was
@@ -439,11 +439,11 @@ export class IncomingRequest {
       const pathnameString = (urlObj.pathname === '') ? '/' : urlObj.pathname;
 
       // `slice(1)` to avoid having an empty component as the first element. And
-      // freezing `parts` lets `new TreePathKey()` avoid making a copy.
+      // freezing `parts` lets `new PathKey()` avoid making a copy.
       const pathParts = Object.freeze(pathnameString.slice(1).split('/'));
 
       target.type           = 'origin';
-      target.pathname       = new TreePathKey(pathParts, false);
+      target.pathname       = new PathKey(pathParts, false);
       target.pathnameString = pathnameString;
       target.searchString   = urlObj.search;
     } else if (targetString === '*') {

--- a/src/net-util/export/UriUtil.js
+++ b/src/net-util/export/UriUtil.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { MustBe } from '@this/typey';
 
 
@@ -88,7 +88,7 @@ export class UriUtil {
   }
 
   /**
-   * Gets the string form of a {@link TreePathKey} as a URI path, that is, the
+   * Gets the string form of a {@link PathKey} as a URI path, that is, the
    * part of a URI after the hostname. The result is in absolute form by default
    * (prefixed with `/`), or is optionally in relative form (prefixed with
    * `./`). Empty components are represented as one might expect, with no
@@ -96,13 +96,13 @@ export class UriUtil {
    * path or with a trailing slash for an empty component at the end of the
    * path.
    *
-   * @param {TreePathKey} key The key to convert.
+   * @param {PathKey} key The key to convert.
    * @param {boolean} [relative] Make the result relative (with `./` as the
    *   prefix).
    * @returns {string} The string form.
    */
   static pathStringFrom(key, relative = false) {
-    MustBe.instanceOf(key, TreePathKey);
+    MustBe.instanceOf(key, PathKey);
 
     return key.toString({
       prefix:         relative ? '.' : '/',

--- a/src/net-util/export/UriUtil.js
+++ b/src/net-util/export/UriUtil.js
@@ -88,8 +88,8 @@ export class UriUtil {
   }
 
   /**
-   * Gets the string form of a {@link PathKey} as a URI path, that is, the
-   * part of a URI after the hostname. The result is in absolute form by default
+   * Gets the string form of a {@link PathKey} as a URI path, that is, the part
+   * of a URI after the hostname. The result is in absolute form by default
    * (prefixed with `/`), or is optionally in relative form (prefixed with
    * `./`). Empty components are represented as one might expect, with no
    * characters between two slashes for an empty component in the middle of a

--- a/src/net-util/tests/HostInfo.test.js
+++ b/src/net-util/tests/HostInfo.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { HostInfo } from '@this/net-util';
 
 
@@ -57,7 +57,7 @@ describe('.nameKey', () => {
     const hi  = new HostInfo(name, 123);
     const key = hi.nameKey;
 
-    expect(key).toBeInstanceOf(TreePathKey);
+    expect(key).toBeInstanceOf(PathKey);
     expect(key.wildcard).toBeFalse();
     expect(key.path).toBeArrayOfSize(parts.length);
     expect(key.path).toEqual(parts);

--- a/src/net-util/tests/HostUtil.test.js
+++ b/src/net-util/tests/HostUtil.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { HostUtil } from '@this/net-util';
 
 
@@ -514,7 +514,7 @@ describe('hostnameStringFrom()', () => {
   ${['foo', 'bar', 'baz']} | ${false} | ${'baz.bar.foo'}
   ${['foo', 'bar', 'baz']} | ${true}  | ${'*.baz.bar.foo'}
   `('on { path: $path, wildcard: $wildcard }', ({ path, wildcard, expected }) => {
-    const key    = new TreePathKey(path, wildcard);
+    const key    = new PathKey(path, wildcard);
     const result = HostUtil.hostnameStringFrom(key);
 
     expect(result).toBe(expected);

--- a/src/net-util/tests/UriUtil.test.js
+++ b/src/net-util/tests/UriUtil.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { UriUtil } from '@this/net-util';
 
 
@@ -65,7 +65,7 @@ describe('pathStringFrom()', () => {
     ${['foo', 'bar', 'baz']} | ${false} | ${'/foo/bar/baz'}
     ${['foo', 'bar', 'baz']} | ${true}  | ${'/foo/bar/baz/*'}
     `('on { path: $path, wildcard: $wildcard }', ({ path, wildcard, expected }) => {
-      const key    = new TreePathKey(path, wildcard);
+      const key    = new PathKey(path, wildcard);
       const result = UriUtil.pathStringFrom(key, ...relArg);
 
       if (relArg[0] === true) {

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathMap } from '@this/collections';
+import { TreeMap } from '@this/collections';
 import { Names } from '@this/compy';
 import { HostUtil, IntfRequestHandler } from '@this/net-util';
 import { MustBe } from '@this/typey';
@@ -18,7 +18,7 @@ export class HostRouter extends BaseApplication {
    * BaseApplication}) which should handle that prefix. Gets set in {@link
    * #_impl_start}.
    *
-   * @type {?TreePathMap<IntfRequestHandler>}
+   * @type {?TreeMap<IntfRequestHandler>}
    */
   #routeTree = null;
 
@@ -60,7 +60,7 @@ export class HostRouter extends BaseApplication {
     // that runs.
 
     const appManager = this.root.applicationManager;
-    const routeTree  = new TreePathMap();
+    const routeTree  = new TreeMap();
 
     for (const [host, name] of this.config.routeTree) {
       const app = appManager.get(name);
@@ -93,7 +93,7 @@ export class HostRouter extends BaseApplication {
      * Like the outer `routeTree` except with names instead of handler
      * instances.
      *
-     * @type {TreePathMap<string>}
+     * @type {TreeMap<string>}
      */
     #routeTree;
 
@@ -109,7 +109,7 @@ export class HostRouter extends BaseApplication {
 
       MustBe.plainObject(hosts);
 
-      const routeTree = new TreePathMap();
+      const routeTree = new TreeMap();
 
       for (const [host, name] of Object.entries(hosts)) {
         Names.checkName(name);
@@ -121,7 +121,7 @@ export class HostRouter extends BaseApplication {
     }
 
     /**
-     * @returns {TreePathMap<string>} Like the outer `routeTree` except with
+     * @returns {TreeMap<string>} Like the outer `routeTree` except with
      * names instead of handler instances.
      */
     get routeTree() {

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { PathKey, TreePathMap } from '@this/collections';
+import { PathKey, TreeMap } from '@this/collections';
 import { Names } from '@this/compy';
 import { DispatchInfo, IntfRequestHandler, UriUtil } from '@this/net-util';
 import { MustBe } from '@this/typey';
@@ -19,7 +19,7 @@ export class PathRouter extends BaseApplication {
    * BaseApplication}) which should handle that prefix. Gets set in {@link
    * #_impl_start}.
    *
-   * @type {?TreePathMap<IntfRequestHandler>}
+   * @type {?TreeMap<IntfRequestHandler>}
    */
   #routeTree = null;
 
@@ -66,7 +66,7 @@ export class PathRouter extends BaseApplication {
     // that runs.
 
     const appManager = this.root.applicationManager;
-    const routeTree  = new TreePathMap();
+    const routeTree  = new TreeMap();
 
     for (const [path, name] of this.config.routeTree) {
       const app = appManager.get(name);
@@ -99,7 +99,7 @@ export class PathRouter extends BaseApplication {
      * Like the outer `routeTree` except with names instead of handler
      * instances.
      *
-     * @type {TreePathMap<string>}
+     * @type {TreeMap<string>}
      */
     #routeTree;
 
@@ -115,7 +115,7 @@ export class PathRouter extends BaseApplication {
 
       MustBe.plainObject(paths);
 
-      const routeTree = new TreePathMap();
+      const routeTree = new TreeMap();
 
       for (const [path, name] of Object.entries(paths)) {
         Names.checkName(name);
@@ -127,7 +127,7 @@ export class PathRouter extends BaseApplication {
     }
 
     /**
-     * @returns {TreePathMap<string>} Like the outer `routeTree` except with
+     * @returns {TreeMap<string>} Like the outer `routeTree` except with
      * names instead of handler instances.
      */
     get routeTree() {

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey, TreePathMap } from '@this/collections';
+import { PathKey, TreePathMap } from '@this/collections';
 import { Names } from '@this/compy';
 import { DispatchInfo, IntfRequestHandler, UriUtil } from '@this/net-util';
 import { MustBe } from '@this/typey';
@@ -138,7 +138,7 @@ export class PathRouter extends BaseApplication {
      * Parses a path.
      *
      * @param {string} path The path to parse.
-     * @returns {TreePathKey} The parsed form.
+     * @returns {PathKey} The parsed form.
      */
     static #parsePath(path) {
       const parts = path.split('/');
@@ -195,13 +195,13 @@ export class PathRouter extends BaseApplication {
 
       switch (lastSpecial) {
         case 'directory': {
-          return new TreePathKey([...parts, ''], false);
+          return new PathKey([...parts, ''], false);
         }
         case 'wildcard': {
-          return new TreePathKey([...parts], true);
+          return new PathKey([...parts], true);
         }
         default: {
-          return new TreePathKey(parts, false);
+          return new PathKey(parts, false);
         }
       }
     }

--- a/src/webapp-builtins/tests/PathRouter.test.js
+++ b/src/webapp-builtins/tests/PathRouter.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { RootControlContext } from '@this/compy';
 import { DispatchInfo } from '@this/net-util';
 import { PathRouter } from '@this/webapp-builtins';
@@ -154,7 +154,7 @@ describe('_impl_handleRequest()', () => {
       ]}
       `('calls correct handler chain for $label', async ({ requestPath, expectInfo }) => {
         const request = RequestUtil.makeGet(requestPath);
-        const result  = await pr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
+        const result  = await pr.handleRequest(request, new DispatchInfo(PathKey.EMPTY, request.pathname));
 
         // Fill in the `reqPathStr` for the expectation.
         for (const ei of expectInfo) {
@@ -216,7 +216,7 @@ describe('_impl_handleRequest()', () => {
       ]}
       `('calls correct handler chain for $label', async ({ requestPath, expectInfo }) => {
         const request = RequestUtil.makeGet(requestPath);
-        const result  = await pr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
+        const result  = await pr.handleRequest(request, new DispatchInfo(PathKey.EMPTY, request.pathname));
 
         // Fill in the `reqPathStr` for the expectation.
         for (const ei of expectInfo) {
@@ -243,7 +243,7 @@ describe('_impl_handleRequest()', () => {
     MockApp.mockCalls = [];
 
     const request = RequestUtil.makeGet('/x/y/z');
-    const result  = await pr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
+    const result  = await pr.handleRequest(request, new DispatchInfo(PathKey.EMPTY, request.pathname));
 
     expect(result).not.toBeNull();
     expect(result.mockInfo.application.name).toBe('mockApp2');
@@ -256,7 +256,7 @@ describe('_impl_handleRequest()', () => {
     const pr      = await makeInstance({ '/florp/floop/*': 'mockApp1' });
     const request = RequestUtil.makeGet('/x/y/z');
     const result  = await pr.handleRequest(request,
-      new DispatchInfo(TreePathKey.EMPTY, new TreePathKey(['florp', 'floop', 'bop'], false)));
+      new DispatchInfo(PathKey.EMPTY, new PathKey(['florp', 'floop', 'bop'], false)));
 
     expect(result).not.toBeNull();
 
@@ -272,8 +272,8 @@ describe('_impl_handleRequest()', () => {
     const request = RequestUtil.makeGet('/x/y/z');
     const result  = await pr.handleRequest(request,
       new DispatchInfo(
-        new TreePathKey(['beep'], false),
-        new TreePathKey(['zonk', 'zorch', 'florp'], false)));
+        new PathKey(['beep'], false),
+        new PathKey(['zonk', 'zorch', 'florp'], false)));
 
     expect(result).not.toBeNull();
 

--- a/src/webapp-builtins/tests/RequestDelay.test.js
+++ b/src/webapp-builtins/tests/RequestDelay.test.js
@@ -13,6 +13,7 @@ import { RequestDelay } from '@this/webapp-builtins';
 
 import { RequestUtil } from '#test/RequestUtil';
 
+
 /**
  * Convert the given number to thousandths, dealing with floating point error.
  *

--- a/src/webapp-builtins/tests/RequestDelay.test.js
+++ b/src/webapp-builtins/tests/RequestDelay.test.js
@@ -5,7 +5,7 @@ import { setImmediate } from 'node:timers/promises';
 
 import { PromiseState } from '@this/async';
 import { MockTimeSource } from '@this/clocks';
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { RootControlContext } from '@this/compy';
 import { Duration } from '@this/data-values';
 import { DispatchInfo } from '@this/net-util';
@@ -87,7 +87,7 @@ describe('_impl_handleRequest()', () => {
   test('delays by the configured `delay` amount', async () => {
     const rd      = await makeInstance({ delay: '1234_sec' });
     const request = RequestUtil.makeGet('/florp');
-    const result  = rd.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
+    const result  = rd.handleRequest(request, new DispatchInfo(PathKey.EMPTY, request.pathname));
 
     await setImmediate();
     expect(PromiseState.isPending(result)).toBeTrue();
@@ -109,7 +109,7 @@ describe('_impl_handleRequest()', () => {
     const results = [];
 
     for (let i = 0; i < 200; i++) {
-      results.push(rd.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname)));
+      results.push(rd.handleRequest(request, new DispatchInfo(PathKey.EMPTY, request.pathname)));
       const dur     = timeSource._lastWaitFor().sec;
       const durMsec = toThousandths(dur);
 
@@ -127,7 +127,7 @@ describe('_impl_handleRequest()', () => {
     const waits   = [];
 
     for (let i = 0; i < 400; i++) {
-      results.push(rd.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname)));
+      results.push(rd.handleRequest(request, new DispatchInfo(PathKey.EMPTY, request.pathname)));
       const dur     = timeSource._lastWaitFor().sec;
       const durMsec = toThousandths(dur);
       expect(durMsec >= 20).toBeTrue();

--- a/src/webapp-builtins/tests/RequestFilter.test.js
+++ b/src/webapp-builtins/tests/RequestFilter.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { RootControlContext } from '@this/compy';
 import { DispatchInfo, StatusResponse } from '@this/net-util';
 import { RequestFilter } from '@this/webapp-builtins';
@@ -77,7 +77,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeRequest('post', '/florp');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeNull();
@@ -90,7 +90,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeGet('/florp');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeInstanceOf(StatusResponse);
@@ -106,7 +106,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeGet('/florp/flop');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeNull();
@@ -119,7 +119,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeGet('/florp/flop/');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeNull();
@@ -132,7 +132,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeGet('/florp/flop/oopsie');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeInstanceOf(StatusResponse);
@@ -146,7 +146,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeGet('/florp/flop/oopsie/');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeInstanceOf(StatusResponse);
@@ -162,7 +162,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeGet('/23456/8901/34/67890');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeNull();
@@ -175,7 +175,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeGet('/23456/8901/34/6789/');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeNull();
@@ -188,7 +188,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeGet('/23456/8901/34/678901');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeInstanceOf(StatusResponse);
@@ -202,7 +202,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeGet('/23456/8901/34/67890/');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeInstanceOf(StatusResponse);
@@ -218,7 +218,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeGet('/beep/boop/bop/biff?abcd=ef');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeNull();
@@ -231,7 +231,7 @@ describe('_impl_handleRequest()', () => {
       });
 
       const req    = RequestUtil.makeGet('/beep/boop/bop/biff?abcd=efg');
-      const disp   = new DispatchInfo(TreePathKey.EMPTY, req.pathname);
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
       const result = await rf.handleRequest(req, disp);
 
       expect(result).toBeInstanceOf(StatusResponse);

--- a/src/webapp-builtins/tests/RequestUtil.js
+++ b/src/webapp-builtins/tests/RequestUtil.js
@@ -1,7 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { HttpHeaders, IncomingRequest, RequestContext } from '@this/net-util';
+import { HttpHeaders, IncomingRequest, RequestContext }
+  from '@this/net-util';
 
 
 /**

--- a/src/webapp-builtins/tests/SuffixRouter.test.js
+++ b/src/webapp-builtins/tests/SuffixRouter.test.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { RootControlContext } from '@this/compy';
 import { DispatchInfo, FullResponse } from '@this/net-util';
 import { SuffixRouter } from '@this/webapp-builtins';
@@ -85,7 +85,7 @@ describe('_impl_handleRequest()', () => {
     MockApp.mockCalls = [];
 
     const request = RequestUtil.makeGet(path);
-    const result  = await sr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
+    const result  = await sr.handleRequest(request, new DispatchInfo(PathKey.EMPTY, request.pathname));
     if (expectResponse) {
       expect(result).toBeInstanceOf(FullResponse);
     } else {
@@ -101,7 +101,7 @@ describe('_impl_handleRequest()', () => {
     MockApp.mockCalls = [];
 
     const request = RequestUtil.makeGet(path);
-    const result  = await sr.handleRequest(request, new DispatchInfo(TreePathKey.EMPTY, request.pathname));
+    const result  = await sr.handleRequest(request, new DispatchInfo(PathKey.EMPTY, request.pathname));
     expect(result).toBeNull();
 
     const calls = MockApp.mockCalls;

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -3,7 +3,7 @@
 
 import { SecureContext } from 'node:tls';
 
-import { TreePathMap } from '@this/collections';
+import { TreeMap } from '@this/collections';
 import { BaseAggregateComponent, BaseConfig } from '@this/compy';
 import { IntfLogger } from '@this/loggy-intf';
 import { IntfHostManager } from '@this/net-protocol';
@@ -122,9 +122,9 @@ export class HostManager extends BaseAggregateComponent {
      * Map from each componentized hostname to the {@link NetworkHost} that
      * should be used for it.
      *
-     * @type {TreePathMap<NetworkHost>}
+     * @type {TreeMap<NetworkHost>}
      */
-    #items = new TreePathMap(HostUtil.hostnameStringFrom);
+    #items = new TreeMap(HostUtil.hostnameStringFrom);
 
     /**
      * Constructs an instance.

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreePathKey } from '@this/collections';
+import { PathKey } from '@this/collections';
 import { BaseComponent, BaseConfig, Names } from '@this/compy';
 import { FormatUtils } from '@this/loggy-intf';
 import { IntfAccessLog, IntfRateLimiter, ProtocolWrangler, ProtocolWranglers }
@@ -50,7 +50,7 @@ export class NetworkEndpoint extends BaseComponent {
    */
   async handleRequest(request, dispatch_unused) {
     const application = this.#application;
-    const dispatch    = new DispatchInfo(TreePathKey.EMPTY, request.pathname);
+    const dispatch    = new DispatchInfo(PathKey.EMPTY, request.pathname);
 
     try {
       const result = await application.handleRequest(request, dispatch);


### PR DESCRIPTION
This PR renames the classes in `collections` to make a bit more sense:
* `TreePathMap` -> `TreeMap`
* `TreePathKey` -> `PathKey`
* `TreePathNode` -> `TreeMapNode` (NB: This is a private helper class.)