### PR TITLE
`compy`: Lifecycle methods.

### DIFF
--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -206,11 +206,13 @@ export class BaseComponent {
     this.#context = context;
 
     this.logger?.initializing();
+
     this.#context[ThisModule.SYM_setState]('initializing');
     await this._impl_init();
     if (this.state !== 'stopped') {
       throw new Error('`super._impl_init()` never called on base class.');
     }
+
     this.logger?.initialized();
   }
 
@@ -262,8 +264,13 @@ export class BaseComponent {
     }
 
     this.logger?.starting();
+
+    this.#context[ThisModule.SYM_setState]('starting');
     await this._impl_start();
-    this.#context[ThisModule.SYM_setState]('running');
+    if (this.state !== 'running') {
+      throw new Error('`super._impl_start()` never called on base class.');
+    }
+
     this.logger?.started();
   }
 
@@ -331,13 +338,13 @@ export class BaseComponent {
 
   /**
    * Subclass-specific implementation of {@link #start}. Subclasses should
-   * generally call through to `super` so that all the base classes get a chance
-   * to take action. That said, the base class implementation is a no-op.
+   * always call through to `super` so that all the base classes get a chance to
+   * take action.
    *
    * @abstract
    */
   async _impl_start() {
-    // @emptyBody
+    this.#context[ThisModule.SYM_setState]('running');
   }
 
   /**

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -3,7 +3,7 @@
 
 import { PathKey } from '@this/collections';
 import { IntfLogger } from '@this/loggy-intf';
-import { AskIf, Methods, MustBe } from '@this/typey';
+import { AskIf, MustBe } from '@this/typey';
 
 import { BaseConfig } from '#x/BaseConfig';
 import { ControlContext } from '#x/ControlContext';
@@ -293,8 +293,13 @@ export class BaseComponent {
     const fate = willReload ? 'willReload' : 'shutdown';
 
     this.logger?.stopping(fate);
+
+    this.#context[ThisModule.SYM_setState]('stopping');
     await this._impl_stop(willReload);
-    this.#context[ThisModule.SYM_setState]('stopped');
+    if (this.state !== 'stopped') {
+      throw new Error('`super._impl_stop()` never called on base class.');
+    }
+
     this.logger?.stopped(fate);
   }
 
@@ -349,15 +354,15 @@ export class BaseComponent {
 
   /**
    * Subclass-specific implementation of {@link #stop}. Subclasses should
-   * generally call through to `super` so that all the base classes get a chance
-   * to take action. That said, the base class implementation is a no-op.
+   * always call through to `super` so that all the base classes get a chance to
+   * take action.
    *
    * @abstract
    * @param {boolean} willReload Is this action due to an in-process reload
    *   being requested?
    */
   async _impl_stop(willReload) { // eslint-disable-line no-unused-vars
-    // @emptyBody
+    this.#context[ThisModule.SYM_setState]('stopped');
   }
 
   /**

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -101,7 +101,7 @@ export class BaseComponent {
    * @returns {?ControlContext} Associated context, or `null` if not yet set up.
    */
   get context() {
-    return (this.#initialized ? this.#context : this.#context?.nascentRoot) ?? null;
+    return (this.#contextReady ? this.#context : this.#context?.nascentRoot) ?? null;
   }
 
   /**
@@ -171,7 +171,7 @@ export class BaseComponent {
    * * `running` -- Currently running.
    */
   get state() {
-    return this.#initialized
+    return this.#contextReady
       ? this.context.state
       : 'new';
   }
@@ -197,7 +197,7 @@ export class BaseComponent {
   async init(context) {
     MustBe.instanceOf(context, ControlContext);
 
-    if (this.#initialized) {
+    if (this.#contextReady) {
       throw new Error('Already initialized.');
     } else if ((this.#context !== null) && (this.#context.nascentRoot !== context)) {
       throw new Error('Inconsistent context setup.');
@@ -248,7 +248,7 @@ export class BaseComponent {
    * this method if the instance is not already running.
    */
   async start() {
-    if (!this.#initialized) {
+    if (!this.#contextReady) {
       if (this.#context === null) {
         throw new Error('No context was set up in constructor or `init()`.');
       }
@@ -352,9 +352,9 @@ export class BaseComponent {
   async _prot_addChild(child) {
     MustBe.instanceOf(child, BaseComponent);
 
-    if (!this.#initialized) {
+    if (!this.#contextReady) {
       throw new Error('Cannot add child to uninitialized component.');
-    } else if (child.#initialized) {
+    } else if (child.#contextReady) {
       throw new Error('Child already initialized; cannot add to different parent.');
     }
 
@@ -367,8 +367,10 @@ export class BaseComponent {
     }
   }
 
-  /** @returns {boolean} Whether or not this instance is initialized. */
-  get #initialized() {
+  /**
+   * @returns {boolean} Whether or not this instance's context is ready for use.
+   */
+  get #contextReady() {
     return this.#context instanceof ControlContext;
   }
 

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -206,7 +206,11 @@ export class BaseComponent {
     this.#context = context;
 
     this.logger?.initializing();
+    this.#context[ThisModule.SYM_setState]('initializing');
     await this._impl_init();
+    if (this.state !== 'stopped') {
+      throw new Error('`super._impl_init()` never called on base class.');
+    }
     this.logger?.initialized();
   }
 
@@ -311,7 +315,9 @@ export class BaseComponent {
 
   /**
    * Subclass-specific implementation of {@link #init}. By the time this is
-   * called, the {@link #context} will have been set.
+   * called, the {@link #context} will have been set. Subclasses should always
+   * call through to `super` so that all the base classes get a chance to take
+   * action.
    *
    * **Note:** It is not appropriate to take any overt external action in this
    * method (such as writing files to the filesystem or opening a network
@@ -320,27 +326,31 @@ export class BaseComponent {
    * @abstract
    */
   async _impl_init() {
-    Methods.abstract();
+    this.#context[ThisModule.SYM_setState]('stopped');
   }
 
   /**
-   * Subclass-specific implementation of {@link #start}.
+   * Subclass-specific implementation of {@link #start}. Subclasses should
+   * generally call through to `super` so that all the base classes get a chance
+   * to take action. That said, the base class implementation is a no-op.
    *
    * @abstract
    */
   async _impl_start() {
-    Methods.abstract();
+    // @emptyBody
   }
 
   /**
-   * Subclass-specific implementation of {@link #stop}.
+   * Subclass-specific implementation of {@link #stop}. Subclasses should
+   * generally call through to `super` so that all the base classes get a chance
+   * to take action. That said, the base class implementation is a no-op.
    *
    * @abstract
    * @param {boolean} willReload Is this action due to an in-process reload
    *   being requested?
    */
-  async _impl_stop(willReload) {
-    Methods.abstract(willReload);
+  async _impl_stop(willReload) { // eslint-disable-line no-unused-vars
+    // @emptyBody
   }
 
   /**

--- a/src/compy/export/BaseWrappedHierarchy.js
+++ b/src/compy/export/BaseWrappedHierarchy.js
@@ -85,6 +85,8 @@ export class BaseWrappedHierarchy extends BaseComponent {
     // perspective it's always getting shut down, not reloaded.
     await this.#rootComponent.stop(false);
     this.#rootComponent = null;
+
+    await super._impl_stop();
   }
 
   /**

--- a/src/compy/export/BaseWrappedHierarchy.js
+++ b/src/compy/export/BaseWrappedHierarchy.js
@@ -70,6 +70,7 @@ export class BaseWrappedHierarchy extends BaseComponent {
   /** @override */
   async _impl_init() {
     await this.#loadOrReload();
+    await super._impl_init();
   }
 
   /** @override */

--- a/src/compy/export/BaseWrappedHierarchy.js
+++ b/src/compy/export/BaseWrappedHierarchy.js
@@ -76,6 +76,7 @@ export class BaseWrappedHierarchy extends BaseComponent {
   /** @override */
   async _impl_start() {
     await this.#startOrRestart();
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/compy/export/ControlContext.js
+++ b/src/compy/export/ControlContext.js
@@ -341,7 +341,7 @@ export class ControlContext {
    *
    * @type {Set<string>}
    */
-  static #VALID_STATES = new Set(['initializing', 'running', 'starting', 'stopped']);
+  static #VALID_STATES = new Set(['initializing', 'running', 'starting', 'stopping', 'stopped']);
 
   /**
    * Checks a state string for validity.

--- a/src/compy/export/ControlContext.js
+++ b/src/compy/export/ControlContext.js
@@ -341,7 +341,7 @@ export class ControlContext {
    *
    * @type {Set<string>}
    */
-  static #VALID_STATES = new Set(['running', 'stopped']);
+  static #VALID_STATES = new Set(['initializing', 'running', 'stopped']);
 
   /**
    * Checks a state string for validity.

--- a/src/compy/export/ControlContext.js
+++ b/src/compy/export/ControlContext.js
@@ -341,7 +341,7 @@ export class ControlContext {
    *
    * @type {Set<string>}
    */
-  static #VALID_STATES = new Set(['initializing', 'running', 'stopped']);
+  static #VALID_STATES = new Set(['initializing', 'running', 'starting', 'stopped']);
 
   /**
    * Checks a state string for validity.

--- a/src/compy/export/MockComponent.js
+++ b/src/compy/export/MockComponent.js
@@ -14,11 +14,6 @@ export class MockComponent extends TemplAggregateComponent('MockAggregate', Base
   // @defaultConstructor
 
   /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_stop(willReload_unused) {
     // @emptyBlock
   }

--- a/src/compy/export/MockComponent.js
+++ b/src/compy/export/MockComponent.js
@@ -14,11 +14,6 @@ export class MockComponent extends TemplAggregateComponent('MockAggregate', Base
   // @defaultConstructor
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     // @emptyBlock
   }

--- a/src/compy/export/MockComponent.js
+++ b/src/compy/export/MockComponent.js
@@ -12,9 +12,4 @@ import { TemplAggregateComponent } from '#x/TemplAggregateComponent';
  */
 export class MockComponent extends TemplAggregateComponent('MockAggregate', BaseComponent) {
   // @defaultConstructor
-
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
 }

--- a/src/compy/export/MockRootComponent.js
+++ b/src/compy/export/MockRootComponent.js
@@ -14,11 +14,6 @@ export class MockRootComponent extends TemplAggregateComponent('MockAggregate', 
   // @defaultConstructor
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     // @emptyBlock
   }

--- a/src/compy/export/MockRootComponent.js
+++ b/src/compy/export/MockRootComponent.js
@@ -12,9 +12,4 @@ import { TemplAggregateComponent } from '#x/TemplAggregateComponent';
  */
 export class MockRootComponent extends TemplAggregateComponent('MockAggregate', BaseRootComponent) {
   // @defaultConstructor
-
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
 }

--- a/src/compy/export/MockRootComponent.js
+++ b/src/compy/export/MockRootComponent.js
@@ -14,11 +14,6 @@ export class MockRootComponent extends TemplAggregateComponent('MockAggregate', 
   // @defaultConstructor
 
   /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_stop(willReload_unused) {
     // @emptyBlock
   }

--- a/src/compy/export/TemplThreadComponent.js
+++ b/src/compy/export/TemplThreadComponent.js
@@ -36,11 +36,6 @@ export const TemplThreadComponent = (className, superclass) => {
     // @defaultConstructor
 
     /** @override */
-    async _impl_init() {
-      // @emptyBlock
-    }
-
-    /** @override */
     async _impl_start() {
       await this.#threadlet.start();
     }

--- a/src/compy/export/TemplThreadComponent.js
+++ b/src/compy/export/TemplThreadComponent.js
@@ -42,8 +42,9 @@ export const TemplThreadComponent = (className, superclass) => {
     }
 
     /** @override */
-    async _impl_stop(willReload_unused) {
+    async _impl_stop(willReload) {
       await this.#threadlet.stop();
+      await super._impl_stop(willReload);
     }
 
     /**

--- a/src/compy/export/TemplThreadComponent.js
+++ b/src/compy/export/TemplThreadComponent.js
@@ -38,6 +38,7 @@ export const TemplThreadComponent = (className, superclass) => {
     /** @override */
     async _impl_start() {
       await this.#threadlet.start();
+      await super._impl_start();
     }
 
     /** @override */

--- a/src/webapp-builtins/export/AccessLogToFile.js
+++ b/src/webapp-builtins/export/AccessLogToFile.js
@@ -127,6 +127,8 @@ export class AccessLogToFile extends BaseFileService {
 
     this.#appender = new FileAppender(path, bufferPeriod);
     this.#rotator  = rotate ? new Rotator(config, this.logger) : null;
+
+    await super._impl_init();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/AccessLogToFile.js
+++ b/src/webapp-builtins/export/AccessLogToFile.js
@@ -136,6 +136,7 @@ export class AccessLogToFile extends BaseFileService {
     await this._prot_createDirectoryIfNecessary();
     await this._prot_touchPath();
     await this.#rotator?.start();
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/AccessLogToFile.js
+++ b/src/webapp-builtins/export/AccessLogToFile.js
@@ -142,6 +142,7 @@ export class AccessLogToFile extends BaseFileService {
   /** @override */
   async _impl_stop(willReload) {
     await this.#rotator?.stop(willReload);
+    await super._impl_stop(willReload);
   }
 
   /**

--- a/src/webapp-builtins/export/AccessLogToSyslog.js
+++ b/src/webapp-builtins/export/AccessLogToSyslog.js
@@ -47,11 +47,6 @@ export class AccessLogToSyslog extends BaseService {
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/AccessLogToSyslog.js
+++ b/src/webapp-builtins/export/AccessLogToSyslog.js
@@ -47,11 +47,6 @@ export class AccessLogToSyslog extends BaseService {
   }
 
   /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_stop(willReload_unused) {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/AccessLogToSyslog.js
+++ b/src/webapp-builtins/export/AccessLogToSyslog.js
@@ -45,9 +45,4 @@ export class AccessLogToSyslog extends BaseService {
   _impl_implementedInterfaces() {
     return [IntfAccessLog];
   }
-
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
 }

--- a/src/webapp-builtins/export/ConnectionRateLimiter.js
+++ b/src/webapp-builtins/export/ConnectionRateLimiter.js
@@ -56,11 +56,6 @@ export class ConnectionRateLimiter extends BaseService {
   }
 
   /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_stop(willReload_unused) {
     await this.#bucket.denyAllRequests();
   }

--- a/src/webapp-builtins/export/ConnectionRateLimiter.js
+++ b/src/webapp-builtins/export/ConnectionRateLimiter.js
@@ -56,8 +56,9 @@ export class ConnectionRateLimiter extends BaseService {
   }
 
   /** @override */
-  async _impl_stop(willReload_unused) {
+  async _impl_stop(willReload) {
     await this.#bucket.denyAllRequests();
+    await super._impl_stop(willReload);
   }
 
 

--- a/src/webapp-builtins/export/ConnectionRateLimiter.js
+++ b/src/webapp-builtins/export/ConnectionRateLimiter.js
@@ -56,11 +56,6 @@ export class ConnectionRateLimiter extends BaseService {
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/DataRateLimiter.js
+++ b/src/webapp-builtins/export/DataRateLimiter.js
@@ -47,8 +47,9 @@ export class DataRateLimiter extends BaseService {
   }
 
   /** @override */
-  async _impl_stop(willReload_unused) {
+  async _impl_stop(willReload) {
     await this.#bucket.denyAllRequests();
+    await super._impl_stop(willReload);
   }
 
 

--- a/src/webapp-builtins/export/DataRateLimiter.js
+++ b/src/webapp-builtins/export/DataRateLimiter.js
@@ -47,11 +47,6 @@ export class DataRateLimiter extends BaseService {
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/DataRateLimiter.js
+++ b/src/webapp-builtins/export/DataRateLimiter.js
@@ -47,11 +47,6 @@ export class DataRateLimiter extends BaseService {
   }
 
   /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_stop(willReload_unused) {
     await this.#bucket.denyAllRequests();
   }

--- a/src/webapp-builtins/export/EventFan.js
+++ b/src/webapp-builtins/export/EventFan.js
@@ -66,6 +66,7 @@ export class EventFan extends BaseService {
   /** @override */
   async _impl_init() {
     this.logger?.targets(this.config.services);
+    await super._impl_init();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/EventFan.js
+++ b/src/webapp-builtins/export/EventFan.js
@@ -88,11 +88,6 @@ export class EventFan extends BaseService {
     await super._impl_start();
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
 
   //
   // Static members

--- a/src/webapp-builtins/export/EventFan.js
+++ b/src/webapp-builtins/export/EventFan.js
@@ -84,6 +84,8 @@ export class EventFan extends BaseService {
     }
 
     this.#services = services;
+
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -70,6 +70,8 @@ export class HostRouter extends BaseApplication {
     }
 
     this.#routeTree = routeTree;
+
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -51,6 +51,8 @@ export class HostRouter extends BaseApplication {
     }
 
     this.logger?.routes(routes);
+
+    await super._impl_init();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -74,11 +74,6 @@ export class HostRouter extends BaseApplication {
     await super._impl_start();
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
 
   //
   // Static members

--- a/src/webapp-builtins/export/MemoryMonitor.js
+++ b/src/webapp-builtins/export/MemoryMonitor.js
@@ -36,11 +36,6 @@ export class MemoryMonitor extends BaseService {
   // @defaultConstructor
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     await this.#runner.start();
   }

--- a/src/webapp-builtins/export/MemoryMonitor.js
+++ b/src/webapp-builtins/export/MemoryMonitor.js
@@ -42,8 +42,9 @@ export class MemoryMonitor extends BaseService {
   }
 
   /** @override */
-  async _impl_stop(willReload_unused) {
+  async _impl_stop(willReload) {
     await this.#runner.stop();
+    await super._impl_stop(willReload);
   }
 
   /**

--- a/src/webapp-builtins/export/MemoryMonitor.js
+++ b/src/webapp-builtins/export/MemoryMonitor.js
@@ -38,6 +38,7 @@ export class MemoryMonitor extends BaseService {
   /** @override */
   async _impl_start() {
     await this.#runner.start();
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -80,11 +80,6 @@ export class PathRouter extends BaseApplication {
     await super._impl_start();
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
 
   //
   // Static members

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -76,6 +76,8 @@ export class PathRouter extends BaseApplication {
     }
 
     this.#routeTree = routeTree;
+
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -57,6 +57,8 @@ export class PathRouter extends BaseApplication {
     }
 
     this.logger?.routes(routes);
+
+    await super._impl_init();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/ProcessIdFile.js
+++ b/src/webapp-builtins/export/ProcessIdFile.js
@@ -34,11 +34,6 @@ export class ProcessIdFile extends BaseFileService {
   // @defaultConstructor
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     await this.#runner.start();
   }

--- a/src/webapp-builtins/export/ProcessIdFile.js
+++ b/src/webapp-builtins/export/ProcessIdFile.js
@@ -40,8 +40,9 @@ export class ProcessIdFile extends BaseFileService {
   }
 
   /** @override */
-  async _impl_stop(willReload_unused) {
+  async _impl_stop(willReload) {
     await this.#runner.stop();
+    await super._impl_stop(willReload);
   }
 
   /**

--- a/src/webapp-builtins/export/ProcessIdFile.js
+++ b/src/webapp-builtins/export/ProcessIdFile.js
@@ -36,6 +36,7 @@ export class ProcessIdFile extends BaseFileService {
   /** @override */
   async _impl_start() {
     await this.#runner.start();
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/ProcessInfoFile.js
+++ b/src/webapp-builtins/export/ProcessInfoFile.js
@@ -89,6 +89,8 @@ export class ProcessInfoFile extends BaseFileService {
       // configured).
       this.#saver.stop(willReload);
     }
+
+    await super._impl_stop(willReload);
   }
 
   /**

--- a/src/webapp-builtins/export/ProcessInfoFile.js
+++ b/src/webapp-builtins/export/ProcessInfoFile.js
@@ -75,6 +75,7 @@ export class ProcessInfoFile extends BaseFileService {
     }
 
     await this.#runner.start();
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/ProcessInfoFile.js
+++ b/src/webapp-builtins/export/ProcessInfoFile.js
@@ -48,6 +48,8 @@ export class ProcessInfoFile extends BaseFileService {
   async _impl_init() {
     const { config } = this;
     this.#saver = config.save ? new Saver(config, this.logger) : null;
+
+    await super._impl_init();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/Redirector.js
+++ b/src/webapp-builtins/export/Redirector.js
@@ -62,11 +62,6 @@ export class Redirector extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/Redirector.js
+++ b/src/webapp-builtins/export/Redirector.js
@@ -61,11 +61,6 @@ export class Redirector extends BaseApplication {
     return response;
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
 
   //
   // Static members

--- a/src/webapp-builtins/export/Redirector.js
+++ b/src/webapp-builtins/export/Redirector.js
@@ -62,11 +62,6 @@ export class Redirector extends BaseApplication {
   }
 
   /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_stop(willReload_unused) {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/RequestDelay.js
+++ b/src/webapp-builtins/export/RequestDelay.js
@@ -26,11 +26,6 @@ export class RequestDelay extends BaseApplication {
   }
 
   /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_stop(willReload_unused) {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/RequestDelay.js
+++ b/src/webapp-builtins/export/RequestDelay.js
@@ -25,11 +25,6 @@ export class RequestDelay extends BaseApplication {
     return null;
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
   /**
    * Picks a delay for a request.
    *

--- a/src/webapp-builtins/export/RequestDelay.js
+++ b/src/webapp-builtins/export/RequestDelay.js
@@ -26,11 +26,6 @@ export class RequestDelay extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/RequestFilter.js
+++ b/src/webapp-builtins/export/RequestFilter.js
@@ -82,11 +82,6 @@ export class RequestFilter extends BaseApplication {
   }
 
   /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_stop(willReload_unused) {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/RequestFilter.js
+++ b/src/webapp-builtins/export/RequestFilter.js
@@ -81,11 +81,6 @@ export class RequestFilter extends BaseApplication {
     return null;
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
   /**
    * Returns the appropriate handler response for a request which has been
    * filtered out.

--- a/src/webapp-builtins/export/RequestFilter.js
+++ b/src/webapp-builtins/export/RequestFilter.js
@@ -82,11 +82,6 @@ export class RequestFilter extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/RequestRateLimiter.js
+++ b/src/webapp-builtins/export/RequestRateLimiter.js
@@ -52,11 +52,6 @@ export class RequestRateLimiter extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/RequestRateLimiter.js
+++ b/src/webapp-builtins/export/RequestRateLimiter.js
@@ -52,11 +52,6 @@ export class RequestRateLimiter extends BaseApplication {
   }
 
   /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_stop(willReload_unused) {
     // @emptyBlock
   }

--- a/src/webapp-builtins/export/RequestRateLimiter.js
+++ b/src/webapp-builtins/export/RequestRateLimiter.js
@@ -51,12 +51,6 @@ export class RequestRateLimiter extends BaseApplication {
     return null;
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
-
   //
   // Static members
   //

--- a/src/webapp-builtins/export/SerialRouter.js
+++ b/src/webapp-builtins/export/SerialRouter.js
@@ -63,11 +63,6 @@ export class SerialRouter extends BaseApplication {
     await super._impl_start();
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
 
   //
   // Static members

--- a/src/webapp-builtins/export/SerialRouter.js
+++ b/src/webapp-builtins/export/SerialRouter.js
@@ -59,6 +59,8 @@ export class SerialRouter extends BaseApplication {
     }
 
     this.#routeList = routeList;
+
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/SerialRouter.js
+++ b/src/webapp-builtins/export/SerialRouter.js
@@ -41,6 +41,7 @@ export class SerialRouter extends BaseApplication {
   /** @override */
   async _impl_init() {
     this.logger?.routes(this.config.applications);
+    await super._impl_init();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -95,6 +95,8 @@ export class SimpleResponse extends BaseApplication {
     }
 
     this.#response = response;
+
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -44,11 +44,6 @@ export class SimpleResponse extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     if (this.#response) {
       return;

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -99,11 +99,6 @@ export class SimpleResponse extends BaseApplication {
     await super._impl_start();
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
 
   //
   // Static members

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -147,6 +147,8 @@ export class StaticFiles extends BaseApplication {
 
       this.#notFoundResponse = response;
     }
+
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -151,11 +151,6 @@ export class StaticFiles extends BaseApplication {
     await super._impl_start();
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
   /**
    * Figures out the absolute path to serve for the given request path.
    *

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -120,11 +120,6 @@ export class StaticFiles extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     const siteDirectory = this.#siteDirectory;
 

--- a/src/webapp-builtins/export/SuffixRouter.js
+++ b/src/webapp-builtins/export/SuffixRouter.js
@@ -79,6 +79,8 @@ export class SuffixRouter extends BaseApplication {
     }
 
     this.#routeMap = routeMap;
+
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/SuffixRouter.js
+++ b/src/webapp-builtins/export/SuffixRouter.js
@@ -83,11 +83,6 @@ export class SuffixRouter extends BaseApplication {
     await super._impl_start();
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
 
   //
   // Static members

--- a/src/webapp-builtins/export/SuffixRouter.js
+++ b/src/webapp-builtins/export/SuffixRouter.js
@@ -60,6 +60,8 @@ export class SuffixRouter extends BaseApplication {
     }
 
     this.logger?.routes(routes);
+
+    await super._impl_init();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/SyslogToFile.js
+++ b/src/webapp-builtins/export/SyslogToFile.js
@@ -78,6 +78,7 @@ export class SyslogToFile extends BaseFileService {
 
     await this.#sink.drainAndStop();
     await this.#rotator?.stop(willReload);
+    await super._impl_stop(willReload);
   }
 
   /**

--- a/src/webapp-builtins/export/SyslogToFile.js
+++ b/src/webapp-builtins/export/SyslogToFile.js
@@ -41,6 +41,8 @@ export class SyslogToFile extends BaseFileService {
 
     const { config } = this;
     this.#rotator = config.rotate ? new Rotator(config, this.logger) : null;
+
+    await super._impl_init();
   }
 
   /** @override */

--- a/src/webapp-builtins/export/SyslogToFile.js
+++ b/src/webapp-builtins/export/SyslogToFile.js
@@ -57,6 +57,8 @@ export class SyslogToFile extends BaseFileService {
 
     await this.#sink.start();
     this.logger.running();
+
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-builtins/tests/MockApp.js
+++ b/src/webapp-builtins/tests/MockApp.js
@@ -38,11 +38,6 @@ export class MockApp extends BaseApplication {
   }
 
   /** @override */
-  async _impl_start() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_stop(willReload_unused) {
     // @emptyBlock
   }

--- a/src/webapp-builtins/tests/MockApp.js
+++ b/src/webapp-builtins/tests/MockApp.js
@@ -38,11 +38,6 @@ export class MockApp extends BaseApplication {
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     // @emptyBlock
   }

--- a/src/webapp-builtins/tests/MockApp.js
+++ b/src/webapp-builtins/tests/MockApp.js
@@ -36,9 +36,4 @@ export class MockApp extends BaseApplication {
       return null;
     }
   }
-
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
 }

--- a/src/webapp-core/export/ComponentManager.js
+++ b/src/webapp-core/export/ComponentManager.js
@@ -74,6 +74,7 @@ export class ComponentManager extends TemplAggregateComponent('ComponentAggregat
     const results   = instances.map((c) => c.stop(willReload));
 
     await Promise.all(results);
+    await super._impl_stop(willReload);
   }
 
   /** @override */

--- a/src/webapp-core/export/ComponentManager.js
+++ b/src/webapp-core/export/ComponentManager.js
@@ -65,6 +65,7 @@ export class ComponentManager extends TemplAggregateComponent('ComponentAggregat
     const results   = instances.map((c) => c.start());
 
     await Promise.all(results);
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-core/export/ComponentManager.js
+++ b/src/webapp-core/export/ComponentManager.js
@@ -60,11 +60,6 @@ export class ComponentManager extends TemplAggregateComponent('ComponentAggregat
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     const instances = [...this.children()];
     const results   = instances.map((c) => c.start());

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -80,6 +80,7 @@ export class HostManager extends TemplAggregateComponent('HostAggregate', BaseCo
     const results = hosts.map((h) => h.stop(willReload));
 
     await Promise.all(results);
+    await super._impl_stop(willReload);
   }
 
   /** @override */

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -60,6 +60,7 @@ export class HostManager extends TemplAggregateComponent('HostAggregate', BaseCo
   /** @override */
   async _impl_init() {
     this.#hostMap = new HostManager.HostMap(this.logger);
+    await super._impl_init();
   }
 
   /** @override */

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -71,6 +71,7 @@ export class HostManager extends TemplAggregateComponent('HostAggregate', BaseCo
     const results = hosts.map((h) => h.start());
 
     await Promise.all(results);
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -136,6 +136,7 @@ export class NetworkEndpoint extends BaseComponent {
 
     await this.#wrangler.init(this.logger);
     await this.#wrangler.start();
+    await super._impl_start();
   }
 
   /**

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -147,6 +147,7 @@ export class NetworkEndpoint extends BaseComponent {
    */
   async _impl_stop(willReload) {
     await this.#wrangler.stop(willReload);
+    await super._impl_stop(willReload);
   }
 
 

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -84,6 +84,8 @@ export class NetworkEndpoint extends BaseComponent {
       interface: FormatUtils.networkInterfaceString(iface),
       application
     });
+
+    await super._impl_init();
   }
 
   /** @override */

--- a/src/webapp-core/export/NetworkHost.js
+++ b/src/webapp-core/export/NetworkHost.js
@@ -107,6 +107,8 @@ export class NetworkHost extends BaseComponent {
       const { certificate, privateKey } = config;
       this.#parameters = { certificate, privateKey };
     }
+
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-core/export/NetworkHost.js
+++ b/src/webapp-core/export/NetworkHost.js
@@ -97,11 +97,6 @@ export class NetworkHost extends BaseComponent {
   }
 
   /** @override */
-  async _impl_init() {
-    // @emptyBlock
-  }
-
-  /** @override */
   async _impl_start() {
     const { config } = this;
     const { selfSigned } = config;

--- a/src/webapp-core/export/NetworkHost.js
+++ b/src/webapp-core/export/NetworkHost.js
@@ -111,11 +111,6 @@ export class NetworkHost extends BaseComponent {
     await super._impl_start();
   }
 
-  /** @override */
-  async _impl_stop(willReload_unused) {
-    // @emptyBlock
-  }
-
 
   //
   // Static members.

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -133,6 +133,7 @@ export class WebappRoot extends BaseRootComponent {
     await this.#serviceManager.start();
     await this.#applicationManager.start();
     await this.#endpointManager.start();
+    await super._impl_start();
   }
 
   /** @override */

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -157,6 +157,8 @@ export class WebappRoot extends BaseRootComponent {
       this.#serviceManager.stop(willReload),
       this.#hostManager.stop(willReload)
     ]);
+
+    await super._impl_stop(willReload);
   }
 
 

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -123,6 +123,8 @@ export class WebappRoot extends BaseRootComponent {
     await this.#hostManager.addChildren(hosts);
     await this.#endpointManager.addChildren(endpoints);
     await this.#serviceManager.addChildren(services);
+
+    await super._impl_init();
   }
 
   /** @override */


### PR DESCRIPTION
This PR changes the three lifecycle methods on `BaseComponent` to require concrete classes to call through to the respective superclass methods, as opposed to the previous status quo which was that a given concrete component class was expected to have exactly one class in its superclass chain (including itself) which was to be the sole definer of those methods. This became a problem with the introduction of the templated mixin-style classes, which need to be able to participate in the lifecycle.

Nice outcome is that this PR has a net reduction of lines, mostly because I got to delete a bunch of no-op methods.