### PR TITLE
`BaseConfig` and `BaseStruct`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Breaking changes:
   * Renamed `Struct` -> `Sexp`, because it's really this project's version of
     the "sexp" concept. And for similar reasons, renamed the `type` field of it
     to `functor`. This rename also makes room for the new `Struct`-y thing.
+  * Moved `BaseConfig` here from `compy`.
   * New class `BaseStruct`, extracted from `BaseConfig`, because _most_ of what
     `BaseConfig` did was not particularly specific to configuration, per se.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ Breaking changes:
 * `data-values`:
   * Renamed `Struct` -> `Sexp`, because it's really this project's version of
     the "sexp" concept. And for similar reasons, renamed the `type` field of it
-    to `functor`. This rename also makes room for a new `Struct`.
+    to `functor`. This rename also makes room for the new `Struct`-y thing.
+  * New class `BaseStruct`, extracted from `BaseConfig`, because _most_ of what
+    `BaseConfig` did was not particularly specific to configuration, per se.
 
 Other notable changes:
 * `compy`:

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -92,8 +92,8 @@ use the following comment in place of an intentionally omitted constructor:
 ### Member naming (and details)
 
 * `_config_<name>` &mdash; Method defined by configuration classes which are
-  (direct or indirect) subclasses of `compy.BaseConfig`. Each such method is
-  responsible for validating and parsing/converting the correspondingly named
+  (direct or indirect) subclasses of `data-values.BaseConfig`. Each such method
+  is responsible for validating and parsing/converting the correspondingly named
   property of a plain-object configuration.
 
 * `_impl_<name>` &mdash; Declared in base classes, _either_ as abstract and left

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PathKey } from '@this/collections';
+import { BaseConfig } from '@this/data-values';
 import { IntfLogger } from '@this/loggy-intf';
 import { AskIf, MustBe } from '@this/typey';
 
-import { BaseConfig } from '#x/BaseConfig';
 import { ControlContext } from '#x/ControlContext';
 import { Names } from '#x/Names';
 import { RootControlContext } from '#x/RootControlContext';

