### PR TITLE
More rate limit stuff

### DIFF
--- a/doc/configuration/2-common-configuration.md
+++ b/doc/configuration/2-common-configuration.md
@@ -78,7 +78,7 @@ Frequencies are specified using the class `Frequency`. The available units are:
 * `/hour` or `/hr` or `/h` &mdash; Per hour.
 * `/day` or `/d` &mdash; Per (24-hour) day.
 
-As a rarely-useful addition, the _numerator_ unit `hertz` or `hz` is allowed as
+As a rarely-useful addition, the _numerator_ unit `hertz` or `Hz` is allowed as
 an equivalent to `/sec`.
 
 ## Rate Limiting

--- a/doc/configuration/2-common-configuration.md
+++ b/doc/configuration/2-common-configuration.md
@@ -22,7 +22,7 @@ Several configurations are specified as real-world units, including for example
 time durations and data quantities. Each type of unit has a corresponding class,
 and can be specified in a configuration file using that class directly or by
 providing a string that can be parsed into an instance of that class. The
-classes are all in the `data-values` module.
+classes are all in either the `data-values` or `webapp-util` module.
 
 When using a string, the accepted syntax is a number in the usual JavaScript
 form (including exponents and internal underscores), followed by the unit
@@ -48,11 +48,30 @@ are:
 * `kB`, `MB`, `GB`, or `TB` &mdash; Standard decimal powers-of-1000 bytes.
 * `KiB`, `MiB`, `GiB`, or `TiB` &mdash; Standard binary powers-of-1024 bytes.
 
+```js
+import { ByteCount } from '@lactoserv/data-values';
+```
+
 ### `ByteRate`
 
 Rates of data flow are specified using the class `ByteRate`. The available units
 are the same as with `ByteCount` for the numerator and the same as with
