### PR TITLE
`TokenBucket` home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
+* `async` / `webapp-util`:
+  * Moved `TokenBucket` from `async` to `webapp-util`. It _was_ the only
+    not-particularly-simple class in `async`, and its placement in that module
+    had become the source of a module dependency cycle.
 * `clocky` / `clocks`:
   * Renamed module to `clocky`, to harmonize with the other `*y` modules.
 * `collections`:

--- a/scripts/lib/bashy-node/node-project/build-main-module
+++ b/scripts/lib/bashy-node/node-project/build-main-module
@@ -211,7 +211,7 @@ function copy-local-modules {
     local copyCmd
     copyCmd="$(
         jget --output=raw "${deps}" \
-            cmd='lib rsync-local' \
+            cmd='lib rsync-local --delete' \
             toDir="${moduleDestDir}" '
           .localDirs
         | to_entries

--- a/src/async/index.js
+++ b/src/async/index.js
@@ -14,5 +14,4 @@ export * from '#x/Mutex';
 export * from '#x/PromiseState';
 export * from '#x/PromiseUtil';
 export * from '#x/Threadlet';
-export * from '#x/TokenBucket';
 export * from '#x/TypeEventPredicate';

--- a/src/async/package.json
+++ b/src/async/package.json
@@ -13,8 +13,6 @@
   },
 
   "dependencies": {
-    "@this/clocky": "*",
-    "@this/data-values": "*",
     "@this/typey": "*"
   }
 }

--- a/src/clocky/package.json
+++ b/src/clocky/package.json
@@ -13,6 +13,7 @@
   },
 
   "dependencies": {
+    "@this/async": "*",
     "@this/data-values": "*",
     "@this/typey": "*"
   }

--- a/src/webapp-builtins/export/RateLimiter.js
+++ b/src/webapp-builtins/export/RateLimiter.js
@@ -1,12 +1,12 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TokenBucket } from '@this/async';
 import { Frequency } from '@this/data-values';
 import { IntfLogger } from '@this/loggy-intf';
 import { IntfRateLimiter } from '@this/net-protocol';
 import { MustBe } from '@this/typey';
 import { BaseService } from '@this/webapp-core';
+import { TokenBucket } from '@this/webapp-util';
 
 import { RateLimitedStream } from '#p/RateLimitedStream';
 

--- a/src/webapp-builtins/private/RateLimitedStream.js
+++ b/src/webapp-builtins/private/RateLimitedStream.js
@@ -5,9 +5,10 @@ import { Socket } from 'node:net';
 import { Duplex, Readable, Writable } from 'node:stream';
 import { setImmediate } from 'node:timers';
 
-import { ManualPromise, TokenBucket } from '@this/async';
+import { ManualPromise } from '@this/async';
 import { IntfLogger } from '@this/loggy-intf';
 import { MustBe } from '@this/typey';
+import { TokenBucket } from '@this/webapp-util';
 
 
 /**

--- a/src/webapp-util/export/TokenBucket.js
+++ b/src/webapp-util/export/TokenBucket.js
@@ -7,7 +7,6 @@ import { Duration, Frequency, Moment } from '@this/data-values';
 import { MustBe } from '@this/typey';
 
 
-
 /**
  * Implementation of a "rate limiter with burstiness service", which is based on
  * the "token bucket" / "leaky bucket" algorithms. This actually implements

--- a/src/webapp-util/export/TokenBucket.js
+++ b/src/webapp-util/export/TokenBucket.js
@@ -1,12 +1,11 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { ManualPromise, Threadlet } from '@this/async';
 import { IntfTimeSource, StdTimeSource } from '@this/clocky';
 import { Duration, Frequency, Moment } from '@this/data-values';
 import { MustBe } from '@this/typey';
 
-import { ManualPromise } from '#x/ManualPromise';
-import { Threadlet } from '#x/Threadlet';
 
 
 /**

--- a/src/webapp-util/export/TokenBucket.js
+++ b/src/webapp-util/export/TokenBucket.js
@@ -155,7 +155,7 @@ export class TokenBucket {
       maxQueueGrantSize = null,
       maxQueueSize      = null,
       partialTokens     = false,
-      timeSource        = StdTimeSource.INSTANCE
+      timeSource        = TokenBucket.#DEFAULT_TIME_SOURCE
     } = options;
 
     this.#flowRate = MustBe.instanceOf(flowRate, Frequency);
@@ -626,4 +626,16 @@ export class TokenBucket {
       await this.#timeSource.waitUntil(time);
     }
   }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * Default time source.
+   *
+   * @type {StdTimeSource}
+   */
+  static #DEFAULT_TIME_SOURCE = StdTimeSource.INSTANCE;
 }

--- a/src/webapp-util/index.js
+++ b/src/webapp-util/index.js
@@ -4,3 +4,4 @@
 export * from '#x/BaseFileService';
 export * from '#x/Rotator';
 export * from '#x/Saver';
+export * from '#x/TokenBucket';

--- a/src/webapp-util/tests/TokenBucket.test.js
+++ b/src/webapp-util/tests/TokenBucket.test.js
@@ -3,10 +3,11 @@
 
 import { setImmediate } from 'node:timers/promises';
 
-import { PromiseState, TokenBucket } from '@this/async';
+import { PromiseState } from '@this/async';
 import { IntfTimeSource, MockTimeSource, StdTimeSource }
   from '@this/clocky';
 import { Duration, Frequency, Moment } from '@this/data-values';
+import { TokenBucket } from '@this/webapp-util';
 
 
 /**


### PR DESCRIPTION
This PR moves `TokenBucket` from `async` to `webapp-util`. It _was_ the only not-particularly-simple class in `async`, and its placement in that module had become the source of a module dependency cycle. It is much more "at home" in its new module.