--- a/src/compy/export/BaseConfig.js
+++ b/src/compy/export/BaseConfig.js
@@ -64,46 +64,13 @@ export class BaseConfig extends BaseStruct {
    *   called on.
    */
   static eval(rawConfig, { defaults = {}, targetClass }) {
-    rawConfig ??= {};
-
-    if (rawConfig instanceof this) {
-      return rawConfig;
-    } else if (rawConfig instanceof BaseConfig) {
-      // It's the wrong concrete config class.
-      const gotName = rawConfig.constructor.name;
-      throw new Error(`Incompatible configuration class: expected ${this.name}, got ${gotName}`);
-    } else if (!AskIf.plainObject(rawConfig)) {
-      if (typeof rawConfig === 'object') {
-        const gotName = rawConfig.constructor.name;
-        throw new Error(`Cannot convert non-configuration object: expected ${this.name}, got ${gotName}`);
-      } else {
-        const gotType = typeof rawConfig;
-        throw new Error(`Cannot evaluate non-object as configuration: expected ${this.name}, got ${gotType}`);
-      }
-    }
-
-    // It's a plain object.
-
-    let configObj = rawConfig; // Might get replaced by a modified copy.
-
-    const defaultProp = (k, v, force = false) => {
-      if (force || !Reflect.has(configObj, k)) {
-        if (configObj === rawConfig) {
-          configObj = { ...rawConfig };
-        }
-        configObj[k] = v;
-      }
-    };
-
-    for (const [k, v] of Object.entries(defaults)) {
-      defaultProp(k, v);
-    }
+    const configObj = super.eval(rawConfig, {
+      defaults: { ...defaults, class: targetClass }
+    });
 
     const configTargetClass = configObj.class;
 
-    if ((configTargetClass === null) || (configTargetClass === undefined)) {
-      defaultProp('class', targetClass);
-    } else if (configTargetClass !== targetClass) {
+    if (configTargetClass !== targetClass) {
       if (!AskIf.constructorFunction(configTargetClass)) {
         throw new Error('Expected class (constructor function) for `rawConfig.class`.');
       } else {
@@ -111,6 +78,6 @@ export class BaseConfig extends BaseStruct {
       }
     }
 
-    return new this(configObj);
+    return configObj;
   }
 }

--- a/src/compy/export/BaseConfig.js
+++ b/src/compy/export/BaseConfig.js
@@ -8,9 +8,9 @@ import { AskIf, MustBe } from '@this/typey';
 /**
  * Base class for configuration representation classes. Each concrete subclass
  * is expected to pass a plain object in its `super()` call which is suitable
- * for parsing by the base class. This (base) class defines a small handful of
- * core bindings, and it is up to each subclass to define other bindings
- * specific to the things-they-are-configuring.
+ * for parsing by the base class. This (base) class defines just one property,
+ * `class`, and it is up to each subclass to define other bindings specific to
+ * the things-they-are-configuring.
  */
 export class BaseConfig extends BaseStruct {
   // @defaultConstructor

--- a/src/compy/export/BaseConfig.js
+++ b/src/compy/export/BaseConfig.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { BaseStruct } from '@this/data-values';
 import { AskIf, MustBe } from '@this/typey';
 
 
@@ -11,18 +12,8 @@ import { AskIf, MustBe } from '@this/typey';
  * core bindings, and it is up to each subclass to define other bindings
  * specific to the things-they-are-configuring.
  */
-export class BaseConfig {
-  /**
-   * Constructs an instance.
-   *
-   * @param {object} rawConfig Raw configuration object. See class header for
-   *   details.
-   */
-  constructor(rawConfig) {
-    MustBe.plainObject(rawConfig);
-
-    this.#fillInObject(rawConfig);
-  }
+export class BaseConfig extends BaseStruct {
+  // @defaultConstructor
 
   /**
    * Configuration property: The concrete class of the component to create, or
@@ -44,133 +35,9 @@ export class BaseConfig {
     return MustBe.constructorFunction(value);
   }
 
-  /**
-   * Validates a processed configuration object, optionally changing properties,
-   * prior to actually setting its properties on this instance. Subclasses
-   * should override this if they need to do any final validation or tweakage.
-   * The base class implementation of this method returns its argument (that is,
-   * it does nothing), but concrete subclasses should check their own immediate
-   * superclasses for requirements about calling `super()`.
-   *
-   * @param {object} config Processed configuration object.
-   * @returns {object} Final configuration object to use for setting properties
-   *   on `this`.
-   */
-  _impl_validate(config) {
-    return config;
-  }
-
-  /**
-   * Fills in a property on `this` for each property that is covered by a
-   * `_config_*` method defined by the actual (concrete) class of `this`. If the
-   * given `rawConfig` doesn't have a property for any given checker method,
-   * that method is called with no argument, to give it a chance to use a
-   * default value or simply reject it for not being filled in. After making all
-   * such calls, this method then calls {@link #_impl_validate} to allow the
-   * concrete subclass to do any final validation and tweakage.
-   *
-   * **Note:** This method treats `undefined` in configuration objects like
-   * `null` and will only pass `null` per se into a checker method. And it
-   * throws an error if a checker returns `undefined`, on the assumption that it
-   * is missing an explicit `return`.
-   *
-   * **Note:** For the sake of determinism, this method calls checker methods in
-   * Unicode sort order.
-   *
-   * @param {object} rawConfig Raw configuration object.
-   */
-  #fillInObject(rawConfig) {
-    const checkers    = this.#findConfigCheckers();
-    const sortedNames = [...checkers.keys()].sort();
-    const props       = {};
-    const leftovers   = new Set(Object.keys(rawConfig));
-
-    for (const name of sortedNames) {
-      const checker   = checkers.get(name);
-      const hasConfig = name in rawConfig;
-
-      try {
-        const value = hasConfig
-          ? this[checker](rawConfig[name])
-          : this[checker]();
-
-        if (value === undefined) {
-          throw new Error(`Checker \`${checker}()\` did not return a value. Maybe missing a \`return\`?`);
-        }
-
-        props[name] = value;
-
-        if (hasConfig) {
-          leftovers.delete(name);
-        }
-      } catch (e) {
-        if (!hasConfig) {
-          // This could also be due to a bug in the config class.
-          throw new Error(`Missing required configuration property: \`${name}\``);
-        }
-        throw e;
-      }
-    }
-
-    if (leftovers.size !== 0) {
-      const names = [...leftovers].join(', ');
-      const word  = (leftovers.size === 1) ? 'property' : 'properties';
-      throw new Error(`Extra configuration ${word}: \`${names}\``);
-    }
-
-    const finalProps = this._impl_validate(props);
-
-    if (finalProps === undefined) {
-      throw new Error(`\`_impl_validate()\` did not return a value. Maybe missing a \`return\`?`);
-    }
-
-    for (const [key, value] of Object.entries(finalProps)) {
-      Reflect.defineProperty(this, key, {
-        configurable: false,
-        enumerable:   true,
-        writable:     false,
-        value
-      });
-    }
-  }
-
-  /**
-   * Finds all the `_config_*` methods on `this`, returning a map from the plain
-   * property name to the check method name.
-   *
-   * @returns {Map<string, string>} The map from property names to corresponding
-   *   checker method names.
-   */
-  #findConfigCheckers() {
-    const result = new Map();
-    let   target = this;
-
-    for (;;) {
-      const keys = Reflect.ownKeys(target);
-
-      for (const k of keys) {
-        if (typeof k !== 'string') {
-          continue;
-        }
-
-        const name = k.match(/^_config_(?<name>.*)$/)?.groups.name ?? null;
-
-        if (name && !result.has(name)) {
-          const pd = Reflect.getOwnPropertyDescriptor(target, k);
-          if (typeof pd.value === 'function') {
-            result.set(name, k);
-          }
-        }
-      }
-
-      target = Reflect.getPrototypeOf(target);
-
-      if (!target || (target.constructor === Object)) {
-        break;
-      }
-    }
-
-    return result;
+  /** @override */
+  _impl_propertyPrefix() {
+    return 'config';
   }
 
 

--- a/src/compy/index.js
+++ b/src/compy/index.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from '#x/BaseComponent';
-export * from '#x/BaseConfig';
 export * from '#x/BaseRootComponent';
 export * from '#x/ControlContext';
 export * from '#x/MockComponent';

--- a/src/data-values/export/BaseConfig.js
+++ b/src/data-values/export/BaseConfig.js
@@ -1,8 +1,9 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { BaseStruct } from '@this/data-values';
 import { AskIf, MustBe } from '@this/typey';
+
+import { BaseStruct } from '#x/BaseStruct';
 
 
 /**

--- a/src/data-values/export/BaseStruct.js
+++ b/src/data-values/export/BaseStruct.js
@@ -1,0 +1,244 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { AskIf, MustBe } from '@this/typey';
+
+
+/**
+ * Base class for type-checked "structures." Each concrete subclass is expected
+ * to pass a plain object in its `super()` call which is suitable for parsing by
+ * this (base) class. This class defines the mechanism by which a plain object
+ * gets mapped into properties on the constructed instance, including running
+ * validation on each property and a final overall validation.
+ */
+export class BaseStruct {
+  /**
+   * Constructs an instance.
+   *
+   * @param {object} rawObject Raw object to parse. See class header for
+   *   details.
+   */
+  constructor(rawObject) {
+    MustBe.plainObject(rawObject);
+
+    this.#fillInObject(rawObject);
+  }
+
+  /**
+   * Gets the prefix used on instance members of the class which are to be
+   * treated as property-checker methods. This is `struct` by default.
+   * Subclasses should override this as appropriate for their context.
+   *
+   * @returns {string} The property-checker prefix, as a plain word (not
+   *   surrounded by underscores).
+   */
+  _impl_propertyPrefix() {
+    return 'struct';
+  }
+
+  /**
+   * Validates a processed struct object, optionally changing properties,
+   * prior to actually setting its properties on this instance. Subclasses
+   * should override this if they need to do any final validation or tweakage.
+   * The base class implementation of this method returns its argument (that is,
+   * it does nothing), but concrete subclasses should check their own immediate
+   * superclasses for requirements about calling `super()`.
+   *
+   * @param {object} lessRawObject Processed object (which started as a
+   *   `rawObject`).
+   * @returns {object} Final object to use for setting properties on `this`.
+   */
+  _impl_validate(lessRawObject) {
+    return lessRawObject;
+  }
+
+  /**
+   * Fills in a property on `this` for each property that is covered by a
+   * property-checker method (prefix `_struct_` by default) defined by the
+   * actual (concrete) class of `this`. If the given `rawObject` doesn't have a
+   * property for any given checker method, that method is called with no
+   * argument, to give it a chance to use a default value or simply reject it
+   * for not being filled in. After making all such calls, this method then
+   * calls {@link #_impl_validate} to allow the concrete subclass to do any
+   * final validation and tweakage.
+   *
+   * **Note:** This method treats `undefined` in raw objects like `null` and
+   * will only pass `null` per se into a checker method. And it throws an error
+   * if a checker returns `undefined`, on the assumption that it is missing an
+   * explicit `return`.
+   *
+   * **Note:** For the sake of determinism, this method calls checker methods in
+   * Unicode sort order.
+   *
+   * @param {object} rawObject Raw object.
+   */
+  #fillInObject(rawObject) {
+    const checkers    = this.#findConfigCheckers();
+    const sortedNames = [...checkers.keys()].sort();
+    const props       = {};
+    const leftovers   = new Set(Object.keys(rawObject));
+
+    for (const name of sortedNames) {
+      const checker   = checkers.get(name);
+      const hasConfig = name in rawObject;
+
+      try {
+        const value = hasConfig
+          ? this[checker](rawObject[name])
+          : this[checker]();
+
+        if (value === undefined) {
+          throw new Error(`Checker \`${checker}()\` did not return a value. Maybe missing a \`return\`?`);
+        }
+
+        props[name] = value;
+
+        if (hasConfig) {
+          leftovers.delete(name);
+        }
+      } catch (e) {
+        if (!hasConfig) {
+          // This could also be due to a bug in the concrete struct class.
+          throw new Error(`Missing required property: \`${name}\``);
+        }
+        throw e;
+      }
+    }
+
+    if (leftovers.size !== 0) {
+      const names = [...leftovers].join(', ');
+      const word  = (leftovers.size === 1) ? 'property' : 'properties';
+      throw new Error(`Extra property ${word}: \`${names}\``);
+    }
+
+    const finalProps = this._impl_validate(props);
+
+    if (finalProps === undefined) {
+      throw new Error(`\`_impl_validate()\` did not return a value. Maybe missing a \`return\`?`);
+    }
+
+    for (const [key, value] of Object.entries(finalProps)) {
+      Reflect.defineProperty(this, key, {
+        configurable: false,
+        enumerable:   true,
+        writable:     false,
+        value
+      });
+    }
+  }
+
+  /**
+   * Finds all the property-checker methods on `this`, returning a map from the
+   * plain property name to the check method name.
+   *
+   * @returns {Map<string, string>} The map from property names to corresponding
+   *   checker method names.
+   */
+  #findConfigCheckers() {
+    const result = new Map();
+    const prefix = `_${this._impl_propertyPrefix()}_`;
+    let   target = this;
+
+
+    for (;;) {
+      const keys = Reflect.ownKeys(target);
+
+      for (const k of keys) {
+        if ((typeof k !== 'string') || !k.startsWith(prefix)) {
+          continue;
+        }
+
+        const name = k.slice(prefix.length);
+
+        if (!result.has(name)) {
+          const pd = Reflect.getOwnPropertyDescriptor(target, k);
+          if (typeof pd.value === 'function') {
+            result.set(name, k);
+          }
+        }
+      }
+
+      target = Reflect.getPrototypeOf(target);
+
+      if (!target || (target.constructor === Object)) {
+        break;
+      }
+    }
+
+    return result;
+  }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * "Evaluate" a raw object that was passed to the constructor of a struct
+   * class. This is where the usual rules (e.g. as described by the
+   * `BaseComponent` constructor) are actually implemented. This method is
+   * expected to be called on a concrete subclass of this (base) class, and the
+   * actual called class is used to drive the salient portion of the error
+   * checking.
+   *
+   * @param {?object} rawObject Raw object, including allowing `null` to be
+   *   equivalent to `{}`, and accepting an instance of this class.
+   * @param {object} options Evaluation options.
+   * @param {object} [options.defaults] Default values when evaluating a plain
+   *   object. Defaults to `{}`.
+   * @param {function(new:*)} options.targetClass The class that `rawObject` is
+   *   supposed to be constructing.
+   * @returns {BaseStruct} Instance of the concrete class that this method was
+   *   called on.
+   */
+  static eval(rawObject, { defaults = {}, targetClass }) {
+    rawObject ??= {};
+
+    if (rawObject instanceof this) {
+      return rawObject;
+    } else if (rawObject instanceof BaseStruct) {
+      // It's the wrong concrete class.
+      const gotName = rawObject.constructor.name;
+      throw new Error(`Incompatible struct class: expected ${this.name}, got ${gotName}`);
+    } else if (!AskIf.plainObject(rawObject)) {
+      if (typeof rawObject === 'object') {
+        const gotName = rawObject.constructor.name;
+        throw new Error(`Cannot convert non-struct object: expected ${this.name}, got ${gotName}`);
+      } else {
+        const gotType = typeof rawObject;
+        throw new Error(`Cannot evaluate non-object as struct: expected ${this.name}, got ${gotType}`);
+      }
+    }
+
+    // It's a plain object.
+
+    let finalObj = rawObject; // Might get replaced by a modified copy.
+
+    const defaultProp = (k, v, force = false) => {
+      if (force || !Reflect.has(finalObj, k)) {
+        if (finalObj === rawObject) {
+          finalObj = { ...rawObject };
+        }
+        finalObj[k] = v;
+      }
+    };
+
+    for (const [k, v] of Object.entries(defaults)) {
+      defaultProp(k, v);
+    }
+
+    const objTargetClass = finalObj.class;
+
+    if ((objTargetClass === null) || (objTargetClass === undefined)) {
+      defaultProp('class', targetClass);
+    } else if (objTargetClass !== targetClass) {
+      if (!AskIf.constructorFunction(objTargetClass)) {
+        throw new Error('Expected class (constructor function) for `rawObject.class`.');
+      } else {
+        throw new Error(`Mismatch on \`rawObject.class\`: expected ${targetClass.name}, got ${objTargetClass.name}`);
+      }
+    }
+
+    return new this(finalObj);
+  }
+}

--- a/src/data-values/export/BaseStruct.js
+++ b/src/data-values/export/BaseStruct.js
@@ -6,7 +6,8 @@ import { AskIf, MustBe } from '@this/typey';
 
 /**
  * Base class for type-checked "structures." Each concrete subclass is expected
- * to pass a plain object in its `super()` call which is suitable for parsing by
+ * to pass a plain object in its `super()` constructor call (or pass nothing or
+ * `null` for an all-default construction) which is suitable for parsing by
  * this (base) class. This class defines the mechanism by which a plain object
  * gets mapped into properties on the constructed instance, including running
  * validation on each property and a final overall validation.
@@ -15,11 +16,12 @@ export class BaseStruct {
   /**
    * Constructs an instance.
    *
-   * @param {object} rawObject Raw object to parse. See class header for
-   *   details.
+   * @param {?object} [rawObject] Raw object to parse. This is expected to be
+   *   either a plain object, or `null` to have all default values. The latter
+   *   is equivalent to passing `{}` (an empty object).
    */
-  constructor(rawObject) {
-    MustBe.plainObject(rawObject);
+  constructor(rawObject = null) {
+    rawObject = (rawObject === null) ? {} : MustBe.plainObject(rawObject);
 
     this.#fillInObject(rawObject);
   }

--- a/src/data-values/export/BaseStruct.js
+++ b/src/data-values/export/BaseStruct.js
@@ -189,7 +189,7 @@ export class BaseStruct {
    * @returns {BaseStruct} Instance of the concrete class that this method was
    *   called on.
    */
-  static eval(rawObject, { defaults = {}, targetClass }) {
+  static eval(rawObject, { defaults = {} }) {
     rawObject ??= {};
 
     if (rawObject instanceof this) {

--- a/src/data-values/export/BaseStruct.js
+++ b/src/data-values/export/BaseStruct.js
@@ -7,9 +7,9 @@ import { AskIf, MustBe } from '@this/typey';
 /**
  * Base class for type-checked "structures." Each concrete subclass is expected
  * to pass a plain object in its `super()` constructor call (or pass nothing or
- * `null` for an all-default construction) which is suitable for parsing by
- * this (base) class. This class defines the mechanism by which a plain object
- * gets mapped into properties on the constructed instance, including running
+ * `null` for an all-default construction) which is suitable for parsing by this
+ * (base) class. This class defines the mechanism by which a plain object gets
+ * mapped into properties on the constructed instance, including running
  * validation on each property and a final overall validation.
  */
 export class BaseStruct {
@@ -39,11 +39,11 @@ export class BaseStruct {
   }
 
   /**
-   * Validates a processed struct object, optionally changing properties,
-   * prior to actually setting its properties on this instance. Subclasses
-   * should override this if they need to do any final validation or tweakage.
-   * The base class implementation of this method returns its argument (that is,
-   * it does nothing), but concrete subclasses should check their own immediate
+   * Validates a processed struct object, optionally changing properties, prior
+   * to actually setting its properties on this instance. Subclasses should
+   * override this if they need to do any final validation or tweakage. The base
+   * class implementation of this method returns its argument (that is, it does
+   * nothing), but concrete subclasses should check their own immediate
    * superclasses for requirements about calling `super()`.
    *
    * @param {object} lessRawObject Processed object (which started as a

--- a/src/data-values/export/BaseStruct.js
+++ b/src/data-values/export/BaseStruct.js
@@ -186,8 +186,6 @@ export class BaseStruct {
    * @param {object} options Evaluation options.
    * @param {object} [options.defaults] Default values when evaluating a plain
    *   object. Defaults to `{}`.
-   * @param {function(new:*)} options.targetClass The class that `rawObject` is
-   *   supposed to be constructing.
    * @returns {BaseStruct} Instance of the concrete class that this method was
    *   called on.
    */
@@ -225,18 +223,6 @@ export class BaseStruct {
 
     for (const [k, v] of Object.entries(defaults)) {
       defaultProp(k, v);
-    }
-
-    const objTargetClass = finalObj.class;
-
-    if ((objTargetClass === null) || (objTargetClass === undefined)) {
-      defaultProp('class', targetClass);
-    } else if (objTargetClass !== targetClass) {
-      if (!AskIf.constructorFunction(objTargetClass)) {
-        throw new Error('Expected class (constructor function) for `rawObject.class`.');
-      } else {
-        throw new Error(`Mismatch on \`rawObject.class\`: expected ${targetClass.name}, got ${objTargetClass.name}`);
-      }
     }
 
     return new this(finalObj);

--- a/src/data-values/export/ConverterConfig.js
+++ b/src/data-values/export/ConverterConfig.js
@@ -6,8 +6,8 @@ import { AskIf, MustBe } from '@this/typey';
 import { BaseConfig } from '#x/BaseConfig';
 import { BaseConverter } from '#x/BaseConverter';
 import { Ref } from '#x/Ref';
-import { SpecialConverters } from '#x/SpecialConverters';
 import { Sexp } from '#x/Sexp';
+import { SpecialConverters } from '#x/SpecialConverters';
 
 
 /**

--- a/src/data-values/export/ConverterConfig.js
+++ b/src/data-values/export/ConverterConfig.js
@@ -3,6 +3,7 @@
 
 import { AskIf, MustBe } from '@this/typey';
 
+import { BaseConfig } from '#x/BaseConfig';
 import { BaseConverter } from '#x/BaseConverter';
 import { Ref } from '#x/Ref';
 import { SpecialConverters } from '#x/SpecialConverters';
@@ -35,164 +36,94 @@ import { Sexp } from '#x/Sexp';
  * In cases where these values are allowed, a function is also sometimes
  * allowed, which can be called on to provide a replacement value.
  */
-export class ConverterConfig {
-  /**
-   * Classes whose instances are treated as data values.
-   *
-   * @type {Array<function(new:*)>}
-   */
-  #dataClasses;
+export class ConverterConfig extends BaseConfig {
+  // @defaultConstructor
 
   /**
-   * Are converted data values to be frozen?
+   * Classes whose instances are treated as data values. This value is always
+   * frozen; if passed in upon construction as an unfrozen value, then a frozen
+   * clone is used.
    *
-   * @type {boolean}
+   * @param {Array<function(new:*)>} [value] Proposed configuration value.
+   *   Default `[Ref, Sexp]`.
+   * @returns {Array<function(new:*)>} Accepted configuration value.
    */
-  #freeze;
+  _config_dataClasses(value = Object.freeze([Ref, Sexp])) {
+    MustBe.arrayOf(value, AskIf.constructorFunction);
+
+    return Object.isFrozen(value) ? value : Object.freeze([...value]);
+  }
 
   /**
-   * Action to take when asked to encode a function.
+   * Are converted data values to be frozen? If `false`, then no frozen data
+   * values will be returned, even if they required no other conversion during
+   * encoding.
    *
-   * @type {string|(function(*): *)}
+   * @param {boolean} [value] Proposed configuration value. Default `true`.
+   * @returns {boolean} Accepted configuration value.
    */
-  #functionAction;
+  _config_freeze(value = true) {
+    return MustBe.boolean(value);
+  }
+
+  /**
+   * Action to take when asked to encode a function. See class header comment
+   * for details.
+   *
+   * @param {string|(function(*): *)} [value] Proposed configuration value.
+   *   Default `'wrap'`.
+   * @returns {string|(function(*): *)} Accepted configuration value.
+   */
+  _config_functionAction(value = 'wrap') {
+    return ConverterConfig.#checkAction(value);
+  }
 
   /**
    * Should instance-defined `ENCODE()` methods be honored?
    *
-   * @type {boolean}
+   * @param {boolean} [value] Proposed configuration value. Default `true`.
+   * @returns {boolean} Accepted configuration value.
    */
-  #honorEncodeMethod;
+  _config_honorEncodeMethod(value = true) {
+    return MustBe.boolean(value);
+  }
 
   /**
    * Action to take when asked to encode an instance (object with a class) which
    * is not otherwise covered by other configuration options.
    *
-   * @type {string|(function(*): *)}
+   * @param {string|(function(*): *)} [value] Proposed configuration value.
+   *   Default `'wrap'`.
+   * @returns {string|(function(*): *)} Accepted configuration value.
    */
-  #instanceAction;
+  _config_instanceAction(value = 'wrap') {
+    return ConverterConfig.#checkAction(value);
+  }
 
   /**
-   * {?BaseConverter} Converter to handle any special cases that take precedence
-   * over other configuration options.
+   * Converter to handle any special cases that take precedence
+   * over other configuration options, or `null` if there are no
+   * special cases.
+   *
+   * @param {?BaseConverter} [value] Proposed configuration value. Default
+   *   {@link SpecialConverters#STANDARD}.
+   * @returns {?BaseConverter} Accepted configuration value.
    */
-  #specialCases;
+  _config_specialCases(value = SpecialConverters.STANDARD) {
+    return (value === null)
+      ? null
+      : MustBe.instanceOf(value, BaseConverter);
+  }
 
   /**
    * Action to take when encountering a symbol-keyed object or array property.
    * Allowed to be either `error` or `omit`.
    *
-   * @type {string}
+   * @param {string} [value] Proposed configuration value. Default `'omit'`.
+   * @returns {string} Accepted configuration value.
    */
-  #symbolKeyAction;
-
-  /**
-   * Constructs an instance. See the accessors on this class for details on the
-   * options, including defaults.
-   *
-   * @param {?object} [options] Configuration options, or `null` to use the
-   *   default configuration.
-   */
-  constructor(options = null) {
-    options = (options === null) ? {} : MustBe.plainObject(options);
-
-    const {
-      dataClasses       = [Ref, Sexp],
-      freeze            = true,
-      functionAction    = 'wrap',
-      honorEncodeMethod = true,
-      instanceAction    = 'wrap',
-      specialCases      = SpecialConverters.STANDARD,
-      symbolKeyAction   = 'omit'
-    } = options;
-
-    this.#dataClasses       = Object.freeze(
-      MustBe.arrayOf(dataClasses, AskIf.constructorFunction));
-    this.#freeze            = MustBe.boolean(freeze);
-    this.#functionAction    = ConverterConfig.#checkAction(functionAction);
-    this.#honorEncodeMethod = MustBe.boolean(honorEncodeMethod);
-    this.#instanceAction    = ConverterConfig.#checkAction(instanceAction);
-    this.#specialCases      = (specialCases === null)
-      ? null
-      : MustBe.instanceOf(specialCases, BaseConverter);
-    this.#symbolKeyAction   =
-      ConverterConfig.#checkSymbolKeyAction(symbolKeyAction);
-  }
-
-  /**
-   * @returns {Array<function(new:*)>} Classes whose instances are treated as
-   * data values.
-   *
-   * Default value if not passed during construction: `[Ref, Sexp]`.
-   *
-   * This value is always frozen; if passed in upon construction as an unfrozen
-   * value, then frozen clone is used.
-   */
-  get dataClasses() {
-    return this.#dataClasses;
-  }
-
-  /**
-   * @returns {boolean} Are converted data values to be frozen? If `false`, then
-   * no frozen data values will be returned, even if they required no other
-   * conversion during encoding.
-   *
-   * Default value if not passed during construction: `true`
-   */
-  get freeze() {
-    return this.#freeze;
-  }
-
-  /**
-   * @returns {string|(function(*): *)} Action to take when asked to encode a
-   * function.
-   *
-   * Default value if not passed during construction: `wrap`
-   */
-  get functionAction() {
-    return this.#functionAction;
-  }
-
-  /**
-   * @returns {boolean} Should instance-defined `ENCODE()` methods be honored?
-   *
-   * Default value if not passed during construction: `true`
-   */
-  get honorEncodeMethod() {
-    return this.#honorEncodeMethod;
-  }
-
-  /**
-   * @returns {string|(function(*): *)} Action to take when asked to encode an
-   * instance (object with a class) which is not otherwise covered by other
-   * configuration options.
-   *
-   * Default value if not passed during construction: `wrap`
-   */
-  get instanceAction() {
-    return this.#instanceAction;
-  }
-
-  /**
-   * @returns {?BaseConverter} Converter to handle any special cases that take
-   * precedence over other configuration options, or `null` if there are no
-   * special cases.
-   *
-   * Default value if not passed during construction: {@link
-   * SpecialConverters#STANDARD}.
-   */
-  get specialCases() {
-    return this.#specialCases;
-  }
-
-  /**
-   * @returns {string} Action to take when encountering a symbol-keyed object or
-   * array property. Allowed to be either `error` or `omit`.
-   *
-   * Default value if not passed during construction: `omit`
-   */
-  get symbolKeyAction() {
-    return this.#symbolKeyAction;
+  _config_symbolKeyAction(value = 'omit') {
+    return ConverterConfig.#checkSymbolKeyAction(value);
   }
 
   /**
@@ -204,7 +135,7 @@ export class ConverterConfig {
    *   data classes.
    */
   isDataInstance(value) {
-    for (const cls of this.#dataClasses) {
+    for (const cls of this.dataClasses) {
       if (value instanceof cls) {
         return true;
       }

--- a/src/data-values/export/ConverterConfig.js
+++ b/src/data-values/export/ConverterConfig.js
@@ -101,9 +101,8 @@ export class ConverterConfig extends BaseConfig {
   }
 
   /**
-   * Converter to handle any special cases that take precedence
-   * over other configuration options, or `null` if there are no
-   * special cases.
+   * Converter to handle any special cases that take precedence over other
+   * configuration options, or `null` if there are no special cases.
    *
    * @param {?BaseConverter} [value] Proposed configuration value. Default
    *   {@link SpecialConverters#STANDARD}.

--- a/src/data-values/export/StackTrace.js
+++ b/src/data-values/export/StackTrace.js
@@ -4,8 +4,8 @@
 import { AskIf, MustBe } from '@this/typey';
 
 import { BaseConverter } from '#x/BaseConverter';
-import { StackFrame } from '#x/StackFrame';
 import { Sexp } from '#x/Sexp';
+import { StackFrame } from '#x/StackFrame';
 
 
 /**

--- a/src/data-values/index.js
+++ b/src/data-values/index.js
@@ -3,6 +3,7 @@
 
 export * from '#x/BaseConverter';
 export * from '#x/BaseDataClass';
+export * from '#x/BaseStruct';
 export * from '#x/ByteCount';
 export * from '#x/ByteRate';
 export * from '#x/Converter';

--- a/src/data-values/index.js
+++ b/src/data-values/index.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+export * from '#x/BaseConfig';
 export * from '#x/BaseConverter';
 export * from '#x/BaseDataClass';
 export * from '#x/BaseStruct';

--- a/src/data-values/private/ConvError.js
+++ b/src/data-values/private/ConvError.js
@@ -4,8 +4,8 @@
 import { MustBe } from '@this/typey';
 
 import { BaseConverter } from '#x/BaseConverter';
-import { StackTrace } from '#x/StackTrace';
 import { Sexp } from '#x/Sexp';
+import { StackTrace } from '#x/StackTrace';
 
 
 /**

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -4,7 +4,7 @@
 import * as util from 'node:util';
 
 import { EventPayload, EventSource } from '@this/async';
-import { BaseConverter, Moment, StackTrace, Sexp } from '@this/data-values';
+import { BaseConverter, Moment, Sexp, StackTrace } from '@this/data-values';
 import { Chalk } from '@this/text';
 import { MustBe } from '@this/typey';
 

--- a/src/webapp-util/export/BaseFileService.js
+++ b/src/webapp-util/export/BaseFileService.js
@@ -4,8 +4,7 @@
 import * as fs from 'node:fs/promises';
 
 import { WallClock } from '@this/clocky';
-import { BaseConfig } from '@this/compy';
-import { ByteCount, Duration } from '@this/data-values';
+import { BaseConfig, ByteCount, Duration } from '@this/data-values';
 import { Paths, Statter } from '@this/fs-util';
 import { MustBe } from '@this/typey';
 import { BaseService } from '@this/webapp-core';


### PR DESCRIPTION
This PR moves `BaseConfig` from `compy` to `data-values`, and then extracts a base class out of it `BaseStruct`. The latter is in recognition that _most_ of what `BaseConfig` does is not specific to configuration.

And, with the module move, `data-values.ConverterConfig` could actually be made to inherit from `BaseConfig`. (Before this PR, it would have caused a circular dependency.)