### PR TITLE
Major boilerplate / ceremony reduction when defining configurations

### DIFF
--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -174,8 +174,8 @@ This application accepts the following configuration bindings:
   specified, it defaults to `308` ("Permanent Redirect").
 * `target` &mdash; The base URL to redirect to. This is prepended to the partial
   path of each request to form the final redirection URL.
-* `cacheControl` &mdash; `cache-control` header definition. If present and not
-  `null`, every cacheable response comes with the specified header.
+* `cacheControl` &mdash; Optional `cache-control` header definition. If present
+  and not `null`, every cacheable response comes with the specified header.
 
 ```js
 import { Redirector } from '@lactoserv/webapp-builtins';

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -238,9 +238,10 @@ filter can be included early in the list of applications of a
 
 This application accepts the following configuration bindings:
 
-* `acceptMethods` &mdash; Array of strings indicating which request methods to
-  accept. The array can include any of `connect`, `delete`, `get`, `head`,
-  `options`, `patch`, `post`, `put`, and/or `trace`. Defaults to the entire set.
+* `acceptMethods` &mdash; String (for a single item) or array of strings
+  indicating which request methods to accept, or `null` not to do method
+  filtering. Allowed methods are `connect`, `delete`, `get`, `head`, `options`,
+  `patch`, `post`, `put`, and/or `trace` (all lowercase). Defaults to `null`.
 * `filterResponseStatus` &mdash; Status to report when a request has been
   filtered out (as opposed to having been redirected). Defaults to `404` ("Not
   Found").

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -33,7 +33,7 @@ names (e.g. `noStore` for `no-store`). Values can be:
 ### ETag Configuration: `etag`
 
 Applications and services that generate ETags accept an `etag` binding. When it
-is absent or `false` (if allowed), no ETags are generated. If it is specified as
+is absent or `null` (if allowed), no ETags are generated. If it is specified as
 `true` or `{}` (the empty object), ETags are generated using a default
 configuration. If it is specified as an object with bindings, the following
 properties are recognized:
@@ -387,10 +387,10 @@ configuration bindings:
   an explicit `charset` is honored (e.g. `text/plain; charset=iso-8859-1`), but
   if not specified then `utf-8` is assumed for text types.
 * `cacheControl` &mdash; `cache-control` header definition. If present and not
-  `false`, every cacheable response comes with the specified header. See
+  `null`, every cacheable response comes with the specified header. See
   [Cache control configuration](#cache-control-configuration-cacheControl) for
   details.
-* `etag` &mdash; ETag-generating options. If present and not `false`, the
+* `etag` &mdash; ETag-generating options. If present and not `null`, the
   response comes with an `ETag` header. See
   [ETag Configuration](#etag-configuration-etag) for details.
 * `filePath` &mdash; Optional absolute filesystem path to the file to respond
@@ -457,11 +457,11 @@ reasonable demand:
 An application which serves static files from a local directory. This
 application accepts the following configuration bindings:
 
-* `etag` &mdash; ETag-generating options. If present and not `false`, the
+* `etag` &mdash; ETag-generating options. If present and not `null`, the
   response comes with an `ETag` header. See
   [ETag Configuration](#etag-configuration-etag) for details.
 * `cacheControl` &mdash; `cache-control` header definition. If present and not
-  `false`, every cacheable response comes with the specified header. See
+  `null`, every cacheable response comes with the specified header. See
   [Cache control configuration](#cache-control-configuration-cacheControl) for
   details.
 * `notFoundPath` &mdash; Optional filesystem path to the file to serve when a

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -175,7 +175,7 @@ This application accepts the following configuration bindings:
 * `target` &mdash; The base URL to redirect to. This is prepended to the partial
   path of each request to form the final redirection URL.
 * `cacheControl` &mdash; `cache-control` header definition. If present and not
-  `false`, every cacheable response comes with the specified header.
+  `null`, every cacheable response comes with the specified header.
 
 ```js
 import { Redirector } from '@lactoserv/webapp-builtins';

--- a/doc/configuration/README.md
+++ b/doc/configuration/README.md
@@ -112,6 +112,19 @@ exported configuration object. In each case, the binding is described as a
 element is needed, a plain object may be bound directly instead of being a
 one-element array.
 
