### PR TITLE
No required names

### DIFF
--- a/src/compy/export/BaseConfig.js
+++ b/src/compy/export/BaseConfig.js
@@ -46,16 +46,11 @@ export class BaseConfig {
    *
    * @param {object} rawConfig Raw configuration object. See class header for
    *   details.
-   * @param {boolean} [requireName] Is a `name` binding required?
    */
-  constructor(rawConfig, requireName = false) {
+  constructor(rawConfig) {
     MustBe.plainObject(rawConfig);
 
     const { class: cls = null, name = null } = rawConfig;
-
-    if (requireName && (name === null)) {
-      throw new Error('Missing `name` binding.');
-    }
 
     this.#class  = (cls === null)  ? null : MustBe.constructorFunction(cls);
     this.#name   = (name === null) ? null : Names.checkName(name);

--- a/src/webapp-core/export/BaseApplication.js
+++ b/src/webapp-core/export/BaseApplication.js
@@ -110,7 +110,7 @@ export class BaseApplication extends BaseComponent {
 
   /**
    * Default configuration subclass for this (outer) class, which adds no
-   * configuration option and requires its instances to have `name`.
+   * configuration options.
    *
    * This class mostly exists to be an easy target to use when subclasses want
    * to define configuration classes in the usual way, without having to
@@ -118,9 +118,6 @@ export class BaseApplication extends BaseComponent {
    * most appropriate one to derive from.
    */
   static Config = class Config extends BaseConfig {
-    /** @override */
-    constructor(rawConfig) {
-      super(rawConfig, true /* require `name` */);
-    }
+    // @emptyBlock
   };
 }

--- a/src/webapp-core/export/BaseService.js
+++ b/src/webapp-core/export/BaseService.js
@@ -266,7 +266,7 @@ export class BaseService extends BaseComponent {
 
   /**
    * Default configuration subclass for this (outer) class, which adds no
-   * configuration option and requires its instances to have `name`.
+   * configuration options.
    *
    * This class mostly exists to be an easy target to use when subclasses want
    * to define configuration classes in the usual way, without having to
@@ -274,9 +274,6 @@ export class BaseService extends BaseComponent {
    * most appropriate one to derive from.
    */
   static Config = class Config extends BaseConfig {
-    /** @override */
-    constructor(rawConfig) {
-      super(rawConfig, true /* require `name` */);
-    }
+    // @emptyBlock
   };
 }

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -202,7 +202,7 @@ export class NetworkEndpoint extends BaseComponent {
      * @param {object} rawConfig Raw configuration object.
      */
     constructor(rawConfig) {
-      super(rawConfig, true /* require `name` */);
+      super(rawConfig);
 
       const {
         hostnames = '*',


### PR DESCRIPTION
This small PR drops the option from `BaseConfig` for components to require explicit names. Names have been synthesized when needed for a while now.