### PR TITLE
More `UnitQuantity` stuff.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Breaking changes:
 * `data-values`:
   * Filled out the comparison methods in `Moment`, and made them match the ones
     added to `UnitQuantity` (see below).
-  * Reworked `UnitQuantity.parse()`.
+  * Reworked `UnitQuantity.parse()`, with much more straightforward
+    functionality, including the addition of optional unit conversions.
 * `loggy-intf`:
   * Removed `FormatUtils.byteStringFrom()` in favor of
     `ByteCount.stringFromByteCount()` (see below).

--- a/src/data-values/export/ByteCount.js
+++ b/src/data-values/export/ByteCount.js
@@ -118,7 +118,7 @@ export class ByteCount extends UnitQuantity {
       range         = null
     } = options ?? {};
 
-    let result = UnitQuantity.parse(valueToParse, {
+    const result = UnitQuantity.parse(valueToParse, {
       allowInstance,
       convert: {
         resultUnit: 'byte',

--- a/src/data-values/export/ByteCount.js
+++ b/src/data-values/export/ByteCount.js
@@ -87,7 +87,7 @@ export class ByteCount extends UnitQuantity {
   }));
 
   /**
-   * Parses a string representing a data quantity, returning an instance of this
+   * Parses a string representing a byte count, returning an instance of this
    * class. See {@link UnitQuantity#parse} for details on the allowed syntax.
    * The allowed units are:
    *

--- a/src/data-values/export/ByteCount.js
+++ b/src/data-values/export/ByteCount.js
@@ -106,28 +106,25 @@ export class ByteCount extends UnitQuantity {
    * @param {object} [options] Options to control the allowed range of values.
    * @param {?boolean} [options.allowInstance] Accept instances of this class?
    *   Defaults to `true`.
-   * @param {?number} [options.maxExclusive] Exclusive maximum value, in
-   *   bytes. That is, require `value < maxExclusive`.
-   * @param {?number} [options.maxInclusive] Inclusive maximum value, in
-   *   bytes. That is, require `value <= maxInclusive`.
-   * @param {?number} [options.minExclusive] Exclusive minimum value, in
-   *   bytes. That is, require `value > minExclusive`.
-   * @param {?number} [options.minInclusive] Inclusive minimum value, in
-   *   bytes. That is, require `value >= minInclusive`.
+   * @param {?object} [options.range] Optional range restrictions, in the form
+   *   of the argument required by {@link UnitQuantity#isInRange}. If present,
+   *   the result of a parse is `null` when the range is not satisfied.
    * @returns {?ByteCount} The parsed byte count, or `null` if the value could
    *   not be parsed.
    */
   static parse(valueToParse, options = null) {
-    options ??= {
-      allowInstance: true
-    };
+    const {
+      allowInstance = true,
+      range         = null
+    } = options ?? {};
 
     let result = UnitQuantity.parse(valueToParse, {
-      allowInstance: options.allowInstance,
+      allowInstance,
       convert: {
         resultUnit: 'byte',
         unitMaps:   [this.#BYTE_PER_UNIT]
-      }
+      },
+      ...(range ? { range } : null)
     });
 
     if (result === null) {
@@ -136,7 +133,7 @@ export class ByteCount extends UnitQuantity {
       result = new ByteCount(result.value);
     }
 
-    return result.isInRange(options) ? result : null;
+    return result;
   }
 
   /**

--- a/src/data-values/export/ByteCount.js
+++ b/src/data-values/export/ByteCount.js
@@ -127,13 +127,9 @@ export class ByteCount extends UnitQuantity {
       ...(range ? { range } : null)
     });
 
-    if (result === null) {
-      return null;
-    } else if (!(result instanceof ByteCount)) {
-      result = new ByteCount(result.value);
-    }
-
-    return result;
+    return ((result === null) || (result instanceof ByteCount))
+      ? result
+      : new ByteCount(result.value);
   }
 
   /**

--- a/src/data-values/export/ByteCount.js
+++ b/src/data-values/export/ByteCount.js
@@ -123,17 +123,17 @@ export class ByteCount extends UnitQuantity {
     };
 
     let result = UnitQuantity.parse(valueToParse, {
-      allowInstance: options.allowInstance
+      allowInstance: options.allowInstance,
+      convert: {
+        resultUnit: 'byte',
+        unitMaps:   [this.#BYTE_PER_UNIT]
+      }
     });
 
     if (result === null) {
       return null;
     } else if (!(result instanceof ByteCount)) {
-      const value = result?.convertValue(this.#BYTE_PER_UNIT) ?? null;
-      if (value === null) {
-        return null;
-      }
-      result = new ByteCount(value);
+      result = new ByteCount(result.value);
     }
 
     return result.isInRange(options) ? result : null;

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -143,7 +143,7 @@ export class Duration extends UnitQuantity {
     } = options ?? {};
 
     let result = UnitQuantity.parse(valueToParse, {
-      allowInstance: allowInstance,
+      allowInstance,
       convert: {
         resultUnit: 'sec',
         unitMaps:   [this.#SEC_PER_UNIT]

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -142,7 +142,7 @@ export class Duration extends UnitQuantity {
       range         = null
     } = options ?? {};
 
-    let result = UnitQuantity.parse(valueToParse, {
+    const result = UnitQuantity.parse(valueToParse, {
       allowInstance,
       convert: {
         resultUnit: 'sec',

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -151,13 +151,9 @@ export class Duration extends UnitQuantity {
       ...(range ? { range } : null)
     });
 
-    if (result === null) {
-      return null;
-    } else if (!(result instanceof Duration)) {
-      result = new Duration(result.value);
-    }
-
-    return result;
+    return ((result === null) || (result instanceof Duration))
+      ? result
+      : new Duration(result.value);
   }
 
   /**

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -130,28 +130,25 @@ export class Duration extends UnitQuantity {
    * @param {object} [options] Options to control the allowed range of values.
    * @param {?boolean} [options.allowInstance] Accept instances of this class?
    *   Defaults to `true`.
-   * @param {?number} [options.maxExclusive] Exclusive maximum value, in
-   *   seconds. That is, require `value < maxExclusive`.
-   * @param {?number} [options.maxInclusive] Inclusive maximum value, in
-   *   seconds. That is, require `value <= maxInclusive`.
-   * @param {?number} [options.minExclusive] Exclusive minimum value, in
-   *   seconds. That is, require `value > minExclusive`.
-   * @param {?number} [options.minInclusive] Inclusive minimum value, in
-   *   seconds. That is, require `value >= minInclusive`.
+   * @param {?object} [options.range] Optional range restrictions, in the form
+   *   of the argument required by {@link UnitQuantity#isInRange}. If present,
+   *   the result of a parse is `null` when the range is not satisfied.
    * @returns {?Duration} The parsed duration, or `null` if the value could not
    *   be parsed.
    */
   static parse(valueToParse, options = null) {
-    options ??= {
-      allowInstance: true
-    };
+    const {
+      allowInstance = true,
+      range         = null
+    } = options ?? {};
 
     let result = UnitQuantity.parse(valueToParse, {
-      allowInstance: options.allowInstance,
+      allowInstance: allowInstance,
       convert: {
         resultUnit: 'sec',
         unitMaps:   [this.#SEC_PER_UNIT]
-      }
+      },
+      ...(range ? { range } : null)
     });
 
     if (result === null) {
@@ -160,7 +157,7 @@ export class Duration extends UnitQuantity {
       result = new Duration(result.value);
     }
 
-    return result.isInRange(options) ? result : null;
+    return result;
   }
 
   /**

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -147,17 +147,17 @@ export class Duration extends UnitQuantity {
     };
 
     let result = UnitQuantity.parse(valueToParse, {
-      allowInstance: options.allowInstance
+      allowInstance: options.allowInstance,
+      convert: {
+        resultUnit: 'sec',
+        unitMaps:   [this.#SEC_PER_UNIT]
+      }
     });
 
     if (result === null) {
       return null;
     } else if (!(result instanceof Duration)) {
-      const value = result?.convertValue(this.#SEC_PER_UNIT) ?? null;
-      if (value === null) {
-        return null;
-      }
-      result = new Duration(value);
+      result = new Duration(result.value);
     }
 
     return result.isInRange(options) ? result : null;

--- a/src/data-values/export/Frequency.js
+++ b/src/data-values/export/Frequency.js
@@ -74,7 +74,7 @@ export class Frequency extends UnitQuantity {
   }));
 
   /**
-   * Parses a string representing a duration, returning an instance of this
+   * Parses a string representing a frequency, returning an instance of this
    * class. See {@link UnitQuantity#parse} for details on the allowed syntax.
    * The allowed units are:
    *
@@ -91,40 +91,45 @@ export class Frequency extends UnitQuantity {
    * @param {object} [options] Options to control the allowed range of values.
    * @param {?boolean} [options.allowInstance] Accept instances of this class?
    *   Defaults to `true`.
-   * @param {?number} [options.maxExclusive] Exclusive maximum value, in hertz.
-   *   That is, require `value < maxExclusive`.
-   * @param {?number} [options.maxInclusive] Inclusive maximum value, in hertz.
-   *   That is, require `value <= maxInclusive`.
-   * @param {?number} [options.minExclusive] Exclusive minimum value, in hertz.
-   *   That is, require `value > minExclusive`.
-   * @param {?number} [options.minInclusive] Inclusive minimum value, in hertz.
-   *   That is, require `value >= minInclusive`.
+   * @param {?object} [options.range] Optional range restrictions, in the form
+   *   of the argument required by {@link UnitQuantity#isInRange}. If present,
+   *   the result of a parse is `null` when the range is not satisfied.
    * @returns {?Frequency} The parsed frequency, or `null` if the value could
    *   not be parsed.
    */
   static parse(valueToParse, options = null) {
-    options ??= {
-      allowInstance: true
-    };
+    const {
+      allowInstance = true,
+      range         = null
+    } = options ?? {};
+
+    // This imposes the class's basic range restriction, on top of anything that
+    // the caller provided (if anything).
+    let finalRange;
+    if (range) {
+      finalRange = range;
+      if (typeof range.minInclusive === 'number') {
+        if (range.minInclusive < 0) {
+          finalRange.minInclusive = 0;
+        }
+      } else {
+        finalRange = { ...range, minInclusive: 0 };
+      }
+    } else {
+      finalRange = { minInclusive: 0 };
+    }
 
     let result = UnitQuantity.parse(valueToParse, {
-      allowInstance: options.allowInstance,
+      allowInstance,
       convert: {
         resultUnit: '/sec',
         unitMaps:   [this.#UNIT_PER_SEC]
-      }
+      },
+      range: finalRange
     });
 
-    if (result === null) {
-      return null;
-    } else if (!(result instanceof Frequency)) {
-      const { value } = result;
-      if (value < 0) {
-        return null;
-      }
-      result = new Frequency(value);
-    }
-
-    return result.isInRange(options) ? result : null;
+    return ((result === null) || (result instanceof Frequency))
+      ? result
+      : new Frequency(result.value);
   }
 }

--- a/src/data-values/export/Frequency.js
+++ b/src/data-values/export/Frequency.js
@@ -108,14 +108,18 @@ export class Frequency extends UnitQuantity {
     };
 
     let result = UnitQuantity.parse(valueToParse, {
-      allowInstance: options.allowInstance
+      allowInstance: options.allowInstance,
+      convert: {
+        resultUnit: '/sec',
+        unitMaps:   [this.#UNIT_PER_SEC]
+      }
     });
 
     if (result === null) {
       return null;
     } else if (!(result instanceof Frequency)) {
-      const value = result?.convertValue(this.#UNIT_PER_SEC) ?? null;
-      if ((value === null) || (value < 0)) {
+      const { value } = result;
+      if (value < 0) {
         return null;
       }
       result = new Frequency(value);

--- a/src/data-values/export/Frequency.js
+++ b/src/data-values/export/Frequency.js
@@ -119,7 +119,7 @@ export class Frequency extends UnitQuantity {
       finalRange = { minInclusive: 0 };
     }
 
-    let result = UnitQuantity.parse(valueToParse, {
+    const result = UnitQuantity.parse(valueToParse, {
       allowInstance,
       convert: {
         resultUnit: '/sec',

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -446,6 +446,10 @@ export class UnitQuantity {
       result = this.#parseString(valueToParse);
     }
 
+    if (result === null) {
+      return null;
+    }
+
     if (convert) {
       const { resultUnit = null, unitMaps = null } = convert;
       const unitSpec = UnitQuantity.parseUnitSpec(resultUnit ?? '/');

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -538,7 +538,7 @@ export class UnitQuantity {
       // There is a numerator.
 
       // This regex `match()` shouldn't ever fail.
-      const { n, denomSpec } = unitSpec.match(/^(?<n>[^ _\/]*)[ _]?(?<denomSpec>.*)$/).groups;
+      const { n, denomSpec } = unitSpec.match(/^(?<n>[^ _/]*)[ _]?(?<denomSpec>.*)$/).groups;
 
       numer = n;
       denom = denomMatch(denomSpec);
@@ -582,7 +582,7 @@ export class UnitQuantity {
 
     // This matches both the number and unit spec, but in both cases with loose
     // matching which gets tightened up below.
-    const overallMatch = value.match(/^(?<num>[\-+._0-9eE]+(?<!_))[ _]?(?! )(?<unit>.{0,100})$/);
+    const overallMatch = value.match(/^(?<num>[-+._0-9eE]+(?<!_))[ _]?(?! )(?<unit>.{0,100})$/);
 
     if (!overallMatch) {
       return null;

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -248,6 +248,18 @@ export class UnitQuantity {
   }
 
   /**
+   * Indicates whether the given other instance has the same units as this one.
+   *
+   * @param {UnitQuantity} other Instance to check.
+   * @returns {boolean} `true` iff `other`'s units are the same as this one.
+   */
+  hasSameUnits(other) {
+    MustBe.instanceOf(other, UnitQuantity);
+    return (this.#numeratorUnit === other.#numeratorUnit)
+      && (this.#denominatorUnit === other.#denominatorUnit);
+  }
+
+  /**
    * Returns the inverse of this instance, that is, `1 / value`, with numerator
    * and denominator swapped.
    *

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -425,13 +425,18 @@ export class UnitQuantity {
    *   called to produce the final numeric value. If not specified, then the
    *   original `valueToParse` must use the same units as `resultUnit` (which
    *   means unitless if `resultUnit` is not specified).
+   * @param {?object} [options.range] Optional range restrictions, in the form
+   *   of the argument required by {@link #isInRange}. If present, the result of
+   *   a parse is `null` when the range is not satisfied. If this and `convert`
+   *   are both present, the range check happens _after_ conversion.
    * @returns {?UnitQuantity} The parsed instance, or `null` if the value could
    *   not be parsed.
    */
   static parse(valueToParse, options = null) {
     const {
       allowInstance = true,
-      convert       = null
+      convert       = null,
+      range         = null
     } = options ?? {};
 
     let result;
@@ -480,6 +485,12 @@ export class UnitQuantity {
         if (result.hasSameUnits(valueToParse)) {
           result = valueToParse;
         }
+      }
+    }
+
+    if (range) {
+      if (!result.isInRange(range)) {
+        return null;
       }
     }
 

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -449,10 +449,9 @@ export class UnitQuantity {
       }
     } else {
       result = this.#parseString(valueToParse);
-    }
-
-    if (result === null) {
-      return null;
+      if (result === null) {
+        return null;
+      }
     }
 
     if (convert) {

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -163,11 +163,17 @@ export class UnitQuantity {
    * missing units or conversions).
    *
    * In order to convert, this instance must have a unit (numerator or
-   * denominator) that corresponds to each of the given tables. Each table has
-   * numerator or denominator names (including possibly a mix) as keys, and
-   * multiplication factors as values. A numerator key is a unit name with a
-   * slash (`/`) suffix (e.g., `sec/`). A denominator key is a unit name with a
-   * slash (`/`) prefix (e.g., '/sec').
+   * denominator) that corresponds to each of the given tables, and no other
+   * units. The end result is, in effect, a unitless value having had all the
+   * units canceled out. The idea here is that you can take an instance which is
+   * meant to represent some kind of real-world measurement (such speed) with
+   * a variety of units and end up with a value with implied-but-known units,
+   * e.g., convert `km/sec` _and_ `mile/hr` _and_ `mm/min` all to just `m/sec`.
+   *
+   * Each table has numerator or denominator names (including possibly a mix) as
+   * keys, and multiplication factors as values. A numerator key is a unit name
+   * with a slash (`/`) suffix (e.g., `sec/`). A denominator key is a unit name
+   * with a slash (`/`) prefix (e.g., '/sec').
    *
    * @param {...Map<string, number>} unitMaps One map for each set of required
    *   units.

--- a/src/data-values/tests/ByteCount.test.js
+++ b/src/data-values/tests/ByteCount.test.js
@@ -205,18 +205,18 @@ describe('parse()', () => {
 
   // Success and failure cases, with options.
   test.each`
-  value               | options                     | expected
-  ${'0 byte'}         | ${{ minInclusive: 0 }}      | ${0}
-  ${'-1 byte'}        | ${{ minInclusive: 0 }}      | ${null}
-  ${'0 byte'}         | ${{ minExclusive: 0 }}      | ${null}
-  ${'0.001 byte'}     | ${{ minExclusive: 0 }}      | ${0.001}
-  ${'0 byte'}         | ${{ maxInclusive: 0 }}      | ${0}
-  ${'-0.1 byte'}      | ${{ maxInclusive: 0 }}      | ${-0.1}
-  ${'0 byte'}         | ${{ maxExclusive: 0 }}      | ${null}
-  ${'-.001 byte'}     | ${{ maxExclusive: 0 }}      | ${-0.001}
-  ${'10 KiB'}         | ${{ maxExclusive: 10 }}     | ${null}
-  ${'10 KiB'}         | ${{ maxExclusive: 10241 }}  | ${10240}
-  ${new ByteCount(1)} | ${{ allowInstance: false }} | ${null}
+  value               | options                                | expected
+  ${'0 byte'}         | ${{ range: { minInclusive: 0 } }}      | ${0}
+  ${'-1 byte'}        | ${{ range: { minInclusive: 0 } }}      | ${null}
+  ${'0 byte'}         | ${{ range: { minExclusive: 0 } }}      | ${null}
+  ${'0.001 byte'}     | ${{ range: { minExclusive: 0 } }}      | ${0.001}
+  ${'0 byte'}         | ${{ range: { maxInclusive: 0 } }}      | ${0}
+  ${'-0.1 byte'}      | ${{ range: { maxInclusive: 0 } }}      | ${-0.1}
+  ${'0 byte'}         | ${{ range: { maxExclusive: 0 } }}      | ${null}
+  ${'-.001 byte'}     | ${{ range: { maxExclusive: 0 } }}      | ${-0.001}
+  ${'10 KiB'}         | ${{ range: { maxExclusive: 10 } }}     | ${null}
+  ${'10 KiB'}         | ${{ range: { maxExclusive: 10241 } }}  | ${10240}
+  ${new ByteCount(1)} | ${{ allowInstance: false }}            | ${null}
   `('returns $expected given ($value, $options)', ({ value, options, expected }) => {
     const result = ByteCount.parse(value, options);
 

--- a/src/data-values/tests/Duration.test.js
+++ b/src/data-values/tests/Duration.test.js
@@ -323,17 +323,17 @@ describe('parse()', () => {
 
   // Success and failure cases, with options.
   test.each`
-  value              | options                     | expected
-  ${'0 s'}           | ${{ minInclusive: 0 }}      | ${0}
-  ${'-.001 usec'}    | ${{ minInclusive: 0 }}      | ${null}
-  ${'0 s'}           | ${{ minExclusive: 0 }}      | ${null}
-  ${'0.001 s'}       | ${{ minExclusive: 0 }}      | ${0.001}
-  ${'0 s'}           | ${{ maxInclusive: 0 }}      | ${0}
-  ${'-0.1 sec'}      | ${{ maxInclusive: 0 }}      | ${-0.1}
-  ${'0 s'}           | ${{ maxExclusive: 0 }}      | ${null}
-  ${'-.001 s'}       | ${{ maxExclusive: 0 }}      | ${-0.001}
-  ${'10 msec'}       | ${{ maxExclusive: 1 }}      | ${0.01}
-  ${new Duration(1)} | ${{ allowInstance: false }} | ${null}
+  value              | options                                | expected
+  ${'0 s'}           | ${{ range: { minInclusive: 0 } }}      | ${0}
+  ${'-.001 usec'}    | ${{ range: { minInclusive: 0 } }}      | ${null}
+  ${'0 s'}           | ${{ range: { minExclusive: 0 } }}      | ${null}
+  ${'0.001 s'}       | ${{ range: { minExclusive: 0 } }}      | ${0.001}
+  ${'0 s'}           | ${{ range: { maxInclusive: 0 } }}      | ${0}
+  ${'-0.1 sec'}      | ${{ range: { maxInclusive: 0 } }}      | ${-0.1}
+  ${'0 s'}           | ${{ range: { maxExclusive: 0 } }}      | ${null}
+  ${'-.001 s'}       | ${{ range: { maxExclusive: 0 } }}      | ${-0.001}
+  ${'10 msec'}       | ${{ range: { maxExclusive: 1 } }}      | ${0.01}
+  ${new Duration(1)} | ${{ allowInstance: false }}            | ${null}
   `('returns $expected given ($value, $options)', ({ value, options, expected }) => {
     const result = Duration.parse(value, options);
 

--- a/src/data-values/tests/Frequency.test.js
+++ b/src/data-values/tests/Frequency.test.js
@@ -74,7 +74,7 @@ describe('parse()', () => {
     expect(() => Frequency.parse(arg)).toThrow();
   });
 
-  // Error: Syntax error / unknown unit.
+  // Error: Syntax error / unknown unit / bad value.
   test.each`
   value
   ${''}
@@ -141,18 +141,18 @@ describe('parse()', () => {
 
   // Success and failure cases, with options.
   test.each`
-  value               | options                     | expected
-  ${'0 /s'}           | ${{ minInclusive: 0 }}      | ${0}
-  ${'1.99 /sec'}      | ${{ minInclusive: 2 }}      | ${null}
-  ${'1.99 /msec'}     | ${{ minInclusive: 2 }}      | ${1990}
-  ${'0 per s'}        | ${{ minExclusive: 0 }}      | ${null}
-  ${'0.001 / s'}      | ${{ minExclusive: 0 }}      | ${0.001}
-  ${'2.01 /s'}        | ${{ maxInclusive: 2 }}      | ${null}
-  ${'2 per sec'}      | ${{ maxInclusive: 2 }}      | ${2}
-  ${'2 /s'}           | ${{ maxExclusive: 2 }}      | ${null}
-  ${'1.99 /s'}        | ${{ maxExclusive: 2 }}      | ${1.99}
-  ${'10 per day'}     | ${{ maxExclusive: 100 }}    | ${(1 / 86400) * 10}
-  ${new Frequency(1)} | ${{ allowInstance: false }} | ${null}
+  value               | options                                | expected
+  ${'0 /s'}           | ${{ range: { minInclusive: 0 } }}      | ${0}
+  ${'1.99 /sec'}      | ${{ range: { minInclusive: 2 } }}      | ${null}
+  ${'1.99 /msec'}     | ${{ range: { minInclusive: 2 } }}      | ${1990}
+  ${'0 per s'}        | ${{ range: { minExclusive: 0 } }}      | ${null}
+  ${'0.001 / s'}      | ${{ range: { minExclusive: 0 } }}      | ${0.001}
+  ${'2.01 /s'}        | ${{ range: { maxInclusive: 2 } }}      | ${null}
+  ${'2 per sec'}      | ${{ range: { maxInclusive: 2 } }}      | ${2}
+  ${'2 /s'}           | ${{ range: { maxExclusive: 2 } }}      | ${null}
+  ${'1.99 /s'}        | ${{ range: { maxExclusive: 2 } }}      | ${1.99}
+  ${'10 per day'}     | ${{ range: { maxExclusive: 100 } }}    | ${(1 / 86400) * 10}
+  ${new Frequency(1)} | ${{ allowInstance: false }}            | ${null}
   `('returns $expected given ($value, $options)', ({ value, options, expected }) => {
     const result = Frequency.parse(value, options);
 

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -681,3 +681,143 @@ describe('parse()', () => {
     expect(result.denominatorUnit).toBe(expected[2]);
   });
 });
+
+describe('parseUnitSpec()', () => {
+  // Error: Wrong argument type.
+  test.each`
+  arg
+  ${undefined}
+  ${null}
+  ${false}
+  ${123}
+  ${['123s']}
+  ${new Map()}
+  `('throws given $arg', ({ arg }) => {
+    expect(() => UnitQuantity.parseUnitSpec(arg)).toThrow();
+  });
+
+  // Syntax errors.
+  test.each`
+  value
+  ${'1/a'}           // Invalid character in unit name.
+  ${'a/1'}
+  ${'a1b/'}
+  ${'/a1b'}
+  ${'a per 1'}
+  ${'1 per a'}
+  ${'x_y/'}
+  ${'/x_y'}
+  ${'$ per'}
+  ${'@ per'}
+  ${'# per'}
+  ${'x  /'}          // Too many spaces / underscores.
+  ${'x__/'}
+  ${'x_ /'}
+  ${'x _/'}
+  ${'/  x'}
+  ${'/__x'}
+  ${'/_ x'}
+  ${'/ _x'}
+  ${'x  /y'}
+  ${'x__/y'}
+  ${'x_ /y'}
+  ${'x _/y'}
+  ${'y/  x'}
+  ${'y/__x'}
+  ${'y/_ x'}
+  ${'y/ _x'}
+  ${'x  per'}
+  ${'x__per'}
+  ${'x_ per'}
+  ${'x _per'}
+  ${'per  x'}
+  ${'per__x'}
+  ${'per_ x'}
+  ${'per _x'}
+  ${'x  per y'}
+  ${'x__per y'}
+  ${'x_ per y'}
+  ${'x _per y'}
+  ${'y per  x'}
+  ${'y per__x'}
+  ${'y per_ x'}
+  ${'y per _x'}
+  ${'x/y/z'}         // Too many slashes / "per"s.
+  ${'x//y'}
+  ${'x//'}
+  ${'//y'}
+  ${'x per y/z'}
+  ${'x/y per z'}
+  ${'x per y per z'}
+  ${'x per per y'}
+  ${'x per per'}
+  ${'per per y'}
+  ${'abcdefghijx'}   // Name too long.
+  ${'abcdefghijx/'}
+  ${'/abcdefghijx'}
+  `('returns `null` given `$value`', ({ value }) => {
+    expect(UnitQuantity.parseUnitSpec(value)).toBeNull();
+  });
+
+  // Success cases.
+  test.each`
+  spec                           | expected
+  ${''}                          | ${[null, null]}
+  ${' '}                         | ${[null, null]}
+  ${'  '}                        | ${[null, null]}
+  ${'/'}                         | ${[null, null]}
+  ${'/ '}                        | ${[null, null]}
+  ${' /'}                        | ${[null, null]}
+  ${' / '}                       | ${[null, null]}
+  ${'  /  '}                     | ${[null, null]}
+  ${'per'}                       | ${[null, null]}
+  ${'per '}                      | ${[null, null]}
+  ${' per'}                      | ${[null, null]}
+  ${' per '}                     | ${[null, null]}
+  ${'  per  '}                   | ${[null, null]}
+  ${'x'}                         | ${['x', null]}
+  ${'xyz'}                       | ${['xyz', null]}
+  ${' x'}                        | ${['x', null]}
+  ${'x '}                        | ${['x', null]}
+  ${'  x'}                       | ${['x', null]}
+  ${'x  '}                       | ${['x', null]}
+  ${'  x  '}                     | ${['x', null]}
+  ${'x/'}                        | ${['x', null]}
+  ${'x /'}                       | ${['x', null]}
+  ${'x_/'}                       | ${['x', null]}
+  ${' x_/'}                      | ${['x', null]}
+  ${'x per'}                     | ${['x', null]}
+  ${'x_per'}                     | ${['x', null]}
+  ${' x per '}                   | ${['x', null]}
+  ${'/x'}                        | ${[null, 'x']}
+  ${'/ x'}                       | ${[null, 'x']}
+  ${'/_x'}                       | ${[null, 'x']}
+  ${'/_x '}                      | ${[null, 'x']}
+  ${'per x'}                     | ${[null, 'x']}
+  ${'per_x'}                     | ${[null, 'x']}
+  ${' per x '}                   | ${[null, 'x']}
+  ${'x/y'}                       | ${['x', 'y']}
+  ${'x /y'}                      | ${['x', 'y']}
+  ${'x/ y'}                      | ${['x', 'y']}
+  ${'x / y'}                     | ${['x', 'y']}
+  ${'x_/y'}                      | ${['x', 'y']}
+  ${'x/_y'}                      | ${['x', 'y']}
+  ${'x_/_y'}                     | ${['x', 'y']}
+  ${'x_/ y'}                     | ${['x', 'y']}
+  ${'x /_y'}                     | ${['x', 'y']}
+  ${'  x/y  '}                   | ${['x', 'y']}
+  ${'x per y'}                   | ${['x', 'y']}
+  ${'x_per y'}                   | ${['x', 'y']}
+  ${'x per_y'}                   | ${['x', 'y']}
+  ${'x_per_y'}                   | ${['x', 'y']}
+  ${'abcdefghij/kkkkklllll'}     | ${['abcdefghij', 'kkkkklllll']}
+  ${'abcdefghij per kkkkklllll'} | ${['abcdefghij', 'kkkkklllll']}
+  ${'xyz/xyz'}                   | ${[null, null]} // Units cancel out.
+  `('returns $expected given `$spec`', ({ spec, expected }) => {
+    const result = UnitQuantity.parseUnitSpec(spec);
+
+    expect(result).not.toBeNull();
+    expect(result).toBeArrayOfSize(2);
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -671,6 +671,16 @@ describe('parse()', () => {
         expect(uq).toBeNull();
       });
 
+      test('throws given a syntactically invalid `resultUnit`', () => {
+        const opts = {
+          convert: {
+            resultUnit: 'hey what is happening today?'
+          }
+        };
+
+        expect(() => UnitQuantity.parse('123', opts)).toThrow();
+      });
+
       test('parses a value with matching units', () => {
         const uq = UnitQuantity.parse('99 x / y', {
           convert: {

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -830,7 +830,7 @@ describe('parse()', () => {
           convert: {
             resultUnit: 'a',
             unitMaps: [
-              new Map(Object.entries({ 'a/': 1, 'aaa/': 1000 })),
+              new Map(Object.entries({ 'a/': 1, 'aaa/': 1000 }))
             ]
           },
           range: {

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -631,6 +631,38 @@ describe('parse()', () => {
     });
   });
 
+  describe('with `{ range: ... }`', () => {
+    test('accepts a value that falls within the range', () => {
+      const opt = {
+        range: {
+          minInclusive: 1,
+          maxInclusive: 10
+        }
+      };
+
+      const uq1  = UnitQuantity.parse('1 x', opt);
+      const uq10 = UnitQuantity.parse('10 x', opt);
+
+      expect(uq1.value).toBe(1);
+      expect(uq10.value).toBe(10);
+    });
+
+    test('returns `null` given a value that falls outside the range', () => {
+      const opt = {
+        range: {
+          minExclusive: 1,
+          maxExclusive: 10
+        }
+      };
+
+      const uq1  = UnitQuantity.parse('1 x', opt);
+      const uq10 = UnitQuantity.parse('10 x', opt);
+
+      expect(uq1).toBeNull();
+      expect(uq10).toBeNull();
+    });
+  });
+
   describe('with `{ convert: ... }`', () => {
     describe('without `unitMaps` or `resultUnit`', () => {
       test('returns `null` given a syntactically incorrect value', () => {
@@ -827,6 +859,25 @@ describe('parse()', () => {
 
         const uq = new UnitQuantity(914, 'a', 'b');
         expect(UnitQuantity.parse(uq, opts)).toBe(uq);
+      });
+
+      test('uses `convert` before checking `range`', () => {
+        const opts = {
+          convert: {
+            resultUnit: 'a',
+            unitMaps: [
+              new Map(Object.entries({ 'a/': 1, 'aaa/': 1000 })),
+            ]
+          },
+          range: {
+            minInclusive: 1000
+          }
+        };
+
+        const uq = UnitQuantity.parse('5 aaa', opts);
+        expect(uq).toBeInstanceOf(UnitQuantity);
+        expect(uq.value).toBe(5000);
+        expect(uq.unitString).toBe('a/');
       });
     });
   });

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -633,6 +633,10 @@ describe('parse()', () => {
 
   describe('with `{ convert: ... }`', () => {
     describe('without `unitMaps` or `resultUnit`', () => {
+      test('returns `null` given a syntactically incorrect value', () => {
+        expect(UnitQuantity.parse('12 34 56!', { convert: {} })).toBeNull();
+      });
+
       test('returns `null` given a unit-ful value', () => {
         expect(UnitQuantity.parse('12 x', { convert: {} })).toBeNull();
       });
@@ -647,6 +651,16 @@ describe('parse()', () => {
     });
 
     describe('with `resultUnit` but not `unitMaps`', () => {
+      test('returns `null` given a syntactically incorrect value', () => {
+        const uq = UnitQuantity.parse('zonk 126!', {
+          convert: {
+            resultUnit: 'a/b'
+          }
+        });
+
+        expect(uq).toBeNull();
+      });
+
       test('returns `null` given a unit-ful value with non-matching units', () => {
         const uq = UnitQuantity.parse('12 x per y', {
           convert: {
@@ -683,6 +697,18 @@ describe('parse()', () => {
     });
 
     describe('with `unitMaps` but not `resultUnit`', () => {
+      test('returns `null` given a syntactically incorrect value', () => {
+        const uq = UnitQuantity.parse('beep boop bop', {
+          convert: {
+            unitMaps: [
+              new Map(Object.entries({ 'x/': 2 }))
+            ]
+          }
+        });
+
+        expect(uq).toBeNull();
+      });
+
       test('uses a single-element `unitMaps`', () => {
         const uq = UnitQuantity.parse('12 x', {
           convert: {
@@ -731,6 +757,19 @@ describe('parse()', () => {
     });
 
     describe('with `unitMaps` and `resultUnit`', () => {
+      test('returns `null` given a syntactically incorrect value', () => {
+        const uq = UnitQuantity.parse('flippity flop 999', {
+          convert: {
+            resultUnit: 'x/y',
+            unitMaps: [
+              new Map(Object.entries({ 'x/': 2 }))
+            ]
+          }
+        });
+
+        expect(uq).toBeNull();
+      });
+
       test('uses a two-element `unitMaps`', () => {
         const uq = UnitQuantity.parse('7 x per y', {
           convert: {

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -764,6 +764,21 @@ describe('parse()', () => {
         expect(UnitQuantity.parse('7 x/a', opts)).toBeNull();
         expect(UnitQuantity.parse('7 a/y', opts)).toBeNull();
       });
+
+      test('returns the given actual-instance argument if it came in with the right units', () => {
+        const opts = {
+          convert: {
+            resultUnit: 'a per b',
+            unitMaps: [
+              new Map(Object.entries({ 'a/': 1, 'aa/': 10 })),
+              new Map(Object.entries({ '/b': 1, '/bb': 20 }))
+            ]
+          }
+        };
+
+        const uq = new UnitQuantity(914, 'a', 'b');
+        expect(UnitQuantity.parse(uq, opts)).toBe(uq);
+      });
     });
   });
 

--- a/src/net-util/export/HttpUtil.js
+++ b/src/net-util/export/HttpUtil.js
@@ -416,7 +416,7 @@ export class HttpUtil {
    */
   static #ccSeconds(name, duration) {
     try {
-      duration = Duration.parse(duration, { minInclusive: 0 });
+      duration = Duration.parse(duration, { range: { minInclusive: 0 } });
     } catch {
       if (typeof duration === 'string') {
         return { error: 'Expected non-negative duration string.' };

--- a/src/webapp-builtins/export/AccessLogToFile.js
+++ b/src/webapp-builtins/export/AccessLogToFile.js
@@ -228,7 +228,7 @@ export class AccessLogToFile extends BaseFileService {
       } = rawConfig;
 
       if (bufferPeriod) {
-        this.#bufferPeriod = Duration.parse(bufferPeriod, { minInclusive: 0 });
+        this.#bufferPeriod = Duration.parse(bufferPeriod, { range: { minInclusive: 0 } });
         if (!this.#bufferPeriod) {
           throw new Error(`Could not parse \`bufferPeriod\`: ${bufferPeriod}`);
         }

--- a/src/webapp-builtins/export/MemoryMonitor.js
+++ b/src/webapp-builtins/export/MemoryMonitor.js
@@ -211,12 +211,12 @@ export class MemoryMonitor extends BaseService {
         maxRssBytes  = null
       } = rawConfig;
 
-      this.#checkPeriod = Duration.parse(checkPeriod ?? '5 min', { minInclusive: 1 });
+      this.#checkPeriod = Duration.parse(checkPeriod ?? '5 min', { range: { minInclusive: 1 } });
       if (!this.#checkPeriod) {
         throw new Error(`Could not parse \`checkPeriod\`: ${checkPeriod}`);
       }
 
-      this.#gracePeriod = Duration.parse(gracePeriod ?? '0 sec', { minInclusive: 0 });
+      this.#gracePeriod = Duration.parse(gracePeriod ?? '0 sec', { range: { minInclusive: 0 } });
       if (!this.#gracePeriod) {
         throw new Error(`Could not parse \`gracePeriod\`: ${gracePeriod}`);
       }

--- a/src/webapp-builtins/export/ProcessIdFile.js
+++ b/src/webapp-builtins/export/ProcessIdFile.js
@@ -252,7 +252,7 @@ export class ProcessIdFile extends BaseFileService {
         : MustBe.null(multiprocess);
 
       if (updatePeriod) {
-        this.#updatePeriod = Duration.parse(updatePeriod, { minInclusive: 1 });
+        this.#updatePeriod = Duration.parse(updatePeriod, { range: { minInclusive: 1 } });
         if (!this.#updatePeriod) {
           throw new Error(`Could not parse \`updatePeriod\`: ${updatePeriod}`);
         }

--- a/src/webapp-builtins/export/ProcessInfoFile.js
+++ b/src/webapp-builtins/export/ProcessInfoFile.js
@@ -328,7 +328,7 @@ export class ProcessInfoFile extends BaseFileService {
       const { updatePeriod = null } = rawConfig;
 
       if (updatePeriod) {
-        this.#updatePeriod = Duration.parse(updatePeriod, { minInclusive: 1 });
+        this.#updatePeriod = Duration.parse(updatePeriod, { range: { minInclusive: 1 } });
         if (!this.#updatePeriod) {
           throw new Error(`Could not parse \`updatePeriod\`: ${updatePeriod}`);
         }

--- a/src/webapp-builtins/export/RequestDelay.js
+++ b/src/webapp-builtins/export/RequestDelay.js
@@ -169,7 +169,7 @@ export class RequestDelay extends BaseApplication {
      * @returns {Duration} The parsed value.
      */
     static #parseDelay(value) {
-      return Duration.parse(value, { minInclusive: 0 });
+      return Duration.parse(value, { range: { minInclusive: 0 } });
     }
   };
 }

--- a/src/webapp-builtins/export/SyslogToFile.js
+++ b/src/webapp-builtins/export/SyslogToFile.js
@@ -144,7 +144,7 @@ export class SyslogToFile extends BaseFileService {
       const { bufferPeriod = null, format } = rawConfig;
 
       if (bufferPeriod) {
-        this.#bufferPeriod = Duration.parse(bufferPeriod, { minInclusive: 0 });
+        this.#bufferPeriod = Duration.parse(bufferPeriod, { range: { minInclusive: 0 } });
         if (!this.#bufferPeriod) {
           throw new Error(`Could not parse \`bufferPeriod\`: ${bufferPeriod}`);
         }

--- a/src/webapp-util/export/BaseFileService.js
+++ b/src/webapp-util/export/BaseFileService.js
@@ -296,7 +296,7 @@ export class BaseFileService extends BaseService {
         ? null
         : MustBe.number(atSize, { finite: true, minInclusive: 1 });
 
-      this.#checkPeriod = Duration.parse(checkPeriod ?? '5 min', { minInclusive: 1 });
+      this.#checkPeriod = Duration.parse(checkPeriod ?? '5 min', { range: { minInclusive: 1 } });
       if (!this.#checkPeriod) {
         throw new Error(`Could not parse \`checkPeriod\`: ${checkPeriod}`);
       }


### PR DESCRIPTION
More `UnitQuantity` stuff:

* Add `UnitQuantity.hasSameUnits()`.
* Add `UnitQuantity.parseUnitSpec()`, with a tightened-up definition of what constitutes a unit spec. Now gets used inside `UnitQuantity.parse()`.
* Add unit conversion and range checks to `UnitQuantity.parse()`.
* Change the `parse()` methods  on `ByteCount`, `Duration`, and `Frequency` to take advantage of the base class's new `parse()` abilities.