+In addition, each element can be specified as any of:
+* A plain object with appropriate bindings. This is what is directly documented
+  here.
+* A pre-constructed configuration object of the right class to construct an
+  instance.
+* An actual instance of the right type of object.
+
+For anything but the first form, please refer to the API documentation
+(including documentation comments in the source).
+
+Each of these sections is optional, though it would be unusual to omit either
+`applications` or `endpoints`.
+
 ### `hosts`
 
 `hosts` is a list of hostname bindings. These map possibly-wildcarded hostnames

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -240,7 +240,6 @@ const applications = [
   {
     name:        'responseNotFound',
     class:       SimpleResponse,
-    etag:        false,
     body :       'Sorry! Not found!\n',
     contentType: 'text/plain',
     statusCode:  404

--- a/src/compy/export/BaseConfig.js
+++ b/src/compy/export/BaseConfig.js
@@ -134,7 +134,7 @@ export class BaseConfig {
     if (leftovers.size !== 0) {
       const names = [...leftovers].join(', ');
       const word  = (leftovers.size === 1) ? 'property' : 'properties';
-      throw new Error(`Extra configuration ${word}: \`${names}\``)
+      throw new Error(`Extra configuration ${word}: \`${names}\``);
     }
 
     const finalProps = this._impl_validate(props);
@@ -154,8 +154,8 @@ export class BaseConfig {
   }
 
   /**
-   * Finds all the `_config_*` methods on `this`, returning a map from the
-   * plain property name to the check method name.
+   * Finds all the `_config_*` methods on `this`, returning a map from the plain
+   * property name to the check method name.
    *
    * @returns {Map<string, string>} The map from property names to corresponding
    *   checker method names.

--- a/src/compy/export/BaseConfig.js
+++ b/src/compy/export/BaseConfig.js
@@ -104,14 +104,21 @@ export class BaseConfig {
     const props       = {};
 
     for (const name of sortedNames) {
-      const checker = checkers.get(name);
-      const value   = this[checker](rawConfig[name] ?? null);
+      const checker  = checkers.get(name);
+      const rawValue = rawConfig[name];
 
-      if (value === undefined) {
-        throw new Error(`Checker \`${checker}()\` did not return a value. Maybe missing a \`return\`?`);
+      try {
+        const value = this[checker](rawValue ?? null);
+        if (value === undefined) {
+          throw new Error(`Checker \`${checker}()\` did not return a value. Maybe missing a \`return\`?`);
+        }
+        props[name] = value;
+      } catch (e) {
+        if (!(name in rawConfig)) {
+          throw new Error(`Missing required configuration property: \`${name}\``);
+        }
+        throw e;
       }
-
-      props[name] = value;
     }
 
     const finalProps = this._impl_validate(props);

--- a/src/compy/export/BaseConfig.js
+++ b/src/compy/export/BaseConfig.js
@@ -27,18 +27,18 @@ export class BaseConfig {
   }
 
   /**
-   * Configuration property `class`: The concrete class of the component to
-   * create, or `null` if the class is (going to be) implied by context (such as
-   * by passing an instance directly to the corresponding component
-   * constructor). This property isn't required in general, but it _is_ required
-   * if the configuration instance gets used in a context where the concrete
-   * component class is not in fact implied.
+   * Configuration property: The concrete class of the component to create, or
+   * `null` if the class is (going to be) implied by context (such as by passing
+   * an instance directly to the corresponding component constructor). This
+   * property isn't required in general, but it _is_ required if the
+   * configuration instance gets used in a context where the concrete component
+   * class is not in fact implied.
    *
    * @param {?function(new:object)} [value] Proposed configuration value.
    *   Default `null`;
    * @returns {?function(new:object)} Accepted configuration value.
    */
-  _check_class(value = null) {
+  _config_class(value = null) {
     if (value === null) {
       return null;
     }
@@ -47,8 +47,8 @@ export class BaseConfig {
   }
 
   /**
-   * Configuration property `name`: The item's name, or `null` if it does not
-   * have a configured name. If `null`, the corresponding component will get a
+   * Configuration property: The item's name, or `null` if it does not have a
+   * configured name. If `null`, the corresponding component will get a
    * synthesized name as soon as it is attached to a hierarchy. If non-`null`,
    * it must adhere to the syntax defined by {@link Names#checkName}. Names are
    * used when finding a component in its hierarchy, and for use when logging.
@@ -56,7 +56,7 @@ export class BaseConfig {
    * @param {?string} [value] Proposed configuration value. Default `null`.
    * @returns {?string} Accepted configuration value.
    */
-  _check_name(value = null) {
+  _config_name(value = null) {
     if (value === null) {
       return null;
     }
@@ -82,7 +82,7 @@ export class BaseConfig {
 
   /**
    * Fills in a property on `this` for each property that is covered by a
-   * `_check_*` method defined by the actual (concrete) class of `this`. If the
+   * `_config_*` method defined by the actual (concrete) class of `this`. If the
    * given `rawConfig` doesn't have a property for any given checker method,
    * that method is called with no argument, to give it a chance to use a
    * default value or simply reject it for not being filled in. After making all
@@ -145,7 +145,7 @@ export class BaseConfig {
   }
 
   /**
-   * Finds all the `_check_*` methods on `this`, returning a map from the
+   * Finds all the `_config_*` methods on `this`, returning a map from the
    * plain property name to the check method name.
    *
    * @returns {Map<string, string>} The map from property names to corresponding
@@ -159,7 +159,7 @@ export class BaseConfig {
       const keys = Reflect.ownKeys(target);
 
       for (const k of keys) {
-        const name = k.match(/^_check_(?<name>.*)$/)?.groups.name ?? null;
+        const name = k.match(/^_config_(?<name>.*)$/)?.groups.name ?? null;
         if (name && !result.has(name)) {
           const pd = Reflect.getOwnPropertyDescriptor(target, k);
           if (typeof pd.value === 'function') {

--- a/src/compy/export/BaseConfig.js
+++ b/src/compy/export/BaseConfig.js
@@ -12,35 +12,8 @@ import { Names } from '#x/Names';
  * for parsing by the base class. This (base) class defines a small handful of
  * core bindings, and it is up to each subclass to define other bindings
  * specific to the things-they-are-configuring.
- *
- * The bindings recognized by this class are:
- *
- * * `{?function(new:object)} class` -- The concrete class of the component to
- *   create, or `null` if the class is (going to be) implied by context (such as
- *   by passing an instance directly to the corresponding component
- *   constructor). This binding isn't required in general, but it _is_ required
- *   if the configuration instance gets used in a context where the concrete
- *   component class is not in fact implied.
- * * `name` -- Optional name for the component, for use when finding it in its
- *   hierarchy, and for use when logging. If non-`null`, it must adhere to the
- *   syntax defined by {@link Names#checkName}.
  */
 export class BaseConfig {
-  /**
-   * The class of the item to create, or `null` if the class is expected to be
-   * implied by context whenever this instance is used.
-   *
-   * @type {?function(new:object)}
-   */
-  #class;
-
-  /**
-   * The item's name, or `null` if it does not have a configured name.
-   *
-   * @type {?string}
-   */
-  #name;
-
   /**
    * Constructs an instance.
    *
@@ -50,26 +23,146 @@ export class BaseConfig {
   constructor(rawConfig) {
     MustBe.plainObject(rawConfig);
 
-    const { class: cls = null, name = null } = rawConfig;
-
-    this.#class  = (cls === null)  ? null : MustBe.constructorFunction(cls);
-    this.#name   = (name === null) ? null : Names.checkName(name);
+    this.#fillInObject(rawConfig);
   }
 
   /**
-   * @returns {?function(new:object)} The class of the item to create, or `null`
-   * if the class is expected to be implied by context whenever this instance is
-   * used.
+   * Configuration property `class`: The concrete class of the component to
+   * create, or `null` if the class is (going to be) implied by context (such as
+   * by passing an instance directly to the corresponding component
+   * constructor). This property isn't required in general, but it _is_ required
+   * if the configuration instance gets used in a context where the concrete
+   * component class is not in fact implied.
+   *
+   * @param {?function(new:object)} value Proposed configuration value.
+   * @returns {?function(new:object)} Accepted configuration value.
    */
-  get class() {
-    return this.#class;
+  _check_class(value) {
+    if (value === null) {
+      return null;
+    }
+
+    return MustBe.constructorFunction(value);
   }
 
   /**
-   * @returns {?string} The item's name, or `null` if it does not have a
-   * configured name.
+   * Configuration property `name`: The item's name, or `null` if it does not
+   * have a configured name. If `null`, the corresponding component will get a
+   * synthesized name as soon as it is attached to a hierarchy. If non-`null`,
+   * it must adhere to the syntax defined by {@link Names#checkName}. Names are
+   * used when finding a component in its hierarchy, and for use when logging.
+   *
+   * @param {?string} value Proposed configuration value.
+   * @returns {?string} Accepted configuration value.
    */
-  get name() {
-    return this.#name;
+  _check_name(value) {
+    if (value === null) {
+      return null;
+    }
+
+    return Names.checkName(value);
+  }
+
+  /**
+   * Validates a processed configuration object, optionally changing properties,
+   * prior to actually setting its properties on this instance. Subclasses
+   * should override this if they need to do any final validation or tweakage.
+   * The base class implementation of this method returns its argument (that is,
+   * it does nothing), but concrete subclasses should check their own immediate
+   * superclasses for requirements about calling `super()`.
+   *
+   * @param {object} config Processed configuration object.
+   * @returns {object} Final configuration object to use for setting properties
+   *   on `this`.
+   */
+  _impl_validate(config) {
+    return config;
+  }
+
+  /**
+   * Fills in a property on `this` for each property that is covered by a
+   * `_check_*` method defined by the actual (concrete) class of `this`. If the
+   * given `rawConfig` doesn't have a property for any given checker method,
+   * that method is called with `null` as the argument, to give it a chance to
+   * reject it not being filled in. After making all such calls, this method
+   * then calls {@link #_impl_validate} to allow the concrete subclass to do
+   * any final validation and tweakage.
+   *
+   * **Note:** This method treats `undefined` in configuration objects like
+   * `null` and will only pass `null` per se into a checker method. And it
+   * throws an error if a checker returns `undefined`, on the assumption that it
+   * is missing an explicit `return`.
+   *
+   * **Note:** For the sake of determinism, this method calls checker methods in
+   * Unicode sort order.
+   *
+   * @param {object} rawConfig Raw configuration object.
+   */
+  #fillInObject(rawConfig) {
+    const checkers    = this.#findConfigCheckers();
+    const sortedNames = [...checkers.keys()].sort();
+    const props       = {};
+
+    for (const name of sortedNames) {
+      const checker = checkers.get(name);
+      const value   = this[checker](rawConfig[name] ?? null);
+
+      if (value === undefined) {
+        throw new Error(`Checker \`${checker}()\` did not return a value. Maybe missing a \`return\`?`);
+      }
+
+      props[name] = value;
+    }
+
+    const finalProps = this._impl_validate(props);
+
+    if (finalProps === undefined) {
+      throw new Error(`\`_impl_validate()\` did not return a value. Maybe missing a \`return\`?`);
+    }
+
+    for (const [key, value] of Object.entries(finalProps)) {
+      Reflect.defineProperty(this, key, {
+        configurable: false,
+        enumerable:   true,
+        writable:     false,
+        value
+      });
+    }
+
+    // TODO: Reject `rawConfig` with extra properties not covered by checkers.
+  }
+
+  /**
+   * Finds all the `_check_*` methods on `this`, returning a map from the
+   * plain property name to the check method name.
+   *
+   * @returns {Map<string, string>} The map from property names to corresponding
+   *   checker method names.
+   */
+  #findConfigCheckers() {
+    const result = new Map();
+    let   target = this;
+
+    for (;;) {
+      const keys = Reflect.ownKeys(target);
+
+      for (const k of keys) {
+        const name = k.match(/^_check_(?<name>.*)$/)?.groups.name ?? null;
+        if (name && !result.has(name)) {
+          const pd = Reflect.getOwnPropertyDescriptor(target, k);
+          if (typeof pd.value === 'function') {
+            result.set(name, k);
+          }
+        }
+      }
+
+      target = Reflect.getPrototypeOf(target);
+
+      if (!target || (target.constructor === Object)) {
+        break;
+      }
+    }
+
+    return result;
   }
 }

--- a/src/compy/export/BaseConfig.js
+++ b/src/compy/export/BaseConfig.js
@@ -103,6 +103,7 @@ export class BaseConfig {
     const checkers    = this.#findConfigCheckers();
     const sortedNames = [...checkers.keys()].sort();
     const props       = {};
+    const leftovers   = new Set(Object.keys(rawConfig));
 
     for (const name of sortedNames) {
       const checker   = checkers.get(name);
@@ -118,12 +119,22 @@ export class BaseConfig {
         }
 
         props[name] = value;
+
+        if (hasConfig) {
+          leftovers.delete(name);
+        }
       } catch (e) {
         if (!hasConfig) {
           throw new Error(`Missing required configuration property: \`${name}\``);
         }
         throw e;
       }
+    }
+
+    if (leftovers.size !== 0) {
+      const names = [...leftovers].join(', ');
+      const word  = (leftovers.size === 1) ? 'property' : 'properties';
+      throw new Error(`Extra configuration ${word}: \`${names}\``)
     }
 
     const finalProps = this._impl_validate(props);
@@ -140,8 +151,6 @@ export class BaseConfig {
         value
       });
     }
-
-    // TODO: Reject `rawConfig` with extra properties not covered by checkers.
   }
 
   /**

--- a/src/typey/export/StringUtil.js
+++ b/src/typey/export/StringUtil.js
@@ -11,11 +11,12 @@ import { MustBe } from '#x/MustBe';
 export class StringUtil {
   /**
    * Takes either a string or array of strings, and checks that each one matches
-   * a given pattern or passes a given filter.
+   * a given pattern, is contained in a given set, or passes a given filter.
    *
    * @param {*} items Items to check.
-   * @param {string|RegExp|function(string): string} patternOrFilter Pattern or
-   *   filter/checker function which must match all the items.
+   * @param {string|Set|RegExp|function(string): string} patternOrFilter Pattern
+   *   or filter/checker function which must match all the items. If passed a
+   *   string, it is interpreted as a regex.
    * @returns {Array<string>} Frozen copy of the `items` if a `string[]`, frozen
    *   array of just `items` if a simple `string`. If given a filter, the return
    *   value is a frozen array of all the results from calls to the filter.
@@ -31,7 +32,16 @@ export class StringUtil {
 
     let filter;
 
-    if (AskIf.callableFunction(patternOrFilter)) {
+    if (patternOrFilter instanceof Set) {
+      const set = patternOrFilter;
+      filter = (item) => {
+        if (!set.has(item)) {
+          const setStr = `[${[...set].join(', ')}]`;
+          throw new Error(`String is not in set ${setStr}: ${item}`);
+        }
+        return item;
+      };
+    } else if (AskIf.callableFunction(patternOrFilter)) {
       filter = patternOrFilter;
     } else {
       if (typeof patternOrFilter === 'string') {

--- a/src/typey/tests/StringUtil.test.js
+++ b/src/typey/tests/StringUtil.test.js
@@ -45,6 +45,14 @@ describe('checkAndFreezeStrings()', () => {
       expect(result).toEqual(['florp']);
     });
 
+    test('returns an array with it, if it is in a given `Set`', () => {
+      const value  = 'florp';
+      const result = StringUtil.checkAndFreezeStrings(value, new Set(['flip', 'florp']));
+
+      expect(result).toBeFrozen();
+      expect(result).toEqual(['florp']);
+    });
+
     test('returns its filtered value, as mapped by a filter function', () => {
       const value  = 'florp';
       const filter = (x) => x.toUpperCase();
@@ -54,13 +62,19 @@ describe('checkAndFreezeStrings()', () => {
       expect(result).toEqual(['FLORP']);
     });
 
+    test('throws, if it is not in a given `Set`', () => {
+      const value = 'florp';
+      const set   = new Set(['bomp', 'bump']);
+      expect(() => StringUtil.checkAndFreezeStrings(value, set)).toThrow();
+    });
+
     test('throws, if it does not pass a regex filter', () => {
-      const value  = 'florp';
+      const value = 'florp';
       expect (() => StringUtil.checkAndFreezeStrings(value, /^g/)).toThrow();
     });
 
     test('throws, if it does not pass a regex filter passed as a string', () => {
-      const value  = 'florp';
+      const value = 'florp';
       expect (() => StringUtil.checkAndFreezeStrings(value, '^g')).toThrow();
     });
 
@@ -91,6 +105,12 @@ describe('checkAndFreezeStrings()', () => {
       checkResult(arg, result);
     });
 
+    test('returns a frozen copy, if all elements are in a given `Set`', () => {
+      const arg    = ['flip', 'flop', 'florp'];
+      const result = StringUtil.checkAndFreezeStrings(arg, new Set(['yip', 'flip', 'flop', 'florp', 'zip']));
+      checkResult(arg, result);
+    });
+
     test('returns an array with it, if it passes a regex filter passed as a string', () => {
       const arg    = ['flip', 'flop', 'florp'];
       const result = StringUtil.checkAndFreezeStrings(arg, 'p$');
@@ -102,6 +122,12 @@ describe('checkAndFreezeStrings()', () => {
       const filter = (x) => x.startsWith('z') ? `YES-${x}` : `NO-${x}`;
       const result = StringUtil.checkAndFreezeStrings(arg, filter);
       checkResult(arg, result, ['YES-zip', 'YES-zap', 'YES-zowie', 'YES-zamboni', 'NO-urp']);
+    });
+
+    test('throws, if an element is not in a given `Set`', () => {
+      const arg = ['flip', 'flop', 'florp'];
+      const set = new Set(['yip', 'flip', 'florp', 'zip']);
+      expect (() => StringUtil.checkAndFreezeStrings(arg, set)).toThrow();
     });
 
     test('throws, if an element does not pass a regex filter', () => {

--- a/src/webapp-builtins/export/AccessLogToFile.js
+++ b/src/webapp-builtins/export/AccessLogToFile.js
@@ -200,6 +200,8 @@ export class AccessLogToFile extends BaseFileService {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseFileService.Config {
+    // @defaultConstructor
+
     /**
      * How long to buffer updates for, or `null` to not do any buffering. If
      * passed as a string, it is parsed by {@link Duration#parse}.

--- a/src/webapp-builtins/export/AccessLogToFile.js
+++ b/src/webapp-builtins/export/AccessLogToFile.js
@@ -211,6 +211,10 @@ export class AccessLogToFile extends BaseFileService {
      * @returns {?Duration} Accepted configuration value.
      */
     _config_bufferPeriod(value = null) {
+      if (value === null) {
+        return null;
+      }
+
       const result = Duration.parse(value, { range: { minInclusive: 0 } });
 
       if (!result) {

--- a/src/webapp-builtins/export/AccessLogToFile.js
+++ b/src/webapp-builtins/export/AccessLogToFile.js
@@ -201,62 +201,33 @@ export class AccessLogToFile extends BaseFileService {
    */
   static #Config = class Config extends BaseFileService.Config {
     /**
-     * How long to buffer updates for, or `null` to not do any buffering.
+     * How long to buffer updates for, or `null` to not do any buffering. If
+     * passed as a string, it is parsed by {@link Duration#parse}.
      *
-     * @type {?Duration}
+     * @param {?string|Duration} value Proposed configuration value. Default
+     *   `null`.
+     * @returns {?Duration} Accepted configuration value.
      */
-    #bufferPeriod;
+    _config_bufferPeriod(value = null) {
+      const result = Duration.parse(value, { range: { minInclusive: 0 } });
+
+      if (!result) {
+        throw new Error(`Could not parse \`bufferPeriod\`: ${value}`);
+      }
+
+      return (result === 0) ? null : result;
+    }
 
     /**
      * Maximum rendered URL length, or `null` for no maximum.
      *
-     * @type {?number}
+     * @param {?number} value Proposed configuration value. Default `null`.
+     * @returns {?number} Accepted configuration value.
      */
-    #maxUrlLength;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const {
-        bufferPeriod = null,
-        maxUrlLength = null
-      } = rawConfig;
-
-      if (bufferPeriod) {
-        this.#bufferPeriod = Duration.parse(bufferPeriod, { range: { minInclusive: 0 } });
-        if (!this.#bufferPeriod) {
-          throw new Error(`Could not parse \`bufferPeriod\`: ${bufferPeriod}`);
-        }
-        if (this.#bufferPeriod === 0) {
-          this.#bufferPeriod = null;
-        }
-      } else {
-        this.#bufferPeriod = MustBe.null(bufferPeriod);
-      }
-
-      this.#maxUrlLength = maxUrlLength
-        ? MustBe.number(maxUrlLength, { safeInteger: true, minInclusive: 20 })
-        : MustBe.null(maxUrlLength);
-    }
-
-    /**
-     * @returns {?Duration} How long to buffer updates for, or `null` to not do
-     * any buffering.
-     */
-    get bufferPeriod() {
-      return this.#bufferPeriod;
-    }
-
-    /**
-     * @returns {number} Maximum rendered URL length, or `null` for no maximum.
-     */
-    get maxUrlLength() {
-      return this.#maxUrlLength;
+    _config_maxUrlLength(value = null) {
+      return (value === null)
+        ? null
+        : MustBe.number(value, { safeInteger: true, minInclusive: 20 });
     }
   };
 }

--- a/src/webapp-builtins/export/ConnectionRateLimiter.js
+++ b/src/webapp-builtins/export/ConnectionRateLimiter.js
@@ -89,7 +89,7 @@ export class ConnectionRateLimiter extends BaseService {
      * instance of {@link ConnectionRate}.
      *
      * @param {string|ConnectionRate} value Proposed configuration value.
-     * @returns {?ConnectionRate} Accepted configuration value.
+     * @returns {ConnectionRate} Accepted configuration value.
      */
     _config_flowRate(value) {
       if ((typeof value === 'string') || (value instanceof ConnectionRate)) {
@@ -104,7 +104,7 @@ export class ConnectionRateLimiter extends BaseService {
      * parsed into an instance of {@link ConnectionCount}.
      *
      * @param {string|ConnectionCount} value Proposed configuration value.
-     * @returns {?ConnectionCount} Accepted configuration value.
+     * @returns {ConnectionCount} Accepted configuration value.
      */
     _config_maxBurst(value) {
       if ((typeof value === 'string') || (value instanceof ConnectionCount)) {
@@ -119,7 +119,7 @@ export class ConnectionRateLimiter extends BaseService {
      * `null` to have no limit. If passed as a `string` it is parsed into an
      * instance of {@link ConnectionCount}.
      *
-     * @param {string|ConnectionCount} value Proposed configuration value.
+     * @param {?string|ConnectionCount} value Proposed configuration value.
      * @returns {?ConnectionCount} Accepted configuration value.
      */
     _config_maxQueue(value = null) {

--- a/src/webapp-builtins/export/ConnectionRateLimiter.js
+++ b/src/webapp-builtins/export/ConnectionRateLimiter.js
@@ -85,30 +85,61 @@ export class ConnectionRateLimiter extends BaseService {
    */
   static #Config = class Config extends BaseService.Config {
     /**
-     * Configuration for the token bucket to use.
+     * Connection flow rate. If passed as a `string` it is parsed into an
+     * instance of {@link ConnectionRate}.
      *
-     * @type {object}
+     * @param {string|ConnectionRate} value Proposed configuration value.
+     * @returns {?ConnectionRate} Accepted configuration value.
      */
-    #bucket;
+    _config_flowRate(value) {
+      if ((typeof value === 'string') || (value instanceof ConnectionRate)) {
+        return value;
+      }
+
+      throw new Error('Invalid value for `flowRate`.');
+    }
 
     /**
-     * Constructs an instance.
+     * Maximum count of connections in a burst. If passed as a `string` it is
+     * parsed into an instance of {@link ConnectionCount}.
      *
-     * @param {object} rawConfig Raw configuration object.
+     * @param {string|ConnectionCount} value Proposed configuration value.
+     * @returns {?ConnectionCount} Accepted configuration value.
      */
-    constructor(rawConfig) {
-      super(rawConfig);
+    _config_maxBurst(value) {
+      if ((typeof value === 'string') || (value instanceof ConnectionCount)) {
+        return value;
+      }
 
-      this.#bucket = RateLimitConfig.parse(rawConfig, {
-        allowMqg:  false,
+      throw new Error('Invalid value for `maxBurst`.');
+    }
+
+    /**
+     * Maximum count of connections that can be queued up for acceptance, or
+     * `null` to have no limit. If passed as a `string` it is parsed into an
+     * instance of {@link ConnectionCount}.
+     *
+     * @param {string|ConnectionCount} value Proposed configuration value.
+     * @returns {?ConnectionCount} Accepted configuration value.
+     */
+    _config_maxQueue(value = null) {
+      if (value === null) {
+        return null;
+      } else if ((typeof value === 'string') || (value instanceof ConnectionCount)) {
+        return value;
+      }
+
+      throw new Error('Invalid value for `maxQueue`.');
+    }
+
+    /** @override */
+    _impl_validate(config) {
+      const bucket = RateLimitConfig.parse(config, {
         rateType:  ConnectionRate,
         tokenType: ConnectionCount
       });
-    }
 
-    /** @returns {object} Configuration for the token bucket to use. */
-    get bucket() {
-      return this.#bucket;
+      return super._impl_validate({ ...config, bucket });
     }
   };
 }

--- a/src/webapp-builtins/export/DataRateLimiter.js
+++ b/src/webapp-builtins/export/DataRateLimiter.js
@@ -76,8 +76,8 @@ export class DataRateLimiter extends BaseService {
    */
   static #Config = class Config extends BaseService.Config {
     /**
-     * Data rate. If passed as a `string` it is parsed into an
-     * instance of {@link ByteRate}.
+     * Data rate. If passed as a `string` it is parsed into an instance of
+     * {@link ByteRate}.
      *
      * @param {string|ByteRate} value Proposed configuration value.
      * @returns {ByteRate} Accepted configuration value.
@@ -91,8 +91,8 @@ export class DataRateLimiter extends BaseService {
     }
 
     /**
-     * Maximum data burst size. If passed as a `string` it is
-     * parsed into an instance of {@link ByteCount}.
+     * Maximum data burst size. If passed as a `string` it is parsed into an
+     * instance of {@link ByteCount}.
      *
      * @param {string|ByteCount} value Proposed configuration value.
      * @returns {ByteCount} Accepted configuration value.
@@ -106,9 +106,9 @@ export class DataRateLimiter extends BaseService {
     }
 
     /**
-     * Maximum amount of data that can be queued up for writing, or
-     * `null` to have no limit. If passed as a `string` it is parsed into an
-     * instance of {@link ByteCount}.
+     * Maximum amount of data that can be queued up for writing, or `null` to
+     * have no limit. If passed as a `string` it is parsed into an instance of
+     * {@link ByteCount}.
      *
      * @param {?string|ByteCount} value Proposed configuration value.
      * @returns {?ByteCount} Accepted configuration value.
@@ -126,8 +126,8 @@ export class DataRateLimiter extends BaseService {
     /**
      * Maximum amount of data that will be allowed to be written in a single
      * grant, or `null` to use the default limit (of the smaller of `maxBurst`
-     * and `maxQueue`). If passed as a `string` it is parsed into an
-     * instance of {@link ByteCount}.
+     * and `maxQueue`). If passed as a `string` it is parsed into an instance of
+     * {@link ByteCount}.
      *
      * @param {?string|ByteCount} value Proposed configuration value.
      * @returns {?ByteCount} Accepted configuration value.

--- a/src/webapp-builtins/export/DataRateLimiter.js
+++ b/src/webapp-builtins/export/DataRateLimiter.js
@@ -76,30 +76,80 @@ export class DataRateLimiter extends BaseService {
    */
   static #Config = class Config extends BaseService.Config {
     /**
-     * Configuration for the token bucket to use.
+     * Data rate. If passed as a `string` it is parsed into an
+     * instance of {@link ByteRate}.
      *
-     * @type {object}
+     * @param {string|ByteRate} value Proposed configuration value.
+     * @returns {ByteRate} Accepted configuration value.
      */
-    #bucket;
+    _config_flowRate(value) {
+      if ((typeof value === 'string') || (value instanceof ByteRate)) {
+        return value;
+      }
+
+      throw new Error('Invalid value for `flowRate`.');
+    }
 
     /**
-     * Constructs an instance.
+     * Maximum data burst size. If passed as a `string` it is
+     * parsed into an instance of {@link ByteCount}.
      *
-     * @param {object} rawConfig Raw configuration object.
+     * @param {string|ByteCount} value Proposed configuration value.
+     * @returns {ByteCount} Accepted configuration value.
      */
-    constructor(rawConfig) {
-      super(rawConfig);
+    _config_maxBurst(value) {
+      if ((typeof value === 'string') || (value instanceof ByteCount)) {
+        return value;
+      }
 
-      this.#bucket = RateLimitConfig.parse(rawConfig, {
-        allowMqg:  true,
+      throw new Error('Invalid value for `maxBurst`.');
+    }
+
+    /**
+     * Maximum amount of data that can be queued up for writing, or
+     * `null` to have no limit. If passed as a `string` it is parsed into an
+     * instance of {@link ByteCount}.
+     *
+     * @param {?string|ByteCount} value Proposed configuration value.
+     * @returns {?ByteCount} Accepted configuration value.
+     */
+    _config_maxQueue(value = null) {
+      if (value === null) {
+        return null;
+      } else if ((typeof value === 'string') || (value instanceof ByteCount)) {
+        return value;
+      }
+
+      throw new Error('Invalid value for `maxQueue`.');
+    }
+
+    /**
+     * Maximum amount of data that will be allowed to be written in a single
+     * grant, or `null` to use the default limit (of the smaller of `maxBurst`
+     * and `maxQueue`). If passed as a `string` it is parsed into an
+     * instance of {@link ByteCount}.
+     *
+     * @param {?string|ByteCount} value Proposed configuration value.
+     * @returns {?ByteCount} Accepted configuration value.
+     */
+    _config_maxQueueGrant(value = null) {
+      if (value === null) {
+        return null;
+      } else if ((typeof value === 'string') || (value instanceof ByteCount)) {
+        return value;
+      }
+
+      throw new Error('Invalid value for `maxQueueGrant`.');
+    }
+
+    /** @override */
+    _impl_validate(config) {
+      const bucket = RateLimitConfig.parse(config, {
         rateType:  ByteRate,
         tokenType: ByteCount
       });
-    }
 
-    /** @returns {object} Configuration for the token bucket to use. */
-    get bucket() {
-      return this.#bucket;
+      return super._impl_validate({ ...config, bucket });
     }
   };
 }

--- a/src/webapp-builtins/export/EventFan.js
+++ b/src/webapp-builtins/export/EventFan.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Names } from '@this/compy';
-import { MustBe } from '@this/typey';
+import { StringUtil } from '@this/typey';
 import { BaseService } from '@this/webapp-core';
 
 
@@ -104,39 +104,19 @@ export class EventFan extends BaseService {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseService.Config {
+    // @defaultConstructor
+
     /**
-     * Like the outer `services` except with names instead of service instances.
+     * Names of services to fan out to. Each name must be a valid component
+     * name, per {@link Names#checkName}.
      *
-     * @type {Array<string>}
+     * @param {string|Array<string>} value Proposed configuration value.
+     * @returns {Array<string>} Accepted configuration value.
      */
-    #services;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const { services } = rawConfig;
-
-      MustBe.arrayOfString(services);
-
-      for (const name of services) {
-        Names.checkName(name);
-      }
-
-      // `[...]` to copy the list in order to avoid outside interference.
-      this.#services = [...services];
-    }
-
-    /**
-     * @returns {Array<string>} Like the outer `services` except with names
-     * instead of service instances.
-     */
-    get services() {
-      return this.#services;
+    _config_services(value) {
+      return StringUtil.checkAndFreezeStrings(
+        value,
+        (item) => Names.checkName(item));
     }
   };
 }

--- a/src/webapp-builtins/export/MemoryMonitor.js
+++ b/src/webapp-builtins/export/MemoryMonitor.js
@@ -174,8 +174,8 @@ export class MemoryMonitor extends BaseService {
      * How often to check, in seconds. If passed as a string, it is parsed by
      * {@link Duration#parse}.
      *
-     * @param {string|Duration} [value] Proposed configuration value. Default
-     *   `5 min`
+     * @param {string|Duration} [value] Proposed configuration value. Default `5
+     *   min`
      * @returns {Duration} Accepted configuration value.
      */
     _config_checkPeriod(value = '5 min') {
@@ -192,8 +192,8 @@ export class MemoryMonitor extends BaseService {
      * Grace period before triggering an action. If passed as a string, it is
      * parsed by {@link Duration#parse}.
      *
-     * @param {string|Duration} [value] Proposed configuration value. Default
-     *   `0 sec` (that is, no grace period).
+     * @param {string|Duration} [value] Proposed configuration value. Default `0
+     *   sec` (that is, no grace period).
      * @returns {Duration} Accepted configuration value.
      */
     _config_gracePeriod(value = '0 sec') {

--- a/src/webapp-builtins/export/MemoryMonitor.js
+++ b/src/webapp-builtins/export/MemoryMonitor.js
@@ -168,92 +168,66 @@ export class MemoryMonitor extends BaseService {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseService.Config {
-    /**
-     * How often to check, in seconds.
-     *
-     * @type {Duration}
-     */
-    #checkPeriod;
+    // @defaultConstructor
 
     /**
-     * Grace period before triggering an action.
+     * How often to check, in seconds. If passed as a string, it is parsed by
+     * {@link Duration#parse}.
      *
-     * @type {Duration}
+     * @param {string|Duration} [value] Proposed configuration value. Default
+     *   `5 min`
+     * @returns {Duration} Accepted configuration value.
      */
-    #gracePeriod;
+    _config_checkPeriod(value = '5 min') {
+      const result = Duration.parse(value, { range: { minInclusive: 1 } });
+
+      if (!result) {
+        throw new Error(`Could not parse \`checkPeriod\`: ${value}`);
+      }
+
+      return result;
+    }
+
+    /**
+     * Grace period before triggering an action. If passed as a string, it is
+     * parsed by {@link Duration#parse}.
+     *
+     * @param {string|Duration} [value] Proposed configuration value. Default
+     *   `0 sec` (that is, no grace period).
+     * @returns {Duration} Accepted configuration value.
+     */
+    _config_gracePeriod(value = '0 sec') {
+      const result = Duration.parse(value, { range: { minInclusive: 0 } });
+
+      if (!result) {
+        throw new Error(`Could not parse \`gracePeriod\`: ${value}`);
+      }
+
+      return result;
+    }
 
     /**
      * Maximum allowed size of heap usage, in bytes, or `null` for no limit.
      *
-     * @type {?number}
+     * @param {?number} [value] Proposed configuration value. Default `null`.
+     * @returns {?number} Accepted configuration value.
      */
-    #maxHeapBytes;
+    _config_maxHeapBytes(value = null) {
+      return (value === null)
+        ? null
+        : MustBe.number(value, { finite: true, minInclusive: 1024 * 1024 });
+    }
 
     /**
      * Maximum allowed size of RSS, in bytes, or `null` for no limit.
      *
-     * @type {?number}
+     * @param {?number} [value] Proposed configuration value. Default `null`.
+     * @returns {?number} Accepted configuration value.
      */
-    #maxRssBytes;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const {
-        checkPeriod  = null,
-        gracePeriod  = null,
-        maxHeapBytes = null,
-        maxRssBytes  = null
-      } = rawConfig;
-
-      this.#checkPeriod = Duration.parse(checkPeriod ?? '5 min', { range: { minInclusive: 1 } });
-      if (!this.#checkPeriod) {
-        throw new Error(`Could not parse \`checkPeriod\`: ${checkPeriod}`);
-      }
-
-      this.#gracePeriod = Duration.parse(gracePeriod ?? '0 sec', { range: { minInclusive: 0 } });
-      if (!this.#gracePeriod) {
-        throw new Error(`Could not parse \`gracePeriod\`: ${gracePeriod}`);
-      }
-
-      this.#maxHeapBytes = (maxHeapBytes === null)
+    _config_maxRssBytes(value = null) {
+      return (value === null)
         ? null
-        : MustBe.number(maxHeapBytes, { finite: true, minInclusive: 1024 * 1024 });
-
-      this.#maxRssBytes = (maxRssBytes === null)
-        ? null
-        : MustBe.number(maxRssBytes, { finite: true, minInclusive: 1024 * 1024 });
-    }
-
-    /** @returns {Duration} How often to check. */
-    get checkPeriod() {
-      return this.#checkPeriod;
-    }
-
-    /** @returns {Duration} Grace period before triggering an action. */
-    get gracePeriod() {
-      return this.#gracePeriod;
-    }
-
-    /**
-     * @returns {?number} Maximum allowed size of heap usage, in bytes, or
-     * `null` for no limit.
-     */
-    get maxHeapBytes() {
-      return this.#maxHeapBytes;
-    }
-
-    /**
-     * @returns {?number} Maximum allowed size of RSS, in bytes, or `null` for
-     * no limit.
-     */
-    get maxRssBytes() {
-      return this.#maxRssBytes;
+        : MustBe.number(value, { finite: true, minInclusive: 1024 * 1024 });
     }
   };
 }

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -120,6 +120,11 @@ export class PathRouter extends BaseApplication {
       return result;
     }
 
+
+    //
+    // Static members
+    //
+
     /**
      * Parses a path.
      *

--- a/src/webapp-builtins/export/ProcessIdFile.js
+++ b/src/webapp-builtins/export/ProcessIdFile.js
@@ -223,55 +223,38 @@ export class ProcessIdFile extends BaseFileService {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseFileService.Config {
+    // @defaultConstructor
+
     /**
      * Allow multiple processes to be listed in the file?
      *
-     * @type {boolean}
+     * @param {boolean} [value] Proposed configuration value. Default `false`.
+     * @returns {boolean} Accepted configuration value.
      */
-    #multiprocess;
+    _config_multiprocess(value = false) {
+      return MustBe.boolean(value);
+    };
 
     /**
-     * How often to update the info file, or `null` to not perform updates.
+     * How often to update the info file, or `null` to not perform updates. If
+     * passed as a string, it is parsed by {@link Duration#parse}.
      *
-     * @type {?Duration}
+     * @param {?string|Duration} value Proposed configuration value. Default
+     *   `null`.
+     * @returns {?Duration} Accepted configuration value.
      */
-    #updatePeriod;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const { multiprocess = null, updatePeriod = null } = rawConfig;
-
-      this.#multiprocess = (typeof multiprocess === 'boolean')
-        ? multiprocess
-        : MustBe.null(multiprocess);
-
-      if (updatePeriod) {
-        this.#updatePeriod = Duration.parse(updatePeriod, { range: { minInclusive: 1 } });
-        if (!this.#updatePeriod) {
-          throw new Error(`Could not parse \`updatePeriod\`: ${updatePeriod}`);
-        }
-      } else {
-        this.#updatePeriod = MustBe.null(updatePeriod);
+    _config_updatePeriod(value = null) {
+      if (value === null) {
+        return null;
       }
-    }
 
-    /** @returns {boolean} Allow multiple processes to be listed in the file? */
-    get multiprocess() {
-      return this.#multiprocess;
-    }
+      const result = Duration.parse(value, { range: { minInclusive: 0 } });
 
-    /**
-     * @returns {?Duration} How often to update the info file, or `null` to not
-     * perform updates.
-     */
-    get updatePeriod() {
-      return this.#updatePeriod;
+      if (!result) {
+        throw new Error(`Could not parse \`updatePeriod\`: ${value}`);
+      }
+
+      return (result === 0) ? null : result;
     }
   };
 }

--- a/src/webapp-builtins/export/ProcessIdFile.js
+++ b/src/webapp-builtins/export/ProcessIdFile.js
@@ -236,8 +236,8 @@ export class ProcessIdFile extends BaseFileService {
     };
 
     /**
-     * How often to update the info file, or `null` to not perform updates. If
-     * passed as a string, it is parsed by {@link Duration#parse}.
+     * How often to update the process ID file, or `null` to not perform
+     * updates. If passed as a string, it is parsed by {@link Duration#parse}.
      *
      * @param {?string|Duration} value Proposed configuration value. Default
      *   `null`.
@@ -248,13 +248,13 @@ export class ProcessIdFile extends BaseFileService {
         return null;
       }
 
-      const result = Duration.parse(value, { range: { minInclusive: 0 } });
+      const result = Duration.parse(value, { range: { minInclusive: 1 } });
 
       if (!result) {
         throw new Error(`Could not parse \`updatePeriod\`: ${value}`);
       }
 
-      return (result === 0) ? null : result;
+      return result;
     }
   };
 }

--- a/src/webapp-builtins/export/ProcessInfoFile.js
+++ b/src/webapp-builtins/export/ProcessInfoFile.js
@@ -310,39 +310,28 @@ export class ProcessInfoFile extends BaseFileService {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseFileService.Config {
-    /**
-     * How often to update the info file, or `null` to not perform updates.
-     *
-     * @type {?Duration}
-     */
-    #updatePeriod;
+    // @defaultConstructor
 
     /**
-     * Constructs an instance.
+     * How often to update the process info file, or `null` to not perform
+     * updates. If passed as a string, it is parsed by {@link Duration#parse}.
      *
-     * @param {object} rawConfig Raw configuration object.
+     * @param {?string|Duration} value Proposed configuration value. Default
+     *   `null`.
+     * @returns {?Duration} Accepted configuration value.
      */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const { updatePeriod = null } = rawConfig;
-
-      if (updatePeriod) {
-        this.#updatePeriod = Duration.parse(updatePeriod, { range: { minInclusive: 1 } });
-        if (!this.#updatePeriod) {
-          throw new Error(`Could not parse \`updatePeriod\`: ${updatePeriod}`);
-        }
-      } else {
-        this.#updatePeriod = MustBe.null(updatePeriod);
+    _config_updatePeriod(value = null) {
+      if (value === null) {
+        return null;
       }
-    }
 
-    /**
-     * @returns {?Duration} How often to update the info file, or `null` to not
-     * perform updates.
-     */
-    get updatePeriod() {
-      return this.#updatePeriod;
+      const result = Duration.parse(value, { range: { minInclusive: 1 } });
+
+      if (!result) {
+        throw new Error(`Could not parse \`updatePeriod\`: ${value}`);
+      }
+
+      return result;
     }
   };
 }

--- a/src/webapp-builtins/export/ProcessInfoFile.js
+++ b/src/webapp-builtins/export/ProcessInfoFile.js
@@ -9,7 +9,6 @@ import { Duration } from '@this/data-values';
 import { Statter } from '@this/fs-util';
 import { Host, ProcessInfo, ProcessUtil, ProductInfo }
   from '@this/host';
-import { MustBe } from '@this/typey';
 import { BaseFileService, Saver } from '@this/webapp-util';
 
 

--- a/src/webapp-builtins/export/Redirector.js
+++ b/src/webapp-builtins/export/Redirector.js
@@ -93,33 +93,33 @@ export class Redirector extends BaseApplication {
     // @defaultConstructor
 
     /**
-     * Configuration property `statusCode`: The redirect status code to use.
+     * The redirect status code to use.
      *
      * @param {number} [value] Proposed configuration value. Default `308`.
      * @returns {number} Accepted configuration value.
      */
-    _check_statusCode(value = 308) {
+    _config_statusCode(value = 308) {
       return MustBe.number(value, { minInclusive: 300, maxInclusive: 399 });
     }
 
     /**
-     * Configuration property `target`: The target base URI.
+     * The target base URI.
      *
      * @param {string} value Proposed configuration value.
      * @returns {string} Accepted configuration value.
      */
-    _check_target(value) {
+    _config_target(value) {
       return UriUtil.checkBasicUri(value);
     }
 
     /**
-     * Configuration property `cacheControl`: `cache-control` header to
-     * automatically include, or `null` not to do that.
+     * `cache-control` header to automatically include in responses, or `null`
+     * not to include that header.
      *
      * @param {?string} [value] Proposed configuration value. Default `null`.
      * @returns {?string} Accepted configuration value.
      */
-    _check_cacheControl(value = null) {
+    _config_cacheControl(value = null) {
       if (value === null) {
         return null;
       } else if (typeof value === 'string') {

--- a/src/webapp-builtins/export/Redirector.js
+++ b/src/webapp-builtins/export/Redirector.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FullResponse, HttpUtil, UriUtil } from '@this/net-util';
-import { MustBe } from '@this/typey';
+import { AskIf, MustBe } from '@this/typey';
 import { BaseApplication } from '@this/webapp-core';
 
 
@@ -90,74 +90,45 @@ export class Redirector extends BaseApplication {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseApplication.Config {
-    /**
-     * The redirect status code to use.
-     *
-     * @type {number}
-     */
-    #statusCode;
+    // @defaultConstructor
 
     /**
-     * The target base URI.
+     * Configuration property `statusCode`: The redirect status code to use.
      *
-     * @type {string}
+     * @param {number} [value] Proposed configuration value. Default `308`.
+     * @returns {number} Accepted configuration value.
      */
-    #target;
+    _check_statusCode(value = 308) {
+      return MustBe.number(value, { minInclusive: 300, maxInclusive: 399 });
+    }
 
     /**
-     * `cache-control` header to automatically include, or `null` not to do
-     * that.
+     * Configuration property `target`: The target base URI.
      *
-     * @type {?string}
+     * @param {string} value Proposed configuration value.
+     * @returns {string} Accepted configuration value.
      */
-    #cacheControl = null;
+    _check_target(value) {
+      return UriUtil.checkBasicUri(value);
+    }
 
     /**
-     * Constructs an instance.
+     * Configuration property `cacheControl`: `cache-control` header to
+     * automatically include, or `null` not to do that.
      *
-     * @param {object} rawConfig Raw configuration object.
+     * @param {?string} value Proposed configuration value.
+     * @returns {?string} Accepted configuration value.
      */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const {
-        cacheControl = null,
-        statusCode = null,
-        target
-      } = rawConfig;
-
-      this.#statusCode = statusCode
-        ? MustBe.number(statusCode, { minInclusive: 300, maxInclusive: 399 })
-        : 308;
-
-      this.#target = UriUtil.checkBasicUri(target);
-
-      if ((cacheControl !== null) && (cacheControl !== false)) {
-        this.#cacheControl = (typeof cacheControl === 'string')
-          ? cacheControl
-          : HttpUtil.cacheControlHeader(cacheControl);
-        if (!this.#cacheControl) {
-          throw new Error('Invalid `cacheControl` option.');
-        }
+    _check_cacheControl(value) {
+      if (value === null) {
+        return null;
+      } else if (typeof value === 'string') {
+        return value;
+      } else if (AskIf.plainObject(value)) {
+        return HttpUtil.cacheControlHeader(value);
+      } else {
+        throw new Error('Invalid `cacheControl` option.');
       }
-    }
-
-    /**
-     * @returns {?string} `cache-control` header to automatically include, or
-     * `null` not to do that.
-     */
-    get cacheControl() {
-      return this.#cacheControl;
-    }
-
-    /** @returns {string} The target base URI. */
-    get statusCode() {
-      return this.#statusCode;
-    }
-
-    /** @returns {string} The target base URI. */
-    get target() {
-      return this.#target;
     }
   };
 }

--- a/src/webapp-builtins/export/Redirector.js
+++ b/src/webapp-builtins/export/Redirector.js
@@ -116,10 +116,10 @@ export class Redirector extends BaseApplication {
      * Configuration property `cacheControl`: `cache-control` header to
      * automatically include, or `null` not to do that.
      *
-     * @param {?string} value Proposed configuration value.
+     * @param {?string} [value] Proposed configuration value. Default `null`.
      * @returns {?string} Accepted configuration value.
      */
-    _check_cacheControl(value) {
+    _check_cacheControl(value = null) {
       if (value === null) {
         return null;
       } else if (typeof value === 'string') {

--- a/src/webapp-builtins/export/Redirector.js
+++ b/src/webapp-builtins/export/Redirector.js
@@ -113,10 +113,12 @@ export class Redirector extends BaseApplication {
     }
 
     /**
-     * `cache-control` header to automatically include in responses, or `null`
-     * not to include that header.
+     * `cache-control` header to automatically include, or `null` not to include
+     * it. Can be passed either as a literal string or an object to be passed to
+     * {@link HttpUtil#cacheControlHeader}.
      *
-     * @param {?string} [value] Proposed configuration value. Default `null`.
+     * @param {?string|object} [value] Proposed configuration value. Default
+     *   `null`.
      * @returns {?string} Accepted configuration value.
      */
     _config_cacheControl(value = null) {

--- a/src/webapp-builtins/export/RequestDelay.js
+++ b/src/webapp-builtins/export/RequestDelay.js
@@ -73,6 +73,8 @@ export class RequestDelay extends BaseApplication {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseApplication.Config {
+    // @defaultConstructor
+
     /**
      * Delay time, or `null` if `minDelay` and `maxDelay` are being used. If
      * passed as a string, it is parsed by {@link Duration#parse}.

--- a/src/webapp-builtins/export/RequestDelay.js
+++ b/src/webapp-builtins/export/RequestDelay.js
@@ -88,8 +88,8 @@ export class RequestDelay extends BaseApplication {
     }
 
     /**
-     * Maximum delay time, inclusive, if delays are to be made randomly within
-     * a range, or `null` if `delay` is being used. If passed as a string, it is
+     * Maximum delay time, inclusive, if delays are to be made randomly within a
+     * range, or `null` if `delay` is being used. If passed as a string, it is
      * parsed by {@link Duration#parse}.
      *
      * @param {?string|Duration} value Proposed configuration value. Default
@@ -101,9 +101,9 @@ export class RequestDelay extends BaseApplication {
     }
 
     /**
-     * Minimum delay time, inclusive, if delays are to be made randomly within
-     * a range, or `null` if `delay` is being used. If passed as a string, it
-     * is parsed by {@link Duration#parse}.
+     * Minimum delay time, inclusive, if delays are to be made randomly within a
+     * range, or `null` if `delay` is being used. If passed as a string, it is
+     * parsed by {@link Duration#parse}.
      *
      * @param {?string|Duration} value Proposed configuration value. Default
      *   `null`.

--- a/src/webapp-builtins/export/RequestDelay.js
+++ b/src/webapp-builtins/export/RequestDelay.js
@@ -74,87 +74,82 @@ export class RequestDelay extends BaseApplication {
    */
   static #Config = class Config extends BaseApplication.Config {
     /**
-     * Maximum delay time, inclusive.
+     * Delay time, or `null` if `minDelay` and `maxDelay` are being used. If
+     * passed as a string, it is parsed by {@link Duration#parse}.
      *
-     * @type {Duration}
+     * @param {?string|Duration} value Proposed configuration value. Default
+     *   `null`.
+     * @returns {?Duration} Accepted configuration value.
      */
-    #maxDelay;
+    _config_delay(value = null) {
+      return (value === null) ? null : Config.#parseDelay(value);
+    }
 
     /**
-     * Minimum delay time, inclusive.
+     * Maximum delay time, inclusive, if delays are to be made randomly within
+     * a range, or `null` if `delay` is being used. If passed as a string, it is
+     * parsed by {@link Duration#parse}.
      *
-     * @type {Duration}
+     * @param {?string|Duration} value Proposed configuration value. Default
+     *   `null`.
+     * @returns {?Duration} Accepted configuration value.
      */
-    #minDelay;
+    _config_maxDelay(value = null) {
+      return (value === null) ? null : Config.#parseDelay(value);
+    }
 
     /**
-     * Time source.
+     * Minimum delay time, inclusive, if delays are to be made randomly within
+     * a range, or `null` if `delay` is being used. If passed as a string, it
+     * is parsed by {@link Duration#parse}.
      *
-     * @type {IntfTimeSource}
+     * @param {?string|Duration} value Proposed configuration value. Default
+     *   `null`.
+     * @returns {?Duration} Accepted configuration value.
      */
-    #timeSource;
+    _config_minDelay(value = null) {
+      return (value === null) ? null : Config.#parseDelay(value);
+    }
 
     /**
-     * Constructs an instance.
+     * Time source, or `null` to use the standard time source. This
+     * configuration option is mostly intended for testing.
      *
-     * @param {object} rawConfig Raw configuration object.
+     * @param {?IntfTimeSource} [value] Proposed configuration value. Default
+     *   `null`.
+     * @returns {IntfTimeSource} Accepted configuration value.
      */
-    constructor(rawConfig) {
-      super(rawConfig);
+    _config_timeSource(value = null) {
+      // TODO: Check that a non-`null` `value` actually implements
+      // `IntfTimeSource`.
 
-      const {
-        delay      = null,
-        minDelay   = null,
-        maxDelay   = null,
-        timeSource = null
-      } = rawConfig;
+      return (value === null)
+        ? StdTimeSource.INSTANCE
+        : MustBe.object(value);
+    }
 
-      if (delay !== null) {
-        if ((maxDelay !== null) || (minDelay !== null)) {
-          throw new Error('Must specify either `delay` or both `minDelay` and `maxDelay`.');
-        }
-        this.#maxDelay = Config.#parseDelay(delay);
-        this.#minDelay = this.#maxDelay;
-      } else if ((maxDelay !== null) && (minDelay !== null)) {
-        this.#maxDelay = Config.#parseDelay(maxDelay);
-        this.#minDelay = Config.#parseDelay(minDelay);
-        if (this.#minDelay.gt(this.#maxDelay)) {
-          throw new Error('`minDelay` must not be greater than `maxDelay`.');
-        } else if (this.#minDelay.eq(this.#maxDelay)) {
-          // Allow a literal `===` comparison in the handler.
-          this.#minDelay = this.#maxDelay;
-        }
-      } else {
+    /** @override */
+    _impl_validate(config) {
+      const { delay } = config;
+      let   { maxDelay, minDelay } = config;
+
+      if (!!delay === !!(maxDelay || minDelay)) {
         throw new Error('Must specify either `delay` or both `minDelay` and `maxDelay`.');
+      } else if (delay) {
+        maxDelay = minDelay = delay;
+      } else if (!(maxDelay && minDelay)) {
+        throw new Error('Must specify both `minDelay` and `maxDelay` if either is used.');
+      } else if (minDelay.gt(maxDelay)) {
+        throw new Error('`minDelay` must not be greater than `maxDelay`.');
+      } else if (minDelay.eq(maxDelay)) {
+        // This allows a `===` comparison in the handler to work.
+        minDelay = maxDelay;
       }
 
-      if (timeSource === null) {
-        this.#timeSource = StdTimeSource.INSTANCE;
-      } else {
-        // TODO: Check that it actually implements `IntfTimeSource`.
-        this.#timeSource = MustBe.object(timeSource);
-      }
-    }
+      const result = { ...config, maxDelay, minDelay };
+      delete result.delay;
 
-    /**
-     * @returns {Duration} Maximum delay time, inclusive.
-     */
-    get maxDelay() {
-      return this.#maxDelay;
-    }
-
-    /**
-     * @returns {Duration} Minimum delay time, inclusive.
-     */
-    get minDelay() {
-      return this.#minDelay;
-    }
-
-    /**
-     * @returns {IntfTimeSource} Time source.
-     */
-    get timeSource() {
-      return this.#timeSource;
+      return super._impl_validate(result);
     }
 
 

--- a/src/webapp-builtins/export/RequestFilter.js
+++ b/src/webapp-builtins/export/RequestFilter.js
@@ -3,7 +3,7 @@
 
 import { FullResponse, HttpUtil, StatusResponse, TypeOutgoingResponse }
   from '@this/net-util';
-import { MustBe } from '@this/typey';
+import { MustBe, StringUtil } from '@this/typey';
 import { BaseApplication } from '@this/webapp-core';
 
 
@@ -120,185 +120,126 @@ export class RequestFilter extends BaseApplication {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseApplication.Config {
-    /**
-     * The response status to use when filtering out a request.
-     *
-     * @type {number}
-     */
-    #filterResponseStatus;
+    // @defaultConstructor
 
     /**
-     * Set of request methods (e.g. `post`) that the application accepts.
+     * Set of request methods (e.g. `post`) that the application accepts,
+     * lowercased, or `null` if not to filter on request methods. When passed as
+     * non-`null`, it is expected to be a single string (if only one method is
+     * to be accepted) or an array of strings.
      *
-     * @type {Set<string>}
+     * @param {?string|Array<string>} value Proposed configuration value.
+     *   Default `null`.
+     * @returns {?Set<string>} Accepted configuration value.
      */
-    #acceptMethods;
-
-    /**
-     * Maximum allowed dispatch `extra` path length in slash-separated
-     * components (inclusive), or `null` if there is no limit.
-     *
-     * @type {?number}
-     */
-    #maxPathDepth;
-
-    /**
-     * Maximum allowed dispatch `extra` path length in octets (inclusive), or
-     * `null` if there is no limit.
-     *
-     * @type {?number}
-     */
-    #maxPathLength;
-
-    /**
-     * Maximum allowed query (search string) length in octets (inclusive), or
-     * `null` if there is no limit.
-     *
-     * @type {?number}
-     */
-    #maxQueryLength;
-
-    /**
-     * Redirect file paths to the corresponding directory?
-     *
-     * @type {boolean}
-     */
-    #redirectDirectories;
-
-    /**
-     * Redirect directory paths to the corresponding file?
-     *
-     * @type {boolean}
-     */
-    #redirectFiles;
-
-    /**
-     * Reject directory (non-file) paths?
-     *
-     * @type {boolean}
-     */
-    #rejectDirectories;
-
-    /**
-     * Reject file (non-directory) paths?
-     *
-     * @type {boolean}
-     */
-    #rejectFiles;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const {
-        acceptMethods        = null,
-        filterResponseStatus = 404,
-        maxPathDepth         = null,
-        maxPathLength        = null,
-        maxQueryLength       = null,
-        redirectDirectories  = false,
-        redirectFiles        = false,
-        rejectDirectories    = false,
-        rejectFiles          = false
-      } = rawConfig;
-
-      this.#acceptMethods = (acceptMethods === null)
-        ? null
-        : new Set(MustBe.arrayOfString(acceptMethods, Config.#METHODS));
-      this.#filterResponseStatus = HttpUtil.checkStatus(filterResponseStatus);
-      this.#maxPathDepth = (maxPathDepth === null)
-        ? null
-        : MustBe.number(maxPathDepth, { safeInteger: true, minInclusive: 0 });
-      this.#maxPathLength = (maxPathLength === null)
-        ? null
-        : MustBe.number(maxPathLength, { safeInteger: true, minInclusive: 0 });
-      this.#maxQueryLength = (maxQueryLength === null)
-        ? null
-        : MustBe.number(maxQueryLength, { safeInteger: true, minInclusive: 0 });
-      this.#redirectDirectories = MustBe.boolean(redirectDirectories);
-      this.#redirectFiles       = MustBe.boolean(redirectFiles);
-      this.#rejectDirectories   = MustBe.boolean(rejectDirectories);
-      this.#rejectFiles         = MustBe.boolean(rejectFiles);
-
-      const boolCount =
-        redirectDirectories + redirectFiles + rejectDirectories + rejectFiles;
-      if (boolCount > 1) {
-        throw new Error('Cannot configure more than one `redirect*` or `reject*` option as `true`.');
+    _config_acceptMethods(value = null) {
+      if (value === null) {
+        return null;
+      } else {
+        const array = StringUtil.checkAndFreezeStrings(value, Config.#METHODS);
+        return new Set(array);
       }
     }
 
     /**
-     * @returns {Set<string>} Set of request methods (e.g. `post`) that the
-     * application accepts.
+     * The response status to use when filtering out a request.
+     *
+     * @param {number} [value] Proposed configuration value. Default `404`.
+     * @returns {number} Accepted configuration value.
      */
-    get acceptMethods() {
-      return this.#acceptMethods;
-    }
-
-    /**
-     * @returns {number} The response status to use when filtering out a
-     * request.
-     */
-    get filterResponseStatus() {
-      return this.#filterResponseStatus;
+    _config_filterResponseStatus(value = 404) {
+      return HttpUtil.checkStatus(value);
     }
 
     /**
      * Maximum allowed dispatch `extra` path length in slash-separated
      * components (inclusive), or `null` if there is no limit.
      *
-     * @type {?number}
+     * @param {?number} [value] Proposed configuration value. Default `null`.
+     * @returns {?number} Accepted configuration value.
      */
-    get maxPathDepth() {
-      return this.#maxPathDepth;
+    _config_maxPathDepth(value = null) {
+      return (value === null)
+        ? null
+        : MustBe.number(value, { safeInteger: true, minInclusive: 0 });
     }
 
     /**
      * Maximum allowed dispatch `extra` path length in octets (inclusive), or
      * `null` if there is no limit.
      *
-     * @type {?number}
+     * @param {?number} [value] Proposed configuration value. Default `null`.
+     * @returns {?number} Accepted configuration value.
      */
-    get maxPathLength() {
-      return this.#maxPathLength;
+    _config_maxPathLength(value = null) {
+      return (value === null)
+        ? null
+        : MustBe.number(value, { safeInteger: true, minInclusive: 0 });
     }
 
     /**
      * Maximum allowed query (search string) length in octets (inclusive), or
      * `null` if there is no limit.
      *
-     * @type {?number}
+     * @param {?number} [value] Proposed configuration value. Default `null`.
+     * @returns {?number} Accepted configuration value.
      */
-    get maxQueryLength() {
-      return this.#maxQueryLength;
+    _config_maxQueryLength(value = null) {
+      return (value === null)
+        ? null
+        : MustBe.number(value, { safeInteger: true, minInclusive: 0 });
     }
 
     /**
-     * @returns {boolean} Redirect file paths to the corresponding directory?
+     * Redirect file paths to the corresponding directory?
+     *
+     * @param {boolean} [value] Proposed configuration value. Default `false`.
+     * @returns {boolean} Accepted configuration value.
      */
-    get redirectDirectories() {
-      return this.#redirectDirectories;
+    _config_redirectDirectories(value = false) {
+      return MustBe.boolean(value);
     }
 
     /**
-     * @returns {boolean} Redirect directory paths to the corresponding file?
+     * Redirect directory paths to the corresponding file?
+     *
+     * @param {boolean} [value] Proposed configuration value. Default `false`.
+     * @returns {boolean} Accepted configuration value.
      */
-    get redirectFiles() {
-      return this.#redirectFiles;
+    _config_redirectFiles(value = false) {
+      return MustBe.boolean(value);
     }
 
-    /** @returns {boolean} Reject directory (non-file) paths? */
-    get rejectDirectories() {
-      return this.#rejectDirectories;
+    /**
+     * Reject directory (non-file) paths?
+     *
+     * @param {boolean} [value] Proposed configuration value. Default `false`.
+     * @returns {boolean} Accepted configuration value.
+     */
+    _config_rejectDirectories(value = false) {
+      return MustBe.boolean(value);
     }
 
-    /** @returns {boolean} Reject file (non-directory) paths? */
-    get rejectFiles() {
-      return this.#rejectFiles;
+    /**
+     * Reject file (non-directory) paths?
+     *
+     * @param {boolean} [value] Proposed configuration value. Default `false`.
+     * @returns {boolean} Accepted configuration value.
+     */
+    _config_rejectFiles(value = false) {
+      return MustBe.boolean(value);
+    }
+
+    /** @override */
+    _impl_validate(config) {
+      const { redirectDirectories, redirectFiles, rejectDirectories, rejectFiles } = config;
+      const boolCount = redirectDirectories + redirectFiles + rejectDirectories + rejectFiles;
+
+      if (boolCount > 1) {
+        throw new Error('Cannot configure more than one `redirect*` or `reject*` option as `true`.');
+      }
+
+      return config;
     }
 
 

--- a/src/webapp-builtins/export/RequestRateLimiter.js
+++ b/src/webapp-builtins/export/RequestRateLimiter.js
@@ -81,30 +81,61 @@ export class RequestRateLimiter extends BaseApplication {
    */
   static #Config = class Config extends BaseApplication.Config {
     /**
-     * Configuration for the token bucket to use.
+     * Request flow rate. If passed as a `string` it is parsed into an
+     * instance of {@link RequestRate}.
      *
-     * @type {object}
+     * @param {string|RequestRate} value Proposed configuration value.
+     * @returns {RequestRate} Accepted configuration value.
      */
-    #bucket;
+    _config_flowRate(value) {
+      if ((typeof value === 'string') || (value instanceof RequestRate)) {
+        return value;
+      }
+
+      throw new Error('Invalid value for `flowRate`.');
+    }
 
     /**
-     * Constructs an instance.
+     * Maximum count of requests in a burst. If passed as a `string` it is
+     * parsed into an instance of {@link RequestCount}.
      *
-     * @param {object} rawConfig Raw configuration object.
+     * @param {string|RequestCount} value Proposed configuration value.
+     * @returns {RequestCount} Accepted configuration value.
      */
-    constructor(rawConfig) {
-      super(rawConfig);
+    _config_maxBurst(value) {
+      if ((typeof value === 'string') || (value instanceof RequestCount)) {
+        return value;
+      }
 
-      this.#bucket = RateLimitConfig.parse(rawConfig, {
-        allowMqg:  false,
+      throw new Error('Invalid value for `maxBurst`.');
+    }
+
+    /**
+     * Maximum count of connections that can be queued up for acceptance, or
+     * `null` to have no limit. If passed as a `string` it is parsed into an
+     * instance of {@link RequestCount}.
+     *
+     * @param {?string|RequestCount} value Proposed configuration value.
+     * @returns {?RequestCount} Accepted configuration value.
+     */
+    _config_maxQueue(value = null) {
+      if (value === null) {
+        return null;
+      } else if ((typeof value === 'string') || (value instanceof RequestCount)) {
+        return value;
+      }
+
+      throw new Error('Invalid value for `maxQueue`.');
+    }
+
+    /** @override */
+    _impl_validate(config) {
+      const bucket = RateLimitConfig.parse(config, {
         rateType:  RequestRate,
         tokenType: RequestCount
       });
-    }
 
-    /** @returns {object} Configuration for the token bucket to use. */
-    get bucket() {
-      return this.#bucket;
+      return super._impl_validate({ ...config, bucket });
     }
   };
 }

--- a/src/webapp-builtins/export/RequestRateLimiter.js
+++ b/src/webapp-builtins/export/RequestRateLimiter.js
@@ -81,8 +81,8 @@ export class RequestRateLimiter extends BaseApplication {
    */
   static #Config = class Config extends BaseApplication.Config {
     /**
-     * Request flow rate. If passed as a `string` it is parsed into an
-     * instance of {@link RequestRate}.
+     * Request flow rate. If passed as a `string` it is parsed into an instance
+     * of {@link RequestRate}.
      *
      * @param {string|RequestRate} value Proposed configuration value.
      * @returns {RequestRate} Accepted configuration value.

--- a/src/webapp-builtins/export/SerialRouter.js
+++ b/src/webapp-builtins/export/SerialRouter.js
@@ -3,7 +3,7 @@
 
 import { Names } from '@this/compy';
 import { IntfRequestHandler } from '@this/net-util';
-import { MustBe } from '@this/typey';
+import { StringUtil } from '@this/typey';
 import { BaseApplication } from '@this/webapp-core';
 
 
@@ -40,7 +40,7 @@ export class SerialRouter extends BaseApplication {
 
   /** @override */
   async _impl_init() {
-    this.logger?.routes(this.config.routeList);
+    this.logger?.routes(this.config.applications);
   }
 
   /** @override */
@@ -52,7 +52,7 @@ export class SerialRouter extends BaseApplication {
     const appManager = this.root.applicationManager;
     const routeList  = [];
 
-    for (const name of this.config.routeList) {
+    for (const name of this.config.applications) {
       const app = appManager.get(name);
       routeList.push(app);
     }
@@ -79,40 +79,19 @@ export class SerialRouter extends BaseApplication {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseApplication.Config {
+    // @defaultConstructor
+
     /**
-     * Like the outer `routeList` except with names instead of application
-     * instances.
+     * List of the names of all the applications to route to, in order. Each
+     * name must be a valid component name, per {@link Names#checkName}.
      *
-     * @type {Array<string>}
+     * @param {Array<string>} value Proposed configuration value.
+     * @returns {Array<string>} Accepted configuration value.
      */
-    #routeList;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const { applications } = rawConfig;
-
-      MustBe.arrayOfString(applications);
-
-      for (const name of applications) {
-        Names.checkName(name);
-      }
-
-      // `[...]` to copy the list in order to avoid outside interference.
-      this.#routeList = [...applications];
-    }
-
-    /**
-     * @returns {Array<string>} Like the outer `routeList` except with names
-     * instead of application instances.
-     */
-    get routeList() {
-      return this.#routeList;
+    _config_applications(value) {
+      return StringUtil.checkAndFreezeStrings(
+        value,
+        (item) => Names.checkName(item));
     }
   };
 }

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -7,7 +7,7 @@ import { WallClock } from '@this/clocky';
 import { Paths, Statter } from '@this/fs-util';
 import { EtagGenerator, FullResponse, HttpUtil, MimeTypes }
   from '@this/net-util';
-import { MustBe } from '@this/typey';
+import { AskIf, MustBe } from '@this/typey';
 import { BaseApplication } from '@this/webapp-core';
 
 
@@ -55,7 +55,7 @@ export class SimpleResponse extends BaseApplication {
     }
 
     const {
-      body, contentType, cacheControl, etagOptions, filePath, statusCode
+      body, contentType, cacheControl, etag, filePath, statusCode
     } = this.config;
 
     const response  = new FullResponse();
@@ -88,10 +88,10 @@ export class SimpleResponse extends BaseApplication {
       response.cacheControl = cacheControl;
     }
 
-    if (etagOptions) {
-      const etagGen = new EtagGenerator(etagOptions);
-      const etag    = await etagGen.etagFromData(response.bodyBuffer ?? '');
-      headers.set('etag', etag);
+    if (etag) {
+      const etagGen    = new EtagGenerator(etag);
+      const etagHeader = await etagGen.etagFromData(response.bodyBuffer ?? '');
+      headers.set('etag', etagHeader);
     }
 
     if (statusCode !== null) {
@@ -121,165 +121,138 @@ export class SimpleResponse extends BaseApplication {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseApplication.Config {
-    /**
-     * Predefined status code of the response, or `null` to use the most
-     * appropriate "success" status code (most typically `200`).
-     *
-     * @type {?number}
-     */
-    #statusCode = null;
+    // @defaultConstructor
 
     /**
-     * Content type of the response, or `null` to infer it from {@link
-     * #filePath}.
+     * Body contents of the response, or `null` to use `filePath` if present
+     * _or_ respond with no body.
      *
-     * @type {?string}
+     * @param {?string|Buffer} [value] Proposed configuration value. Default
+     *   `null`.
+     * @returns {?string|Buffer} Accepted configuration value.
      */
-    #contentType = null;
+    _config_body(value = null) {
+      if (value === null) {
+        return value;
+      } else if ((value instanceof Buffer) || (typeof value === 'string')) {
+        return value;
+      } else {
+        throw new Error('Invalid `body` option.');
+      }
+    }
 
     /**
-     * Body contents of the response, or `null` to use {@link #filePath}.
+     * `cache-control` header to automatically include, or `null` not to include
+     * it. Can be passed either as a literal string or an object to be passed to
+     * {@link HttpUtil#cacheControlHeader}.
      *
-     * @type {?(string|Buffer)}
+     * @param {?string|object} [value] Proposed configuration value. Default
+     *   `null`.
+     * @returns {?string} Accepted configuration value.
      */
-    #body = null;
+    _config_cacheControl(value = null) {
+      if (value === null) {
+        return null;
+      } else if (typeof value === 'string') {
+        return value;
+      } else if (AskIf.plainObject(value)) {
+        return HttpUtil.cacheControlHeader(value);
+      } else {
+        throw new Error('Invalid `cacheControl` option.');
+      }
+    }
 
     /**
-     * `cache-control` header to automatically include, or `null` not to do
-     * that.
+     * Content type of the response, or `null` to infer it from `filePath`.
      *
-     * @type {?string}
+     * @param {?string} [value] Proposed configuration value. Default `null`.
+     * @returns {?string} Accepted configuration value.
      */
-    #cacheControl = null;
+    _config_contentType(value = null) {
+      // Note: Conversion is done in `_impl_validate()`, because we don't know
+      // what options to pass to the MIME type converter until we see if we
+      // have `body` or `filePath`.
+      return (value === null) ? null : MustBe.string(value);
+    }
 
     /**
-     * Etag-generating options, or `null` not to do that.
+     * Etag-generating options, `true` for default options, or `null` not to
+     * include an `etag` header in responses.
      *
-     * @type {?object}
+     * @param {?object|true} [value] Proposed configuration value. Default
+     *   `null`.
+     * @returns {?object} Accepted configuration value.
      */
-    #etagOptions = null;
+    _config_etag(value = null) {
+      if (value === null) {
+        return null;
+      } else if (value === true) {
+        return EtagGenerator.expandOptions({});
+      } else if (AskIf.plainObject(value)) {
+        return EtagGenerator.expandOptions(value);
+      } else {
+        throw new Error('Invalid `etag` option.');
+      }
+    }
 
     /**
-     * Absolute path to a file for the body contents, or `null` if {@link #body}
+     * Absolute path to a file for the body contents, or `null` if `body`
      * is supplied directly.
      *
      * @type {?string}
      */
-    #filePath = null;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const {
-        body         = null,
-        contentType  = null,
-        cacheControl = null,
-        etag         = null,
-        filePath     = null,
-        statusCode   = null
-      } = rawConfig;
-
-      if (body !== null) {
-        if (!(body instanceof Buffer)) {
-          MustBe.string(body);
-        }
-
-        if (contentType === null) {
-          throw new Error('Must supply `contentType` if `body` is used.');
-        } else if (filePath !== null) {
-          throw new Error('Cannot specify both `body` and `filePath`.');
-        }
-
-        const isText = typeof body === 'string';
-
-        this.#body        = body;
-        this.#contentType = MimeTypes.typeFromExtensionOrType(contentType, { isText });
-      } else if (filePath !== null) {
-        this.#filePath    = Paths.checkAbsolutePath(filePath);
-        this.#contentType = (contentType === null)
-          ? MimeTypes.typeFromPathExtension(filePath)
-          : MimeTypes.typeFromExtensionOrType(contentType);
-      } else {
-        // It's an empty body.
-        if (contentType !== null) {
-          throw new Error('Cannot supply `contentType` with empty body.');
-        }
-      }
-
-      if ((cacheControl !== null) && (cacheControl !== false)) {
-        this.#cacheControl = (typeof cacheControl === 'string')
-          ? cacheControl
-          : HttpUtil.cacheControlHeader(cacheControl);
-        if (!this.#cacheControl) {
-          throw new Error('Invalid `cacheControl` option.');
-        }
-      }
-
-      if ((etag !== null) && (etag !== false)) {
-        this.#etagOptions =
-          EtagGenerator.expandOptions((etag === true) ? {} : etag);
-      }
-
-      if (statusCode !== null) {
-        this.#statusCode =
-          MustBe.number(statusCode, {
-            safeInteger:  true,
-            minInclusive: 100,
-            maxInclusive: 599
-          });
-      }
-    }
-
-    /**
-     * @returns {?(string|Buffer)} Body contents of the response, or `null` to
-     * use {@link #filePath}.
-     */
-    get body() {
-      return this.#body;
-    }
-
-    /**
-     * @returns {?string} `cache-control` header to automatically include, or
-     * `null` not to do that.
-     */
-    get cacheControl() {
-      return this.#cacheControl;
-    }
-
-    /**
-     * @returns {?string} Content type of the response, or `null` to infer it
-     * from {@link #filePath}.
-     */
-    get contentType() {
-      return this.#contentType;
-    }
-
-    /** @returns {?object} Etag-generating options, or `null` not to do that. */
-    get etagOptions() {
-      return this.#etagOptions;
-    }
-
-    /**
-     * @returns {?string} Absolute path to a file for the body contents, or
-     * `null` if {@link #body} is supplied directly.
-     */
-    get filePath() {
-      return this.#filePath;
+    _config_filePath(value = null) {
+      return (value === null)
+        ? null
+        : Paths.checkAbsolutePath(value);
     }
 
     /**
      * Predefined status code of the response, or `null` to use the most
-     * appropriate "success" status code (most typically `200`).
+     * appropriate "success" status code (usually but not always `200`).
      *
-     * @type {?number}
+     * @param {?number} [value] Proposed configuration value. Default `null`.
+     * @returns {?number} Accepted configuration value.
      */
-    get statusCode() {
-      return this.#statusCode;
+    _config_statusCode(value = null) {
+      if (value === null) {
+        return null;
+      }
+
+      return MustBe.number(value, {
+        safeInteger:  true,
+        minInclusive: 100,
+        maxInclusive: 599
+      });
+    }
+
+    /** @override */
+    _impl_validate(config) {
+      const { body, filePath } = config;
+      let   { contentType }    = config;
+
+      if (body !== null) {
+        if (contentType === null) {
+          throw new Error('Must specify `contentType` if `body` is used.');
+        } else if (filePath !== null) {
+          throw new Error('Cannot specify both `body` and `filePath`.');
+        }
+
+        contentType = MimeTypes.typeFromExtensionOrType(contentType, {
+          isText: (typeof body === 'string')
+        });
+      } else if (filePath !== null) {
+        contentType = (contentType === null)
+          ? MimeTypes.typeFromPathExtension(filePath)
+          : MimeTypes.typeFromExtensionOrType(contentType);
+      } else {
+        // It's a no-body response.
+        if (contentType !== null) {
+          throw new Error('Cannot specify `contentType` on a no-body response.');
+        }
+      }
+
+      return super._impl_validate({ ...config, contentType });
     }
   };
 }

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -196,8 +196,8 @@ export class SimpleResponse extends BaseApplication {
     }
 
     /**
-     * Absolute path to a file for the body contents, or `null` if `body`
-     * is being used _or_ if this is to be a no-body response.
+     * Absolute path to a file for the body contents, or `null` if `body` is
+     * being used _or_ if this is to be a no-body response.
      *
      * @param {?string} [value] Proposed configuration value. Default `null`.
      * @returns {?string} Accepted configuration value.

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -197,9 +197,10 @@ export class SimpleResponse extends BaseApplication {
 
     /**
      * Absolute path to a file for the body contents, or `null` if `body`
-     * is supplied directly.
+     * is being used _or_ if this is to be a no-body response.
      *
-     * @type {?string}
+     * @param {?string} [value] Proposed configuration value. Default `null`.
+     * @returns {?string} Accepted configuration value.
      */
     _config_filePath(value = null) {
       return (value === null)

--- a/src/webapp-builtins/export/SuffixRouter.js
+++ b/src/webapp-builtins/export/SuffixRouter.js
@@ -122,8 +122,8 @@ export class SuffixRouter extends BaseApplication {
 
     /**
      * Map from each file name suffix spec (e.g. with `*` prefixes) to the name
-     * of the application to handle that spec. On input, the value must be
-     * a plain object.
+     * of the application to handle that spec. On input, the value must be a
+     * plain object.
      *
      * @param {object} value Proposed configuration value.
      * @returns {{ routeMap: Map<string, string>, suffixMatcher: RegExp }}

--- a/src/webapp-builtins/export/SuffixRouter.js
+++ b/src/webapp-builtins/export/SuffixRouter.js
@@ -98,59 +98,44 @@ export class SuffixRouter extends BaseApplication {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseApplication.Config {
-    /**
-     * Like the outer `routeMap` except with names instead of handler instances.
-     *
-     * @type {Map<string, string>}
-     */
-    #routeMap;
-
-    /**
-     * Regular expression which matches the longest handled suffix of a given
-     * file name. This ends up having a form along the lines of
-     * `/(?<!^)(?:(?:[.]bar)|(?:[.]baz)|(?:-bar[.]baz)|(?:))$/`.
-     *
-     * @type {RegExp}
-     */
-    #suffixMatcher;
+    // @defaultConstructor
 
     /**
      * Should directory paths get matched?
      *
-     * @type {boolean}
+     * @param {boolean} [value] Proposed configuration value. Default `false`.
+     * @returns {boolean} Accepted configuration value.
      */
-    #handleDirectories;
+    _config_handleDirectories(value = false) {
+      return MustBe.boolean(value);
+    }
 
     /**
      * Should file paths (non-directories) get matched?
      *
-     * @type {boolean}
+     * @param {boolean} [value] Proposed configuration value. Default `true`.
+     * @returns {boolean} Accepted configuration value.
      */
-    #handleFiles;
+    _config_handleFiles(value = true) {
+      return MustBe.boolean(value);
+    }
 
     /**
-     * Constructs an instance.
+     * Map from each file name suffix spec (e.g. with `*` prefixes) to the name
+     * of the application to handle that spec. On input, the value must be
+     * a plain object.
      *
-     * @param {object} rawConfig Raw configuration object.
+     * @param {object} value Proposed configuration value.
+     * @returns {{ routeMap: Map<string, string>, suffixMatcher: RegExp }}
+     *   Accepted configuration value.
      */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const {
-        handleDirectories = false,
-        handleFiles       = true,
-        suffixes
-      } = rawConfig;
-
-      MustBe.plainObject(suffixes);
-
-      this.#handleDirectories = MustBe.boolean(handleDirectories);
-      this.#handleFiles       = MustBe.boolean(handleFiles);
+    _config_suffixes(value) {
+      MustBe.plainObject(value);
 
       const routeMap   = new Map();
       const regexParts = [];
 
-      for (const [suffix, name] of Object.entries(suffixes)) {
+      for (const [suffix, name] of Object.entries(value)) {
         const { text, regex } = Config.#parseSuffix(suffix);
         if (routeMap.has(text)) {
           throw new Error(`Duplicate suffix spec: ${suffix}`);
@@ -159,35 +144,33 @@ export class SuffixRouter extends BaseApplication {
         regexParts.push(regex);
       }
 
-      this.#routeMap      = routeMap;
-      this.#suffixMatcher = new RegExp(`(?<!^)(?:${regexParts.join('|')})$`);
+      // This is a regex which matches the longest handled suffix of a given
+      // file name. It ends up having a form along the lines of
+      // `/(?<!^)(?:(?:[.]bar)|(?:[.]baz)|(?:-bar[.]baz)|(?:))$/`.
+      const suffixMatcher = new RegExp(`(?<!^)(?:${regexParts.join('|')})$`);
+
+      return { routeMap, suffixMatcher };
     }
 
-    /**
-     * @returns {Map<string, string>} Like the outer `routeMap` except with
-     * names instead of handler instances.
-     */
-    get routeMap() {
-      return this.#routeMap;
+    /** @override */
+    _impl_validate(config) {
+      const { handleDirectories, handleFiles } = config;
+
+      if (!(handleDirectories || handleFiles)) {
+        throw new Error('Must configure at least one of `handleDirectories` or `handleFiles` as true');
+      }
+
+      // Replace `suffixes` with its elements.
+      const result = { ...config, ...(config.suffixes) };
+      delete result.suffixes;
+
+      return super._impl_validate(result);
     }
 
-    /**
-     * @returns {RegExp} Regular expression which matches the longest handled
-     * suffix of a given file name.
-     */
-    get suffixMatcher() {
-      return this.#suffixMatcher;
-    }
 
-    /** @returns {boolean} Should directory paths get matched? */
-    get handleDirectories() {
-      return this.#handleDirectories;
-    }
-
-    /** @returns {boolean} Should file paths (non-directories) get matched? */
-    get handleFiles() {
-      return this.#handleFiles;
-    }
+    //
+    // Static members
+    //
 
     /**
      * Parses a suffix specifier.

--- a/src/webapp-builtins/export/SyslogToFile.js
+++ b/src/webapp-builtins/export/SyslogToFile.js
@@ -119,60 +119,41 @@ export class SyslogToFile extends BaseFileService {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseFileService.Config {
-    /**
-     * How long to buffer updates for, or `null` to not do any buffering.
-     *
-     * @type {?Duration}
-     */
-    #bufferPeriod;
+    // @defaultConstructor
 
     /**
-     * The output format name.
+     * How long to buffer updates for, or `null` to not do any buffering. If
+     * passed as a string, it is parsed by {@link Duration#parse}.
      *
-     * @type {string}
+     * @param {?string|Duration} value Proposed configuration value. Default
+     *   `null`.
+     * @returns {?Duration} Accepted configuration value.
      */
-    #format;
+    _config_bufferPeriod(value = null) {
+      const result = Duration.parse(value, { range: { minInclusive: 0 } });
 
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const { bufferPeriod = null, format } = rawConfig;
-
-      if (bufferPeriod) {
-        this.#bufferPeriod = Duration.parse(bufferPeriod, { range: { minInclusive: 0 } });
-        if (!this.#bufferPeriod) {
-          throw new Error(`Could not parse \`bufferPeriod\`: ${bufferPeriod}`);
-        }
-        if (this.#bufferPeriod === 0) {
-          this.#bufferPeriod = null;
-        }
-      } else {
-        this.#bufferPeriod = MustBe.null(bufferPeriod);
+      if (!result) {
+        throw new Error(`Could not parse \`bufferPeriod\`: ${value}`);
       }
 
-      this.#format = MustBe.string(format);
-
-      if (!TextFileSink.isValidFormat(format)) {
-        throw new Error(`Unknown log format: ${format}`);
-      }
+      return (result === 0) ? null : result;
     }
 
     /**
-     * @returns {?Duration} How long to buffer updates for, or `null` to not do
-     * any buffering.
+     * The output format name. Must be valid per {@link
+     * TextFileSink#isValidFormat}.
+     *
+     * @param {string} value Proposed configuration value.
+     * @returns {string} Accepted configuration value.
      */
-    get bufferPeriod() {
-      return this.#bufferPeriod;
-    }
+    _config_format(value) {
+      MustBe.string(value);
 
-    /** @returns {string} The output format name. */
-    get format() {
-      return this.#format;
+      if (!TextFileSink.isValidFormat(value)) {
+        throw new Error(`Unknown log format: ${value}`);
+      }
+
+      return value;
     }
   };
 }

--- a/src/webapp-builtins/export/SyslogToFile.js
+++ b/src/webapp-builtins/export/SyslogToFile.js
@@ -130,6 +130,10 @@ export class SyslogToFile extends BaseFileService {
      * @returns {?Duration} Accepted configuration value.
      */
     _config_bufferPeriod(value = null) {
+      if (value === null) {
+        return null;
+      }
+
       const result = Duration.parse(value, { range: { minInclusive: 0 } });
 
       if (!result) {

--- a/src/webapp-builtins/tests/RequestDelay.test.js
+++ b/src/webapp-builtins/tests/RequestDelay.test.js
@@ -64,6 +64,10 @@ describe('constructor', () => {
     expect(() => new RequestDelay({ minDelay: '1_sec' })).toThrow();
   });
 
+  test('rejects `minDelay > maxDelay`', () => {
+    expect(() => new RequestDelay({ minDelay: '1_sec', maxDelay: '0.99_sec' })).toThrow();
+  });
+
   test('rejects `delay` with either `minDelay` or `maxDelay`', () => {
     expect(() => new RequestDelay({ delay: '2_sec', minDelay: '1_sec' })).toThrow();
     expect(() => new RequestDelay({ delay: '1_sec', maxDelay: '2_sec' })).toThrow();

--- a/src/webapp-builtins/tests/RequestFilter.test.js
+++ b/src/webapp-builtins/tests/RequestFilter.test.js
@@ -10,6 +10,10 @@ import { RequestUtil } from '#test/RequestUtil';
 
 
 describe('constructor', () => {
+  test('accepts empty options', () => {
+    expect(() => new RequestFilter({})).not.toThrow();
+  });
+
   test('accepts an omnibus valid set of options', () => {
     const opts = {
       name:                 'myFavoriteFilter',
@@ -69,7 +73,7 @@ describe('_impl_handleRequest()', () => {
     return rf;
   }
 
-  describe('with non-`null` `acceptMethods`', () => {
+  describe('with an array for `acceptMethods`', () => {
     test('accepts an allowed method', async () => {
       const rf = await makeInstance({
         acceptMethods:        ['get', 'post'],
@@ -86,6 +90,35 @@ describe('_impl_handleRequest()', () => {
     test('filters out a disallowed method', async () => {
       const rf = await makeInstance({
         acceptMethods:        ['post'],
+        filterResponseStatus: 599
+      });
+
+      const req    = RequestUtil.makeGet('/florp');
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeInstanceOf(StatusResponse);
+      expect(result.status).toBe(599);
+    });
+  });
+
+  describe('with a single string for `acceptMethods`', () => {
+    test('accepts an allowed method', async () => {
+      const rf = await makeInstance({
+        acceptMethods:        'head',
+        filterResponseStatus: 599
+      });
+
+      const req    = RequestUtil.makeRequest('head', '/florp');
+      const disp   = new DispatchInfo(PathKey.EMPTY, req.pathname);
+      const result = await rf.handleRequest(req, disp);
+
+      expect(result).toBeNull();
+    });
+
+    test('filters out a disallowed method', async () => {
+      const rf = await makeInstance({
+        acceptMethods:        'head',
         filterResponseStatus: 599
       });
 

--- a/src/webapp-builtins/tests/SuffixRouter.test.js
+++ b/src/webapp-builtins/tests/SuffixRouter.test.js
@@ -26,6 +26,26 @@ describe('constructor', () => {
     expect(() => new SuffixRouter({ name: 'x', suffixes })).not.toThrow();
   });
 
+  test('rejects both `handle*` being `false`', () => {
+    const opts = {
+      suffixes:          { '*': 'a' },
+      handleDirectories: false,
+      handleFiles:       false
+    };
+
+    expect(() => new SuffixRouter(opts)).toThrow();
+  });
+
+  test.each`
+  opts
+  ${{ handleDirectories: false, handleFiles: true }}
+  ${{ handleDirectories: true,  handleFiles: false }}
+  ${{ handleDirectories: true,  handleFiles: true }}
+  `('accepts $opts', ({ opts }) => {
+    opts = { ...opts, suffixes: { '*': 'a' } };
+    expect(() => new SuffixRouter(opts)).not.toThrow();
+  });
+
   test.each`
   suffix
   ${''}        // Can't be totally empty.

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -160,98 +160,7 @@ export class NetworkEndpoint extends BaseComponent {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseConfig {
-    /**
-     * Name of the application to send requests to.
-     *
-     * @type {string}
-     */
-    #application;
-
-    /**
-     * The hostnames in question.
-     *
-     * @type {Array<string>}
-     */
-    #hostnames;
-
-    /**
-     * Physical interface to listen on; this is the result of a call to {@link
-     * UriUtil#parseInterface}.
-     *
-     * @type {object}
-     */
-    #interface;
-
-    /**
-     * High-level protocol to speak.
-     *
-     * @type {string}
-     */
-    #protocol;
-
-    /**
-     * Role-to-service mappings.
-     *
-     * @type {ServiceUseConfig}
-     */
-    #services;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const {
-        hostnames = '*',
-        interface: iface, // `interface` is a reserved word.
-        application,
-        protocol,
-        services = {}
-      } = rawConfig;
-
-      this.#hostnames = StringUtil.checkAndFreezeStrings(
-        hostnames,
-        (item) => HostUtil.checkHostname(item, true));
-
-      this.#interface   = Object.freeze(HostUtil.parseInterface(iface));
-      this.#application = Names.checkName(application);
-      this.#protocol    = ProtocolWranglers.checkProtocol(protocol);
-      this.#services    = new ServiceUseConfig(services);
-    }
-
-    /** @returns {string} Name of the application to send requests to. */
-    get application() {
-      return this.#application;
-    }
-
-    /**
-     * @returns {Array<string>} List of hostnames, including possibly subdomain
-     * and/or full wildcards.
-     */
-    get hostnames() {
-      return this.#hostnames;
-    }
-
-    /**
-     * @returns {object} Parsed interface. This is a frozen return value from
-     * {@link UriUtil#parseInterface}.
-     */
-    get interface() {
-      return this.#interface;
-    }
-
-    /** @returns {string} High-level protocol to speak. */
-    get protocol() {
-      return this.#protocol;
-    }
-
-    /** @returns {ServiceUseConfig} Role-to-service configuration. */
-    get services() {
-      return this.#services;
-    }
+    // @defaultConstructor
 
     /**
      * Indicates whether the protocol requires host certificate configuration.
@@ -259,7 +168,67 @@ export class NetworkEndpoint extends BaseComponent {
      * @returns {boolean} `true` iff certificates are required.
      */
     requiresCertificates() {
-      return this.#protocol !== 'http';
+      return this.protocol !== 'http';
+    }
+
+    /**
+     * Name of the application to send requests to.
+     *
+     * @param {string} value Proposed configuration value.
+     * @returns {string} Accepted configuration value.
+     */
+    _config_application(value) {
+      return Names.checkName(value);
+    }
+
+    /**
+     * List of hostnames to recognize as valid, including possibly subdomain
+     * wildcards and/or a full wildcard.
+     *
+     * @param {string|Array<string>} [value] Proposed configuration value.
+     *   Default `'*'`.
+     * @returns {Array<string>} Accepted configuration value.
+     */
+    _config_hostnames(value = '*') {
+      return StringUtil.checkAndFreezeStrings(
+        value,
+        (item) => HostUtil.checkHostname(item, true));
+    }
+
+    /**
+     * Interface to listen on. When passed in, this is expected to be a string
+     * which can be parsed by {@link UriUtil#parseInterface}.
+     *
+     * @param {string} value Proposed configuration value.
+     * @returns {object} Accepted configuration value, as parsed by {@link
+     *   UriUtil#parseInterface}.
+     */
+    _config_interface(value) {
+      return Object.freeze(HostUtil.parseInterface(value));
+    }
+
+    /**
+     * High-level protocol to speak. Accepted values are `http`, `http2`, and
+     * `https`.
+     *
+     * @param {string} value Proposed configuration value.
+     * @returns {string} Accepted configuration value.
+     */
+    _config_protocol(value) {
+      return ProtocolWranglers.checkProtocol(value);
+    }
+
+    /**
+     * Role-to-service configuration. When passed in, this is expected to be a
+     * plain object that can be parsed by the {@link ServiceUseConfig}
+     * constructor.
+     *
+     * @param {object} [value] Proposed configuration value. Default `{}` (that
+     *   is, no services).
+     * @returns {ServiceUseConfig} Accepted configuration value.
+     */
+    _config_services(value = {}) {
+      return new ServiceUseConfig(value);
     }
   };
 }

--- a/src/webapp-core/export/NetworkHost.js
+++ b/src/webapp-core/export/NetworkHost.js
@@ -207,7 +207,8 @@ export class NetworkHost extends BaseComponent {
      * covered by the instance. Hostnames can be absolute, partial wildcards, or
      * a full wildcard.
      *
-     * @type {Array<string>}
+     * @param {string|Array<string>} value Proposed configuration value.
+     * @returns {Array<string>} Accepted configuration value.
      */
     _config_hostnames(value) {
       return StringUtil.checkAndFreezeStrings(
@@ -219,7 +220,8 @@ export class NetworkHost extends BaseComponent {
      * The certificate for the hosts, as PEM-encoded data. Allowed to be `null`
      * _only_ if `selfSigned` is configured as `true`.
      *
-     * @type {?string}
+     * @param {?string} value Proposed configuration value. Default `null`.
+     * @returns {?string} Accepted configuration value.
      */
     _config_certificate(value = null) {
       return (value === null)
@@ -231,7 +233,8 @@ export class NetworkHost extends BaseComponent {
      * The private key for the hosts, as PEM-encoded data. Allowed to be `null`
      * _only_ if `selfSigned` is configured as `true`.
      *
-     * @type {?string}
+     * @param {?string} value Proposed configuration value. Default `null`.
+     * @returns {?string} Accepted configuration value.
      */
     _config_privateKey(value = null) {
       return (value === null)
@@ -242,7 +245,8 @@ export class NetworkHost extends BaseComponent {
     /**
      * Is this to be a self-signed certificate?
      *
-     * @type {boolean}
+     * @param {boolean} [value] Proposed configuration value. Default `false`.
+     * @returns {boolean} Accepted configuration value.
      */
     _config_selfSigned(value = false) {
       return MustBe.boolean(value);

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -210,8 +210,8 @@ export class WebappRoot extends BaseComponent {
 
     /**
      * Endpoint instances, or `null` to have no configured endpoints (which
-     * would be unusual). On input, this is expected to be an object
-     * suitable as an argument to {@link BaseComponent#evalArray} (see which).
+     * would be unusual). On input, this is expected to be an object suitable as
+     * an argument to {@link BaseComponent#evalArray} (see which).
      *
      * @param {?object|Array<NetworkEndpoint|NetworkEndpoint.Config>} [value]
      *   Proposed configuration value. Default `null`.

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -193,74 +193,58 @@ export class WebappRoot extends BaseComponent {
    * Configuration item subclass for this (outer) class.
    */
   static #Config = class Config extends BaseConfig {
-    /**
-     * Application instances.
-     *
-     * @type {Array<BaseApplication>}
-     */
-    #applications;
+    // @defaultConstructor
 
     /**
-     * Host handling instances.
+     * Application instances, or `null` to have no configured applications
+     * (which would be unusual). On input, this is expected to be an object
+     * suitable as an argument to {@link BaseComponent#evalArray} (see which).
      *
-     * @type {Array<NetworkHost>}
+     * @param {?object|Array<BaseApplication|BaseApplication.Config>} [value]
+     *   Proposed configuration value. Default `null`.
+     * @returns {Array<BaseApplication>} Accepted configuration value.
      */
-    #hosts;
-
-    /**
-     * Endpoint instances.
-     *
-     * @type {Array<NetworkEndpoint>}
-     */
-    #endpoints;
-
-    /**
-     * Service instances.
-     *
-     * @type {Array<BaseService>}
-     */
-    #services;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Configuration object. See class header for
-     *   details.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const {
-        applications,
-        endpoints,
-        hosts = [],
-        services = []
-      } = rawConfig;
-
-      this.#applications = BaseApplication.evalArray(applications);
-      this.#hosts        = NetworkHost.evalArray(hosts);
-      this.#endpoints    = NetworkEndpoint.evalArray(endpoints);
-      this.#services     = BaseService.evalArray(services);
+    _config_applications(value = null) {
+      return BaseApplication.evalArray(value ?? []);
     }
 
-    /** @returns {Array<BaseApplication>} Application instances. */
-    get applications() {
-      return this.#applications;
+    /**
+     * Endpoint instances, or `null` to have no configured endpoints (which
+     * would be unusual). On input, this is expected to be an object
+     * suitable as an argument to {@link BaseComponent#evalArray} (see which).
+     *
+     * @param {?object|Array<NetworkEndpoint|NetworkEndpoint.Config>} [value]
+     *   Proposed configuration value. Default `null`.
+     * @returns {Array<NetworkEndpoint>} Accepted configuration value.
+     */
+    _config_endpoints(value = null) {
+      return NetworkEndpoint.evalArray(value ?? []);
     }
 
-    /** @returns {Array<NetworkHost>} Host handling instances. */
-    get hosts() {
-      return this.#hosts;
+    /**
+     * Host handling instances, or `null` to have no configured hosts. On input,
+     * this is expected to be an object suitable as an argument to {@link
+     * BaseComponent#evalArray} (see which).
+     *
+     * @param {?object|Array<NetworkHost|NetworkHost.Config>} [value] Proposed
+     *   configuration value. Default `null`.
+     * @returns {Array<NetworkHost>} Accepted configuration value.
+     */
+    _config_hosts(value = null) {
+      return NetworkHost.evalArray(value ?? []);
     }
 
-    /** @returns {Array<NetworkEndpoint>} Endpoint instances. */
-    get endpoints() {
-      return this.#endpoints;
-    }
-
-    /** @returns {Array<BaseService>} Service instances. */
-    get services() {
-      return this.#services;
+    /**
+     * Service instances, or `null` to have no configured services. On input,
+     * this is expected to be an object suitable as an argument to {@link
+     * BaseComponent#evalArray} (see which).
+     *
+     * @param {?object|Array<BaseService|BaseService.Config>} [value] Proposed
+     *   configuration value. Default `null`.
+     * @returns {Array<BaseService>} Accepted configuration value.
+     */
+    _config_services(value = null) {
+      return BaseService.evalArray(value ?? []);
     }
   };
 }

--- a/src/webapp-core/private/ServiceUseConfig.js
+++ b/src/webapp-core/private/ServiceUseConfig.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { BaseConfig, Names } from '@this/compy';
+import { Names } from '@this/compy';
 
 
 /**
@@ -18,7 +18,7 @@ import { BaseConfig, Names } from '@this/compy';
  * * `connectionRateLimiter` -- Connection rate limiter service.
  * * `dataRateLimiter` -- Data rate limiter service.
  */
-export class ServiceUseConfig extends BaseConfig {
+export class ServiceUseConfig {
   /**
    * The role-to-service mapping.
    *
@@ -33,8 +33,6 @@ export class ServiceUseConfig extends BaseConfig {
    *   details.
    */
   constructor(rawConfig) {
-    super(rawConfig);
-
     this.#map = Object.freeze(new Map(Object.entries(rawConfig)));
 
     for (const [role, name] of this.#map) {

--- a/src/webapp-util/export/BaseFileService.js
+++ b/src/webapp-util/export/BaseFileService.js
@@ -61,60 +61,13 @@ export class BaseFileService extends BaseService {
    */
   static Config = class Config extends BaseService.Config {
     /**
-     * The absolute path to use.
-     *
-     * @type {string}
-     */
-    #path;
-
-    /**
      * Path parts, or `null` if not yet calculated.
      *
      * @type {?object}
      */
     #pathParts = null;
 
-    /**
-     * Rotation configuration, if any.
-     *
-     * @type {?BaseFileService.RotateConfig}
-     */
-    #rotate;
-
-    /**
-     * Preservation configuration, if any.
-     *
-     * @type {?BaseFileService.SaveConfig}
-     */
-    #save;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {object} rawConfig Raw configuration object. See class header for
-     *   details.
-     */
-    constructor(rawConfig) {
-      super(rawConfig);
-
-      const { path, rotate, save } = rawConfig;
-
-      if (rotate && save) {
-        throw new Error('Cannot specify both `rotate` and `save`.');
-      }
-
-      this.#path   = Paths.checkAbsolutePath(path);
-      this.#rotate = rotate ? new BaseFileService.RotateConfig(rotate) : null;
-      this.#save   = save   ? new BaseFileService.SaveConfig(save)     : null;
-    }
-
-    /**
-     * @returns {string} The absolute path to write to (with possible infixing
-     * of the final path component, depending on the specific use case).
-     */
-    get path() {
-      return this.#path;
-    }
+    // @defaultConstructor
 
     /**
      * The various parts of {@link #path}. The return value is a frozen plain
@@ -143,19 +96,56 @@ export class BaseFileService extends BaseService {
     }
 
     /**
-     * @returns {?BaseFileService.RotateConfig} Rotation configuration, if any.
+     * The absolute path to write to, with possible infixing of the final path
+     * component, depending on the specific use case.
+     *
+     * @param {string} value Proposed configuration value.
+     * @returns {string} Accepted configuration value.
      */
-    get rotate() {
-      return this.#rotate;
+    _config_path(value) {
+      return Paths.checkAbsolutePath(value);
     }
 
     /**
-     * @returns {?BaseFileService.SaveConfig} Preservation configuration, if
-     * any. If this instance has a {@link #RotateConfig}, that is returned here
-     * too (it's a subclass).
+     * Rotation configuration, or `null` not to do rotation. On input, this is
+     * expected to be a plain object suitable to pass to {@link
+     * BaseFileService#RotateConfig.constructor}.
+     *
+     * @type {?BaseFileService.RotateConfig}
      */
-    get save() {
-      return this.#save ?? this.#rotate;
+    _config_rotate(value = null) {
+      return (value === null)
+        ? null
+        : new BaseFileService.RotateConfig(value);
+    }
+
+    /**
+     * File preservation configuration, or `null` not to do file preservation.
+     * On input, this is expected to be a plain object suitable to pass to
+     * {@link BaseFileService#SaveConfig.constructor}.
+     *
+     * @type {?BaseFileService.SaveConfig}
+     */
+    _config_save(value = null) {
+      return (value === null)
+        ? null
+        : new BaseFileService.SaveConfig(value);
+    }
+
+    /** @override */
+    _impl_validate(config) {
+      const { rotate, save } = config;
+
+      if (rotate && save) {
+        throw new Error('Cannot specify both `rotate` and `save`.');
+      }
+
+      // `rotate` is also used as a `save` config, so copy it to that property.
+      const result = rotate
+        ? { ...config, save: rotate }
+        : config;
+
+      return super._impl_validate(result);
     }
 
     /**
@@ -164,7 +154,7 @@ export class BaseFileService extends BaseService {
      * @returns {object} The split path, as described.
      */
     #makePathParts() {
-      const path = this.#path;
+      const { path } = this;
 
       const { directory, fileName } =
         path.match(/^(?<directory>.*)[/](?<fileName>[^/]+)$/).groups;

--- a/src/webapp-util/export/BaseFileService.js
+++ b/src/webapp-util/export/BaseFileService.js
@@ -4,7 +4,6 @@
 import * as fs from 'node:fs/promises';
 
 import { WallClock } from '@this/clocky';
-import { BaseConfig } from '@this/compy';
 import { Duration } from '@this/data-values';
 import { Paths, Statter } from '@this/fs-util';
 import { MustBe } from '@this/typey';
@@ -180,7 +179,7 @@ export class BaseFileService extends BaseService {
   /**
    * Configuration class for `save` bindings.
    */
-  static SaveConfig = class SaveConfig extends BaseConfig {
+  static SaveConfig = class SaveConfig {
     /**
      * The maximum number of old-file bytes to allow, if so limited.
      *
@@ -215,8 +214,6 @@ export class BaseFileService extends BaseService {
      * @param {object} rawConfig Configuration object.
      */
     constructor(rawConfig) {
-      super(rawConfig);
-
       const {
         maxOldBytes = null,
         maxOldCount = null,

--- a/src/webapp-util/export/BaseFileService.js
+++ b/src/webapp-util/export/BaseFileService.js
@@ -111,7 +111,8 @@ export class BaseFileService extends BaseService {
      * expected to be a plain object suitable to pass to {@link
      * BaseFileService#RotateConfig.constructor}.
      *
-     * @type {?BaseFileService.RotateConfig}
+     * @param {?object} [value] Proposed configuration value. Default `null`.
+     * @returns {?BaseFileService.RotateConfig} Accepted configuration value.
      */
     _config_rotate(value = null) {
       return (value === null)
@@ -124,7 +125,8 @@ export class BaseFileService extends BaseService {
      * On input, this is expected to be a plain object suitable to pass to
      * {@link BaseFileService#SaveConfig.constructor}.
      *
-     * @type {?BaseFileService.SaveConfig}
+     * @param {?object} [value] Proposed configuration value. Default `null`.
+     * @returns {?BaseFileService.SaveConfig} Accepted configuration value.
      */
     _config_save(value = null) {
       return (value === null)


### PR DESCRIPTION
This PR totally reworks how configuration parsing gets done, so as to avoid a ton of previously-required repetition, _and_ to offer a bit better error checking across the board. Though there's only a net saving in this PR of like 70 lines, that's at least in part due to:

* Adding the new configuration parsing code.
* Adding docs to a bunch of properties which weren't previously documented.
* Adding some test cases.

Mostly, component configuration classes had their size dropped by about 1/3 to 1/2 each. The one actually-unfortunate outcome is that the three rate limiter components ended up becoming a little un-DRY compared to their previous state. (Maybe I'll be able to fix them back up.)