-`Frequency` for the denominator (except that `hertz` / `hz` isn't allowed).
+`Frequency` for the denominator (except that `hertz` / `Hz` isn't allowed).
+
+```js
+import { ByteRate } from '@lactoserv/data-values';
+```
+
+### `ConnectionCount` and `ConnectionRate`
+
+Counts and rates of network connections are covered by the classes
+`ConnectionCount` and `ConnectionRate`. The numerator units &mdash;
+`connection`, `conn`, and `c` &mdash; are all equivalent and represent a single
+connection. Denominator units are the same as with `Frequency`.
+
+```js
+import { ConnectionCount, ConnectionRate } from '@lactoserv/webapp-util';
+```
 
 ### `Duration`
 
@@ -65,6 +84,10 @@ Durations are specified using the class `Duration`. The available units are:
 * `minute` or `min` or `m` &mdash; Minutes.
 * `hour` or `hr` or `h` &mdash; Hours.
 * `day` or `d` &mdash; Days, where a "day" is defined to be exactly 24 hours.
+
+```js
+import { Duration } from '@lactoserv/data-values';
+```
 
 ### `Frequency`
 
@@ -80,6 +103,21 @@ Frequencies are specified using the class `Frequency`. The available units are:
 
 As a rarely-useful addition, the _numerator_ unit `hertz` or `Hz` is allowed as
 an equivalent to `/sec`.
+
+```js
+import { Frequency } from '@lactoserv/data-values';
+```
+
+### `RequestCount` and `RequestRate`
+
+Counts and rates of network requests are covered by the classes `RequestCount`
+and `RequestRate`. The numerator units &mdash; `request`, `req`, and `r` &mdash;
+are all equivalent and represent a single request. Denominator units are the
+same as with `Frequency`.
+
+```js
+import { RequestCount, RequestRate } from '@lactoserv/webapp-util';
+```
 
 ## Rate Limiting
 

--- a/doc/configuration/2-common-configuration.md
+++ b/doc/configuration/2-common-configuration.md
@@ -128,8 +128,7 @@ system to allow flow at a defined rate.
 
 These applications and services all accept a common set of configuration
 options. In each specific case, there is a "token unit" and a "flow rate unit."
-The token unit is either a raw number or a real-world unit (as described above).
-The flow rate unit is always a real-world unit of some sort.
+These units are always each a real-world unit of some sort (as described above).
 
 * `flowRate` &mdash; The rate of token flow once any burst capacity is
   exhausted. The rate must be positive.

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -182,9 +182,9 @@ const applications = [
   {
     name:     'requestRate',
     class:    RequestRateLimiter,
-    maxBurst: 20,
-    flowRate: '600 per min',
-    maxQueue: 100
+    maxBurst: '20 req',
+    flowRate: '600 req per min',
+    maxQueue: '100 req'
   },
   {
     name:           'myFilter',

--- a/src/data-values/export/ByteCount.js
+++ b/src/data-values/export/ByteCount.js
@@ -113,17 +113,13 @@ export class ByteCount extends UnitQuantity {
    *   not be parsed.
    */
   static parse(valueToParse, options = null) {
-    const result = UnitQuantity.parse(valueToParse, {
+    return UnitQuantity.parse(valueToParse, {
       ...(options || {}),
       convert: {
-        resultUnit: 'byte',
-        unitMaps:   [this.#BYTE_PER_UNIT]
+        resultClass: ByteCount,
+        unitMaps:    [this.#BYTE_PER_UNIT]
       }
     });
-
-    return ((result === null) || (result instanceof ByteCount))
-      ? result
-      : new ByteCount(result.value);
   }
 
   /**

--- a/src/data-values/export/ByteCount.js
+++ b/src/data-values/export/ByteCount.js
@@ -113,18 +113,12 @@ export class ByteCount extends UnitQuantity {
    *   not be parsed.
    */
   static parse(valueToParse, options = null) {
-    const {
-      allowInstance = true,
-      range         = null
-    } = options ?? {};
-
     const result = UnitQuantity.parse(valueToParse, {
-      allowInstance,
+      ...(options || {}),
       convert: {
         resultUnit: 'byte',
         unitMaps:   [this.#BYTE_PER_UNIT]
-      },
-      ...(range ? { range } : null)
+      }
     });
 
     return ((result === null) || (result instanceof ByteCount))

--- a/src/data-values/export/ByteRate.js
+++ b/src/data-values/export/ByteRate.js
@@ -92,25 +92,7 @@ export class ByteRate extends UnitQuantity {
    *
    * @type {Map<string, number>}
    */
-  static #UNIT_PER_SEC = new Map(Object.entries({
-    '/ns':     1_000_000_000,
-    '/nsec':   1_000_000_000,
-    '/us':     1_000_000,
-    '/usec':   1_000_000,
-    '/ms':     1_000,
-    '/msec':   1_000,
-    '/s':      1,
-    '/sec':    1,
-    '/second': 1,
-    '/m':      (1 / 60),
-    '/min':    (1 / 60),
-    '/minute': (1 / 60),
-    '/h':      (1 / (60 * 60)),
-    '/hr':     (1 / (60 * 60)),
-    '/hour':   (1 / (60 * 60)),
-    '/d':      (1 / (60 * 60 * 24)),
-    '/day':    (1 / (60 * 60 * 24))
-  }));
+  static #UNIT_PER_SEC = Frequency.DENOMINATOR_UNITS;
 
   /**
    * Parses a string representing a byte data rate, returning an instance of

--- a/src/data-values/export/ByteRate.js
+++ b/src/data-values/export/ByteRate.js
@@ -113,18 +113,12 @@ export class ByteRate extends UnitQuantity {
    *   could not be parsed.
    */
   static parse(valueToParse, options = null) {
-    const {
-      allowInstance = true,
-      range         = null
-    } = options ?? {};
-
     const result = UnitQuantity.parse(valueToParse, {
-      allowInstance,
+      ...(options || {}),
       convert: {
         resultUnit: 'byte/sec',
         unitMaps:   [this.#BYTE_PER_UNIT, this.#UNIT_PER_SEC]
-      },
-      ...(range ? { range } : null)
+      }
     });
 
     return ((result === null) || (result instanceof ByteRate))

--- a/src/data-values/export/ByteRate.js
+++ b/src/data-values/export/ByteRate.js
@@ -113,17 +113,13 @@ export class ByteRate extends UnitQuantity {
    *   could not be parsed.
    */
   static parse(valueToParse, options = null) {
-    const result = UnitQuantity.parse(valueToParse, {
+    return UnitQuantity.parse(valueToParse, {
       ...(options || {}),
       convert: {
-        resultUnit: 'byte/sec',
-        unitMaps:   [this.#BYTE_PER_UNIT, this.#UNIT_PER_SEC]
+        resultClass: ByteRate,
+        unitMaps:    [this.#BYTE_PER_UNIT, this.#UNIT_PER_SEC]
       }
     });
-
-    return ((result === null) || (result instanceof ByteRate))
-      ? result
-      : new ByteRate(result.value);
   }
 
   /**

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -140,17 +140,13 @@ export class Duration extends UnitQuantity {
    *   be parsed.
    */
   static parse(valueToParse, options = null) {
-    const result = UnitQuantity.parse(valueToParse, {
+    return UnitQuantity.parse(valueToParse, {
       ...(options || {}),
       convert: {
-        resultUnit: 'sec',
-        unitMaps:   [this.#SEC_PER_UNIT]
+        resultClass: Duration,
+        unitMaps:    [this.#SEC_PER_UNIT]
       }
     });
-
-    return ((result === null) || (result instanceof Duration))
-      ? result
-      : new Duration(result.value);
   }
 
   /**

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -140,18 +140,12 @@ export class Duration extends UnitQuantity {
    *   be parsed.
    */
   static parse(valueToParse, options = null) {
-    const {
-      allowInstance = true,
-      range         = null
-    } = options ?? {};
-
     const result = UnitQuantity.parse(valueToParse, {
-      allowInstance,
+      ...(options || {}),
       convert: {
         resultUnit: 'sec',
         unitMaps:   [this.#SEC_PER_UNIT]
-      },
-      ...(range ? { range } : null)
+      }
     });
 
     return ((result === null) || (result instanceof Duration))

--- a/src/data-values/export/Duration.js
+++ b/src/data-values/export/Duration.js
@@ -183,11 +183,11 @@ export class Duration extends UnitQuantity {
    * @param {number} durationSec Duration in seconds.
    * @param {object} [options] Formatting options.
    * @param {boolean} [options.spaces] Use spaces to separate the number from
-   *   the units? If `false` an underscore is used.
+   *   the units? If `false` an underscore is used. Defaults to `true`;
    * @returns {string} The friendly form.
    */
-  static stringFromSec(durationSec, options = {}) {
-    const { spaces = true } = options;
+  static stringFromSec(durationSec, options = null) {
+    const { spaces = true } = options ?? {};
 
     const spaceyChar = spaces ? ' ' : '_';
 

--- a/src/data-values/export/Frequency.js
+++ b/src/data-values/export/Frequency.js
@@ -42,6 +42,39 @@ export class Frequency extends UnitQuantity {
   //
 
   /**
+   * @returns {Map<string, number>} The set of units which are used as
+   * denominators for this class, in the form used by {@link
+   * UnitQuantity#convert} and {@link UnitQuantity@parse}. This is meant to make
+   * it easier to define rate classes that use non-empty denominators (that is,
+   * to avoid redundancy).
+   *
+   * **Note:** This getter produces a new instance every time it is used,
+   * because JavaScript doesn't provide a straightforward way to produce a
+   * frozen `Map`.
+   */
+  static get DENOMINATOR_UNITS() {
+    return new Map(Object.entries({
+      '/ns':     1_000_000_000,
+      '/nsec':   1_000_000_000,
+      '/us':     1_000_000,
+      '/usec':   1_000_000,
+      '/ms':     1_000,
+      '/msec':   1_000,
+      '/s':      1,
+      '/sec':    1,
+      '/second': 1,
+      '/m':      (1 / 60),
+      '/min':    (1 / 60),
+      '/minute': (1 / 60),
+      '/h':      (1 / (60 * 60)),
+      '/hr':     (1 / (60 * 60)),
+      '/hour':   (1 / (60 * 60)),
+      '/d':      (1 / (60 * 60 * 24)),
+      '/day':    (1 / (60 * 60 * 24))
+    }));
+  }
+
+  /**
    * Instance with value of `0`.
    *
    * @type {Frequency}

--- a/src/data-values/export/Frequency.js
+++ b/src/data-values/export/Frequency.js
@@ -125,16 +125,12 @@ export class Frequency extends UnitQuantity {
    *   not be parsed.
    */
   static parse(valueToParse, options = null) {
-    const result = UnitQuantity.parse(valueToParse, {
+    return UnitQuantity.parse(valueToParse, {
       ...(options || {}),
       convert: {
-        resultUnit: '/sec',
-        unitMaps:   [this.#UNIT_PER_SEC]
+        resultClass: Frequency,
+        unitMaps:    [this.#UNIT_PER_SEC]
       }
     });
-
-    return ((result === null) || (result instanceof Frequency))
-      ? result
-      : new Frequency(result.value);
   }
 }

--- a/src/data-values/export/Frequency.js
+++ b/src/data-values/export/Frequency.js
@@ -42,6 +42,43 @@ export class Frequency extends UnitQuantity {
   //
 
   /**
+   * Denominator multipliers for each named unit to convert to hertz, as a plain
+   * object.
+   *
+   * @type {object}
+   */
+  static #DENOMINATOR_UNITS = Object.freeze({
+    '/ns':     1_000_000_000,
+    '/nsec':   1_000_000_000,
+    '/us':     1_000_000,
+    '/usec':   1_000_000,
+    '/ms':     1_000,
+    '/msec':   1_000,
+    '/s':      1,
+    '/sec':    1,
+    '/second': 1,
+    '/m':      (1 / 60),
+    '/min':    (1 / 60),
+    '/minute': (1 / 60),
+    '/h':      (1 / (60 * 60)),
+    '/hr':     (1 / (60 * 60)),
+    '/hour':   (1 / (60 * 60)),
+    '/d':      (1 / (60 * 60 * 24)),
+    '/day':    (1 / (60 * 60 * 24))
+  });
+
+  /**
+   * Multipliers for each named unit to convert to hertz.
+   *
+   * @type {Map<string, number>}
+   */
+  static #UNIT_PER_SEC = new Map(Object.entries({
+    ...this.#DENOMINATOR_UNITS,
+    'Hz/':     1,
+    'hertz/':  1
+  }));
+
+  /**
    * @returns {Map<string, number>} The set of units which are used as
    * denominators for this class, in the form used by {@link
    * UnitQuantity#convert} and {@link UnitQuantity@parse}. This is meant to make
@@ -53,25 +90,7 @@ export class Frequency extends UnitQuantity {
    * frozen `Map`.
    */
   static get DENOMINATOR_UNITS() {
-    return new Map(Object.entries({
-      '/ns':     1_000_000_000,
-      '/nsec':   1_000_000_000,
-      '/us':     1_000_000,
-      '/usec':   1_000_000,
-      '/ms':     1_000,
-      '/msec':   1_000,
-      '/s':      1,
-      '/sec':    1,
-      '/second': 1,
-      '/m':      (1 / 60),
-      '/min':    (1 / 60),
-      '/minute': (1 / 60),
-      '/h':      (1 / (60 * 60)),
-      '/hr':     (1 / (60 * 60)),
-      '/hour':   (1 / (60 * 60)),
-      '/d':      (1 / (60 * 60 * 24)),
-      '/day':    (1 / (60 * 60 * 24))
-    }));
+    return new Map(Object.entries(this.#DENOMINATOR_UNITS));
   }
 
   /**
@@ -80,33 +99,6 @@ export class Frequency extends UnitQuantity {
    * @type {Frequency}
    */
   static ZERO = new Frequency(0);
-
-  /**
-   * Multipliers for each named unit to convert to hertz.
-   *
-   * @type {Map<string, number>}
-   */
-  static #UNIT_PER_SEC = new Map(Object.entries({
-    '/ns':     1_000_000_000,
-    '/nsec':   1_000_000_000,
-    '/us':     1_000_000,
-    '/usec':   1_000_000,
-    '/ms':     1_000,
-    '/msec':   1_000,
-    '/s':      1,
-    '/sec':    1,
-    '/second': 1,
-    'Hz/':     1,
-    'hertz/':  1,
-    '/m':      (1 / 60),
-    '/min':    (1 / 60),
-    '/minute': (1 / 60),
-    '/h':      (1 / (60 * 60)),
-    '/hr':     (1 / (60 * 60)),
-    '/hour':   (1 / (60 * 60)),
-    '/d':      (1 / (60 * 60 * 24)),
-    '/day':    (1 / (60 * 60 * 24))
-  }));
 
   /**
    * Parses a string representing a frequency, returning an instance of this

--- a/src/data-values/export/Frequency.js
+++ b/src/data-values/export/Frequency.js
@@ -125,18 +125,12 @@ export class Frequency extends UnitQuantity {
    *   not be parsed.
    */
   static parse(valueToParse, options = null) {
-    const {
-      allowInstance = true,
-      range         = null
-    } = options ?? {};
-
     const result = UnitQuantity.parse(valueToParse, {
-      allowInstance,
+      ...(options || {}),
       convert: {
         resultUnit: '/sec',
         unitMaps:   [this.#UNIT_PER_SEC]
-      },
-      ...(range ? { range } : null)
+      }
     });
 
     return ((result === null) || (result instanceof Frequency))

--- a/src/data-values/export/Frequency.js
+++ b/src/data-values/export/Frequency.js
@@ -63,7 +63,7 @@ export class Frequency extends UnitQuantity {
     '/s':      1,
     '/sec':    1,
     '/second': 1,
-    'hz/':     1,
+    'Hz/':     1,
     'hertz/':  1,
     '/m':      (1 / 60),
     '/min':    (1 / 60),
@@ -83,7 +83,7 @@ export class Frequency extends UnitQuantity {
    * * `/ns` or `/nsec` -- per nanosecond
    * * `/us` or `/usec` -- per microsecond
    * * `/ms` or `/msec` -- per millisecond
-   * * `/s`, `/sec`, `hz`, or `hertz` -- per second
+   * * `/s`, `/sec`, `Hz`, or `hertz` -- per second
    * * `/m` or `/min` or `minute` -- per minute
    * * `/h` or `/hr` or `hour` -- per hour
    * * `/d` or `/day` -- per day (defined as exactly once per 24 hours)

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -509,10 +509,10 @@ export class UnitQuantity {
         }
       }
 
-      if (valueToParse instanceof UnitQuantity) {
-        // We started with an instance as the value to parse. If it turns out
-        // that conversion was effectively a no-op, then restore the result to
-        // the original argument.
+      if (valueToParse instanceof (resultClass ?? UnitQuantity)) {
+        // We started with an instance of the right class as the value to parse.
+        // If it turns out that conversion was effectively a no-op, then restore
+        // the result to the original argument.
         if (result.hasSameUnits(valueToParse)) {
           result = valueToParse;
         }

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -358,6 +358,33 @@ export class UnitQuantity {
   }
 
   /**
+   * Gets a string form of this instance.
+   *
+   * @param {object} [options] Formatting options.
+   * @param {boolean} [options.spaces] Use spaces to separate the number from
+   *   the units? If `false` an underscore is used. Defaults to `true`.
+   * @returns {string} The string form.
+   */
+  toString(options = null) {
+    const { spaces = true } = options ?? {};
+
+    const spc   = spaces ? ' ' : '_';
+    const numer = this.#numeratorUnit;
+    const denom = this.#denominatorUnit;
+    const value = this.#value;
+
+    if (numer === null) {
+      return (denom === null)
+        ? `${value}`
+        : `${value}${spc}/${denom}`;
+    } else {
+      return (denom === null)
+        ? `${value}${spc}${numer}`
+        : `${value}${spc}${numer}/${denom}`;
+    }
+  }
+
+  /**
    * Throws an error if either the given value isn't an instance of this class
    * or if its units don't match this class.
    *

--- a/src/data-values/export/UnitQuantity.js
+++ b/src/data-values/export/UnitQuantity.js
@@ -435,8 +435,8 @@ export class UnitQuantity {
    * @param {function(new:*, number)} [options.convert.resultClass] Class to
    *   construct with the final converted value. If specified, a non-`null`
    *   return value from this class will be the result of a `new` call on this
-   *   class, passing it the converted value (a number) as its sole argument.
-   *   It is not valid to specify both this and `resultUnit`.
+   *   class, passing it the converted value (a number) as its sole argument. It
+   *   is not valid to specify both this and `resultUnit`.
    * @param {?string} [options.convert.resultUnit] Optional final result unit,
    *   in the same format as taken by {@link #parseUnitSpec}. If specified, a
    *   non-`null` return value from this method will be an instance of this

--- a/src/data-values/tests/Frequency.test.js
+++ b/src/data-values/tests/Frequency.test.js
@@ -53,6 +53,42 @@ describe('inverse()', () => {
   });
 });
 
+//
+// Static members
+//
+
+describe('.DENOMINATOR_UNITS', () => {
+  test('is a `Map`', () => {
+    expect(Frequency.DENOMINATOR_UNITS).toBeInstanceOf(Map);
+  });
+
+  test('is a new instance with every call', () => {
+    const got1 = Frequency.DENOMINATOR_UNITS;
+    const got2 = Frequency.DENOMINATOR_UNITS;
+    const got3 = Frequency.DENOMINATOR_UNITS;
+
+    expect(got1).not.toBe(got2);
+    expect(got1).not.toBe(got3);
+    expect(got2).not.toBe(got3);
+  });
+
+  test('only contains denominators', () => {
+    const got = Frequency.DENOMINATOR_UNITS;
+
+    for (const [key, value_unused] of got) {
+      expect(key.startsWith('/')).toBeTrue();
+    }
+  });
+
+  test('has at least some of the expected elements', () => {
+    const got = Frequency.DENOMINATOR_UNITS;
+
+    expect(got.get('/sec')).toBe(1);
+    expect(got.get('/msec')).toBe(1000);
+    expect(got.get('/min')).toBe(1 / 60);
+  });
+});
+
 describe('.ZERO', () => {
   test('has the value `0`', () => {
     expect(Frequency.ZERO.hertz).toBe(0);
@@ -105,7 +141,7 @@ describe('parse()', () => {
   ${'0 /sec'}                         | ${0}
   ${'0 /s'}                           | ${0}
   ${'0 hertz'}                        | ${0}
-  ${'0 hz'}                           | ${0}
+  ${'0 Hz'}                           | ${0}
   ${'0 /minute'}                      | ${0}
   ${'0 /min'}                         | ${0}
   ${'0 /m'}                           | ${0}

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -4,6 +4,22 @@
 import { UnitQuantity } from '@this/data-values';
 
 
+/**
+ * Fake unit class.
+ */
+class FakeUnit extends UnitQuantity {
+  /**
+   * Constructs an instance.
+   *
+   * @param {number} value The value.
+   * @param {?string} [numer] Numerator unit.
+   * @param {?string} [denom] Denominator unit.
+   */
+  constructor(value, numer = 'fakeNumer', denom = 'fakeDenom') {
+    super(value, numer, denom);
+  }
+}
+
 describe('constructor()', () => {
   test.each`
   args
@@ -663,7 +679,16 @@ describe('parse()', () => {
   });
 
   describe('with `{ convert: ... }`', () => {
-    describe('without `unitMaps` or `resultUnit`', () => {
+    test('throws when passed both `resultClass` and `resultUnit`', () => {
+      expect(() => UnitQuantity.parse('1 x/y', {
+        convert: {
+          resultUnit:  'x/y',
+          resultClass: UnitQuantity
+        }
+      })).toThrow();
+    });
+
+    describe('without `unitMaps` or `result*`', () => {
       test('returns `null` given a syntactically incorrect value', () => {
         expect(UnitQuantity.parse('12 34 56!', { convert: {} })).toBeNull();
       });
@@ -678,6 +703,50 @@ describe('parse()', () => {
         expect(uq).toBeInstanceOf(UnitQuantity);
         expect(uq.value).toBe(34);
         expect(uq.unitString).toBe('/');
+      });
+    });
+
+    describe('with `resultClass` but not `unitMaps`', () => {
+      test('returns `null` given a syntactically incorrect value', () => {
+        const uq = UnitQuantity.parse('zonk 126!', {
+          convert: {
+            resultClass: FakeUnit
+          }
+        });
+
+        expect(uq).toBeNull();
+      });
+
+      test('parses a unit-ful value with arbitrary units', () => {
+        const uq = UnitQuantity.parse('12 x per y', {
+          convert: {
+            resultClass: FakeUnit
+          }
+        });
+
+        expect(uq).toBeInstanceOf(FakeUnit);
+        expect(uq.value).toBe(12);
+      });
+
+      test('parses a unitless value', () => {
+        const uq = UnitQuantity.parse('4321', {
+          convert: {
+            resultClass: FakeUnit
+          }
+        });
+
+        expect(uq).toBeInstanceOf(FakeUnit);
+        expect(uq.value).toBe(4321);
+      });
+
+      test('throws given a valid value but a non-constuctor for `resultClass`', () => {
+        const opts = {
+          convert: {
+            resultClass: 12345
+          }
+        };
+
+        expect(() => UnitQuantity.parse('123', opts)).toThrow();
       });
     });
 
@@ -737,7 +806,7 @@ describe('parse()', () => {
       });
     });
 
-    describe('with `unitMaps` but not `resultUnit`', () => {
+    describe('with `unitMaps` but not `result*`', () => {
       test('returns `null` given a syntactically incorrect value', () => {
         const uq = UnitQuantity.parse('beep boop bop', {
           convert: {
@@ -794,6 +863,75 @@ describe('parse()', () => {
         expect(UnitQuantity.parse('7 /y', opts)).toBeNull();
         expect(UnitQuantity.parse('7 x/a', opts)).toBeNull();
         expect(UnitQuantity.parse('7 a/y', opts)).toBeNull();
+      });
+    });
+
+    describe('with `unitMaps` and `resultClass`', () => {
+      test('returns `null` given a syntactically incorrect value', () => {
+        const uq = UnitQuantity.parse('flippity flop 999', {
+          convert: {
+            resultClass: FakeUnit,
+            unitMaps: [
+              new Map(Object.entries({ 'x/': 2 }))
+            ]
+          }
+        });
+
+        expect(uq).toBeNull();
+      });
+
+      test('uses a two-element `unitMaps`', () => {
+        const uq = UnitQuantity.parse('7 x per y', {
+          convert: {
+            resultClass: FakeUnit,
+            unitMaps: [
+              new Map(Object.entries({ 'x/': 2, 'xx/': 20 })),
+              new Map(Object.entries({ '/y': 3, '/yy': 30 }))
+            ]
+          }
+        });
+
+        expect(uq).toBeInstanceOf(FakeUnit);
+        expect(uq.value).toBe(42);
+      });
+
+      test('returns `null` given a value with non-fully-matched units', () => {
+        const opts = {
+          convert: {
+            resultClass: FakeUnit,
+            unitMaps: [
+              new Map(Object.entries({ 'x/': 2, 'xx/': 20 })),
+              new Map(Object.entries({ '/y': 3, '/yy': 30 }))
+            ]
+          }
+        };
+
+        expect(UnitQuantity.parse('7', opts)).toBeNull();
+        expect(UnitQuantity.parse('7 x', opts)).toBeNull();
+        expect(UnitQuantity.parse('7 /y', opts)).toBeNull();
+        expect(UnitQuantity.parse('7 x/a', opts)).toBeNull();
+        expect(UnitQuantity.parse('7 a/y', opts)).toBeNull();
+      });
+
+      test('returns the given actual-instance argument if it came in with the right units', () => {
+        class FakerUnit extends FakeUnit {
+          constructor(value) {
+            super(value, 'a', 'b');
+          }
+        }
+
+        const opts = {
+          convert: {
+            resultClass: FakerUnit,
+            unitMaps: [
+              new Map(Object.entries({ 'a/': 1, 'aa/': 10 })),
+              new Map(Object.entries({ '/b': 1, '/bb': 20 }))
+            ]
+          }
+        };
+
+        const uq = new FakerUnit(914, 'a', 'b');
+        expect(UnitQuantity.parse(uq, opts)).toBe(uq);
       });
     });
 

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -456,6 +456,41 @@ describe('inverse()', () => {
   });
 });
 
+describe('toString()', () => {
+  describe.each`
+  opts                 | spaces
+  ${{ spaces: false }} | ${false}
+  ${{ spaces: true }}  | ${true}
+  ${{}}                | ${true}
+  ${null}              | ${true}
+  ${undefined}         | ${true}
+  `('with `options === $opts`', ({ opts, spaces }) => {
+    test.each`
+    value                       | expected
+    ${[0, null, null]}          | ${'0'}
+    ${[0, 'x', null]}           | ${'0 x'}
+    ${[0, 'abc', null]}         | ${'0 abc'}
+    ${[0, null, 'z']}           | ${'0 /z'}
+    ${[0, null, 'def']}         | ${'0 /def'}
+    ${[0, 'q', 'r']}            | ${'0 q/r'}
+    ${[0, 'bip', 'flop']}       | ${'0 bip/flop'}
+    ${[12.34, null, null]}      | ${'12.34'}
+    ${[-123, null, null]}       | ${'-123'}
+    ${[9.9e99, null, null]}     | ${'9.9e+99'}
+    ${[98765, 'xyz', null]}     | ${'98765 xyz'}
+    ${[44.12345, null, 'zonk']} | ${'44.12345 /zonk'}
+    ${[-909, 'aa', 'bb']}       | ${'-909 aa/bb'}
+    `('returns `$expected` given `$value`', ({ value, expected }) => {
+      const uq  = new UnitQuantity(...value);
+      const got = uq.toString(opts);
+      const exp = spaces ? got : got.replace(/[ ]/, '_');
+
+      expect(got).toBeString();
+      expect(got).toBe(exp);
+    });
+  });
+});
+
 
 //
 // Static members

--- a/src/data-values/tests/UnitQuantity.test.js
+++ b/src/data-values/tests/UnitQuantity.test.js
@@ -483,7 +483,7 @@ describe('toString()', () => {
     `('returns `$expected` given `$value`', ({ value, expected }) => {
       const uq  = new UnitQuantity(...value);
       const got = uq.toString(opts);
-      const exp = spaces ? got : got.replace(/[ ]/, '_');
+      const exp = spaces ? expected : expected.replace(/[ ]/, '_');
 
       expect(got).toBeString();
       expect(got).toBe(exp);

--- a/src/webapp-builtins/export/RequestRateLimiter.js
+++ b/src/webapp-builtins/export/RequestRateLimiter.js
@@ -1,7 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { Frequency } from '@this/data-values';
 import { StatusResponse } from '@this/net-util';
 import { BaseApplication } from '@this/webapp-core';
 import { RequestCount, RequestRate, TokenBucket } from '@this/webapp-util';

--- a/src/webapp-builtins/export/RequestRateLimiter.js
+++ b/src/webapp-builtins/export/RequestRateLimiter.js
@@ -4,7 +4,7 @@
 import { Frequency } from '@this/data-values';
 import { StatusResponse } from '@this/net-util';
 import { BaseApplication } from '@this/webapp-core';
-import { TokenBucket } from '@this/webapp-util';
+import { RequestCount, RequestRate, TokenBucket } from '@this/webapp-util';
 
 import { RateLimitConfig } from '#p/RateLimitConfig';
 
@@ -97,8 +97,8 @@ export class RequestRateLimiter extends BaseApplication {
 
       this.#bucket = RateLimitConfig.parse(rawConfig, {
         allowMqg:  false,
-        rateType:  Frequency,
-        tokenType: 'number'
+        rateType:  RequestRate,
+        tokenType: RequestCount
       });
     }
 

--- a/src/webapp-builtins/private/RateLimitConfig.js
+++ b/src/webapp-builtins/private/RateLimitConfig.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Frequency } from '@this/data-values';
-import { MustBe } from '@this/typey';
 import { TokenBucket } from '@this/webapp-util';
 
 
@@ -21,8 +20,8 @@ export class RateLimitConfig {
    *   represents the token flow rate.
    * @param {function(new:*)} options.tokenType Unit quantity class which
    *   represents tokens.
-   * @returns {object} Parsed configuration, suitable for passing to the {@link
-   *   TokenBucket} constructor.
+   * @returns {object} Parsed configuration, suitable for passing to the
+   *   {@link TokenBucket} constructor.
    */
   static parse(config, options) {
     const {

--- a/src/webapp-builtins/private/RateLimitConfig.js
+++ b/src/webapp-builtins/private/RateLimitConfig.js
@@ -19,8 +19,8 @@ export class RateLimitConfig {
    *   configuration.
    * @param {function(new:*)} options.rateType Unit quantity class which
    *   represents the token flow rate.
-   * @param {function(new:*)|string} options.tokenType Unit quantity class which
-   *   represents tokens, or the string `number` if plain numbers are allowed.
+   * @param {function(new:*)} options.tokenType Unit quantity class which
+   *   represents tokens.
    * @returns {object} Parsed configuration, suitable for passing to the
    *   {@link TokenBucket} constructor.
    */
@@ -48,17 +48,16 @@ export class RateLimitConfig {
         throw new Error('Must be a token count.');
       }
 
-      const opts = { range: { minInclusive: 1, maxInclusive: 1e100 } };
+      const result = tokenType.parse(value, {
+        range: { minInclusive: 1, maxInclusive: 1e100 }
+      });
 
-      if (tokenType === 'number') {
-        return MustBe.number(value, opts);
-      } else {
-        const result = tokenType.parse(value, opts);
-        if (result === null) {
-          throw new Error(`Could not parse token count: ${value}`);
-        }
-        return result.value;
+      if (result === null) {
+        throw new Error(`Could not parse token count: ${value}`);
       }
+
+      // `TokenBucket` always wants a plain `number` for its token counts.
+      return result.value;
     };
 
     const result = {

--- a/src/webapp-builtins/private/RateLimitConfig.js
+++ b/src/webapp-builtins/private/RateLimitConfig.js
@@ -21,8 +21,8 @@ export class RateLimitConfig {
    *   represents the token flow rate.
    * @param {function(new:*)} options.tokenType Unit quantity class which
    *   represents tokens.
-   * @returns {object} Parsed configuration, suitable for passing to the
-   *   {@link TokenBucket} constructor.
+   * @returns {object} Parsed configuration, suitable for passing to the {@link
+   *   TokenBucket} constructor.
    */
   static parse(config, options) {
     const {

--- a/src/webapp-util/export/ConnectionCount.js
+++ b/src/webapp-util/export/ConnectionCount.js
@@ -1,0 +1,55 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { UnitQuantity } from '@this/data-values';
+
+
+/**
+ * Representation of a count of connections.
+ */
+export class ConnectionCount extends UnitQuantity {
+  /**
+   * Constructs an instance.
+   *
+   * @param {number} connection The count of connections. Must be finite.
+   */
+  constructor(connection) {
+    super(connection, 'conn', null);
+  }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * Multipliers for each named unit to convert to connections.
+   *
+   * @type {Map<string, number>}
+   */
+  static #CONNECTION_PER_UNIT = new Map(Object.entries({
+    'connection/': 1,
+    'conn/':       1,
+    'c/':          1
+  }));
+
+  /**
+   * Parses a string representing a connection count. See {@link
+   * UnitQuantity#parse} for details.
+   *
+   * @param {string|ConnectionCount|UnitQuantity} valueToParse The value to
+   *   parse, or the value itself.
+   * @param {object} [options] Options to control the allowed range of values.
+   * @returns {?ConnectionCount} The parsed count, or `null` if the value
+   *   could not be parsed.
+   */
+  static parse(valueToParse, options = null) {
+    return UnitQuantity.parse(valueToParse, {
+      ...(options || {}),
+      convert: {
+        resultClass: ConnectionCount,
+        unitMaps:    [this.#CONNECTION_PER_UNIT]
+      }
+    });
+  }
+}

--- a/src/webapp-util/export/ConnectionCount.js
+++ b/src/webapp-util/export/ConnectionCount.js
@@ -40,8 +40,8 @@ export class ConnectionCount extends UnitQuantity {
    * @param {string|ConnectionCount|UnitQuantity} valueToParse The value to
    *   parse, or the value itself.
    * @param {object} [options] Options to control the allowed range of values.
-   * @returns {?ConnectionCount} The parsed count, or `null` if the value
-   *   could not be parsed.
+   * @returns {?ConnectionCount} The parsed count, or `null` if the value could
+   *   not be parsed.
    */
   static parse(valueToParse, options = null) {
     return UnitQuantity.parse(valueToParse, {

--- a/src/webapp-util/export/ConnectionRate.js
+++ b/src/webapp-util/export/ConnectionRate.js
@@ -1,0 +1,64 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { Frequency, UnitQuantity } from '@this/data-values';
+
+
+/**
+ * Representation of a rate of connections, in units of (possibly fractional)
+ * connections per second.
+ */
+export class ConnectionRate extends UnitQuantity {
+  /**
+   * Constructs an instance.
+   *
+   * @param {number} connectionPerSec The number of connections per second. Must
+   *   be finite.
+   */
+  constructor(connectionPerSec) {
+    super(connectionPerSec, 'conn', 'sec');
+  }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * Multipliers for each named unit to convert to connections.
+   *
+   * @type {Map<string, number>}
+   */
+  static #CONNECTION_PER_UNIT = new Map(Object.entries({
+    'connection/': 1,
+    'conn/':       1,
+    'c/':          1
+  }));
+
+  /**
+   * Multipliers for each named unit to convert to hertz (per-second).
+   *
+   * @type {Map<string, number>}
+   */
+  static #UNIT_PER_SEC = Frequency.DENOMINATOR_UNITS;
+
+  /**
+   * Parses a string representing a connection rate. See {@link
+   * UnitQuantity#parse} for details.
+   *
+   * @param {string|ConnectionRate|UnitQuantity} valueToParse The value to
+   *   parse, or the value itself.
+   * @param {object} [options] Options to control the allowed range of values.
+   * @returns {?ConnectionRate} The parsed rate, or `null` if the value could
+   *   not be parsed.
+   */
+  static parse(valueToParse, options = null) {
+    return UnitQuantity.parse(valueToParse, {
+      ...(options || {}),
+      convert: {
+        resultClass: ConnectionRate,
+        unitMaps:    [this.#CONNECTION_PER_UNIT, this.#UNIT_PER_SEC]
+      }
+    });
+  }
+}

--- a/src/webapp-util/export/RequestCount.js
+++ b/src/webapp-util/export/RequestCount.js
@@ -40,8 +40,8 @@ export class RequestCount extends UnitQuantity {
    * @param {string|RequestCount|UnitQuantity} valueToParse The value to parse,
    *   or the value itself.
    * @param {object} [options] Options to control the allowed range of values.
-   * @returns {?RequestCount} The parsed count, or `null` if the value
-   *   could not be parsed.
+   * @returns {?RequestCount} The parsed count, or `null` if the value could not
+   *   be parsed.
    */
   static parse(valueToParse, options = null) {
     return UnitQuantity.parse(valueToParse, {

--- a/src/webapp-util/export/RequestCount.js
+++ b/src/webapp-util/export/RequestCount.js
@@ -37,7 +37,7 @@ export class RequestCount extends UnitQuantity {
    * Parses a string representing a request count. See {@link
    * UnitQuantity#parse} for details.
    *
-   * @param {string|RequestRate|UnitQuantity} valueToParse The value to parse,
+   * @param {string|RequestCount|UnitQuantity} valueToParse The value to parse,
    *   or the value itself.
    * @param {object} [options] Options to control the allowed range of values.
    * @returns {?RequestCount} The parsed count, or `null` if the value

--- a/src/webapp-util/export/RequestCount.js
+++ b/src/webapp-util/export/RequestCount.js
@@ -1,0 +1,55 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { UnitQuantity } from '@this/data-values';
+
+
+/**
+ * Representation of a count of requests.
+ */
+export class RequestCount extends UnitQuantity {
+  /**
+   * Constructs an instance.
+   *
+   * @param {number} request The count of requests. Must be finite.
+   */
+  constructor(request) {
+    super(request, 'req', null);
+  }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * Multipliers for each named unit to convert to requests.
+   *
+   * @type {Map<string, number>}
+   */
+  static #REQUEST_PER_UNIT = new Map(Object.entries({
+    'request/': 1,
+    'req/':     1,
+    'r/':       1
+  }));
+
+  /**
+   * Parses a string representing a request count. See {@link
+   * UnitQuantity#parse} for details.
+   *
+   * @param {string|RequestRate|UnitQuantity} valueToParse The value to parse,
+   *   or the value itself.
+   * @param {object} [options] Options to control the allowed range of values.
+   * @returns {?RequestCount} The parsed count, or `null` if the value
+   *   could not be parsed.
+   */
+  static parse(valueToParse, options = null) {
+    return UnitQuantity.parse(valueToParse, {
+      ...(options || {}),
+      convert: {
+        resultClass: RequestCount,
+        unitMaps:    [this.#REQUEST_PER_UNIT]
+      }
+    });
+  }
+}

--- a/src/webapp-util/export/RequestRate.js
+++ b/src/webapp-util/export/RequestRate.js
@@ -1,0 +1,64 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { Frequency, UnitQuantity } from '@this/data-values';
+
+
+/**
+ * Representation of a rate of requests, in units of (possibly fractional)
+ * requests per second.
+ */
+export class RequestRate extends UnitQuantity {
+  /**
+   * Constructs an instance.
+   *
+   * @param {number} requestPerSec The number of requests per second. Must be
+   * finite.
+   */
+  constructor(requestPerSec) {
+    super(requestPerSec, 'req', 'sec');
+  }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * Multipliers for each named unit to convert to requests.
+   *
+   * @type {Map<string, number>}
+   */
+  static #REQUEST_PER_UNIT = new Map(Object.entries({
+    'request/': 1,
+    'req/':     1,
+    'r/':       1
+  }));
+
+  /**
+   * Multipliers for each named unit to convert to hertz (per-second).
+   *
+   * @type {Map<string, number>}
+   */
+  static #UNIT_PER_SEC = Frequency.DENOMINATOR_UNITS;
+
+  /**
+   * Parses a string representing a request rate. See {@link UnitQuantity#parse}
+   * for details.
+   *
+   * @param {string|RequestRate|UnitQuantity} valueToParse The value to parse,
+   *   or the value itself.
+   * @param {object} [options] Options to control the allowed range of values.
+   * @returns {?RequestRate} The parsed rate, or `null` if the value could not
+   *   be parsed.
+   */
+  static parse(valueToParse, options = null) {
+    return UnitQuantity.parse(valueToParse, {
+      ...(options || {}),
+      convert: {
+        resultClass: RequestRate,
+        unitMaps:    [this.#REQUEST_PER_UNIT, this.#UNIT_PER_SEC]
+      }
+    });
+  }
+}

--- a/src/webapp-util/index.js
+++ b/src/webapp-util/index.js
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '#x/BaseFileService';
+export * from '#x/RequestCount';
+export * from '#x/RequestRate';
 export * from '#x/Rotator';
 export * from '#x/Saver';
 export * from '#x/TokenBucket';

--- a/src/webapp-util/index.js
+++ b/src/webapp-util/index.js
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '#x/BaseFileService';
+export * from '#x/ConnectionCount';
+export * from '#x/ConnectionRate';
 export * from '#x/RequestCount';
 export * from '#x/RequestRate';
 export * from '#x/Rotator';


### PR DESCRIPTION
This PR is more progress on the unit quantity stuff. Highlights:

* Add a `resultClass` option to `UnitQuantity.parse()`.
* Uses that option to simplify all the call sites of `UnitQuantity.parse()`.
* Expose the denominator units from `Frequency`, to make creation of other rate classes easier.
* Add new webapp-specific unit classes for the cross product of {connection, request} x {count, rate}.
* Use `Request{Count,Rate}` as the token bucket types for `RequestRateLimiter`.

(Connection-related tweakage coming soon.)
