### PR TITLE
Bytes, man!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ versioning principles. Unstable releases do not.
 Breaking changes:
 * configuration / `webapp-builtins`:
   * Changed `MemoryMonitor` to use `ByteCount`s for the limit configuration.
+  * Changed the file rotation / preservation configurations that had been plain
+    numbers to instead be `ByteCount`s.
 * `compy`:
   * Reworked how component classes define their configuration properties, to
     be way more ergonomic, avoiding a lot of formerly-required boilerplate and

--- a/doc/configuration/3-built-in-services.md
+++ b/doc/configuration/3-built-in-services.md
@@ -28,9 +28,11 @@ following bindings:
   indicate "never check." Optional and defaults to `5 min`. If specified, the
   value must be at least one second (so as to prevent excessive churn). This is
   only meaningful if `atSize` is also specified.
-* `maxOldBytes` &mdash; How many bytes' worth of old (post-rotation) files
-  should be allowed, or `null` not to have a limit. The oldest files over the
-  limit get deleted after a rotation. Optional, and defaults to `null`.
+* `maxOldSize` &mdash; How many bytes' worth of old (post-rotation) files
+  should be allowed, specified as a byte count as described in
+  [`ByteCount`](./2-common-configuration.md#bytecount), or `null` not to have a
+  limit. The oldest files over the limit get deleted after a rotation. Optional,
+  and defaults to `null`.
 * `maxOldCount` &mdash; How many old (post-rotation) files should be allowed, or
   `null` not to have a limit. The oldest files over the limit get deleted after
    a rotation. Optional, and defaults to `null`.
@@ -47,7 +49,7 @@ available. This is an object with bindings with the same meanings and defaults
 as `rotate`, except that rotation-specific ones are not recognized. These are
 the ones that are used by `save`:
 
-* `maxOldBytes`
+* `maxOldSize`
 * `maxOldCount`
 * `onStart`
 * `onStop`

--- a/doc/configuration/3-built-in-services.md
+++ b/doc/configuration/3-built-in-services.md
@@ -19,8 +19,9 @@ file rotation and cleanup. A `rotate` configuration is an object with the
 following bindings:
 
 * `atSize` &mdash; Rotate when the file becomes the given size (in bytes) or
-  greater. Optional, and if not specified (or if `null`), does not rotate based
-  on size.
+  greater, specified as a byte count as described in
+  [`ByteCount`](./2-common-configuration.md#bytecount), or `null` to not rotate
+  based on size. Optional, and defaults to `null`.
 * `checkPeriod` &mdash; How often to check for a rotation condition, specified
   as a duration value as described in
   [`Duration`](./2-common-configuration.md#duration), or `null` to

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -69,7 +69,7 @@ const services = [
     format:       'human',
     bufferPeriod: '0.25 sec',
     rotate: {
-      atSize:      1024 * 1024,
+      atSize:      '1 MiB',
       onStart:     true,
       maxOldBytes: 10 * 1024 * 1024,
       checkPeriod: '1 min'
@@ -82,7 +82,7 @@ const services = [
     format:       'json',
     bufferPeriod: '0.25 sec',
     rotate: {
-      atSize:      2 * 1024 * 1024,
+      atSize:      '2 MiB',
       onStart:     true,
       onStop:      true,
       maxOldBytes: 10 * 1024 * 1024,
@@ -97,7 +97,7 @@ const services = [
     bufferPeriod: '0.25 sec',
     maxUrlLength: 120,
     rotate: {
-      atSize:       10000,
+      atSize:       '10000 B',
       maxOldCount:  10,
       checkPeriod:  '1 min'
     }

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -71,7 +71,7 @@ const services = [
     rotate: {
       atSize:      '1 MiB',
       onStart:     true,
-      maxOldBytes: 10 * 1024 * 1024,
+      maxOldSize: '10 MiB',
       checkPeriod: '1 min'
     }
   },
@@ -85,7 +85,7 @@ const services = [
       atSize:      '2 MiB',
       onStart:     true,
       onStop:      true,
-      maxOldBytes: 10 * 1024 * 1024,
+      maxOldSize:  '10 MiB',
       maxOldCount: 10,
       checkPeriod: '1 min'
     }

--- a/src/webapp-builtins/export/RequestDelay.js
+++ b/src/webapp-builtins/export/RequestDelay.js
@@ -166,7 +166,13 @@ export class RequestDelay extends BaseApplication {
      * @returns {Duration} The parsed value.
      */
     static #parseDelay(value) {
-      return Duration.parse(value, { range: { minInclusive: 0 } });
+      const result = Duration.parse(value, { range: { minInclusive: 0 } });
+
+      if (result === null) {
+        throw new Error(`Could not parse delay value: ${value}`);
+      }
+
+      return result;
     }
   };
 }

--- a/src/webapp-util/export/BaseFileService.js
+++ b/src/webapp-util/export/BaseFileService.js
@@ -176,17 +176,26 @@ export class BaseFileService extends BaseService {
     // @defaultConstructor
 
     /**
-     * The maximum number of old-file bytes to allow, if so limited.
+     * The maximum size of old files to allow (in aggregate), or `null` to not
+     * have such a size limit. if so limited. If passed as a string, it is
+     * parsed by {@link ByteCount#parse}.
      *
-     * @param {?number} [value] Proposed configuration value. Default `null`.
-     * @returns {?number} Accepted configuration value.
+     * @param {?string|ByteCount} [value] Proposed configuration value. Default
+     *   `null`.
+     * @returns {?ByteCount} Accepted configuration value.
      */
-    _config_maxOldBytes(value = null) {
+    _config_maxOldSize(value = null) {
       if (value === null) {
         return null;
       }
 
-      return MustBe.number(value, { finite: true, minInclusive: 1 });
+      const result = ByteCount.parse(value, { range: { minInclusive: 1 } });
+
+      if (result === null) {
+        throw new Error(`Could not parse \`maxOldSize\`: ${value}`);
+      }
+
+      return result;
     }
 
     /**
@@ -235,7 +244,7 @@ export class BaseFileService extends BaseService {
      * file size. If passed as a string, it is parsed by {@link
      * ByteCount#parse}.
      *
-     * @param {?string|ByteCount} value Proposed configuration value. Default
+     * @param {?string|ByteCount} [value] Proposed configuration value. Default
      *   `null`.
      * @returns {?ByteCount} Accepted configuration value.
      */

--- a/src/webapp-util/export/BaseFileService.js
+++ b/src/webapp-util/export/BaseFileService.js
@@ -5,7 +5,7 @@ import * as fs from 'node:fs/promises';
 
 import { WallClock } from '@this/clocky';
 import { BaseConfig } from '@this/compy';
-import { Duration } from '@this/data-values';
+import { ByteCount, Duration } from '@this/data-values';
 import { Paths, Statter } from '@this/fs-util';
 import { MustBe } from '@this/typey';
 import { BaseService } from '@this/webapp-core';
@@ -231,17 +231,26 @@ export class BaseFileService extends BaseService {
     // @defaultConstructor
 
     /**
-     * The file size at which to rotate, if ever.
+     * The file size at which to rotate, or `null` not to do rotation based on
+     * file size. If passed as a string, it is parsed by {@link
+     * ByteCount#parse}.
      *
-     * @param {?number} [value] Proposed configuration value. Default `null`.
-     * @returns {?number} Accepted configuration value.
+     * @param {?string|ByteCount} value Proposed configuration value. Default
+     *   `null`.
+     * @returns {?ByteCount} Accepted configuration value.
      */
     _config_atSize(value = null) {
       if (value === null) {
         return null;
       }
 
-      return MustBe.number(value, { finite: true, minInclusive: 1 });
+      const result = ByteCount.parse(value, { range: { minInclusive: 1 } });
+
+      if (result === null) {
+        throw new Error(`Could not parse \`atSize\`: ${value}`);
+      }
+
+      return result;
     }
 
     /**

--- a/src/webapp-util/export/Rotator.js
+++ b/src/webapp-util/export/Rotator.js
@@ -53,9 +53,11 @@ export class Rotator extends BaseFilePreserver {
       return;
     }
 
+    const atSize = this.#config.rotate.atSize.byte;
+
     try {
       const stats = await Statter.statOrNull(this.#config.path);
-      if (stats && (stats.size >= this.#config.rotate.atSize)) {
+      if (stats && (stats.size >= atSize)) {
         this._prot_saveNow();
       }
     } catch (e) {

--- a/src/webapp-util/private/BaseFilePreserver.js
+++ b/src/webapp-util/private/BaseFilePreserver.js
@@ -155,12 +155,14 @@ export class BaseFilePreserver {
    * Deletes old (post-preservation) files, as configured.
    */
   async #deleteOldFiles() {
-    const { maxOldCount = null, maxOldBytes = null } = this.#config.save;
+    const { maxOldCount = null, maxOldSize = null } = this.#config.save;
 
-    if ((maxOldCount === null) && (maxOldBytes === null)) {
+    if ((maxOldCount === null) && (maxOldSize === null)) {
       // Not configured to do a deletion pass.
       return;
     }
+
+    const maxOldBytes = maxOldSize?.byte ?? null;
 
     // Find all the files, and sort from newest to oldest.
     const files = await this.#findFiles({ today: true, pastDays: true });


### PR DESCRIPTION
This is a small follow-on PR to fix the `BaseFileService` configs to use `ByteCount` instead of plain numbers, where appropriate.