### PR TITLE
Selective logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ Breaking changes:
     `BaseConfig` did was not particularly specific to configuration, per se.
 
 Other notable changes:
+* configuration:
+  * New top-level (`WebappRoot`) configuration `logging`, to do fine-grained
+    control over which components produce system logs.
 * `compy`:
   * Fixed bug in `BaseComponent.CONFIG_CLASS` which caused it to sometimes
     call base classes' `_impl_configClass()` multiple times (which isn't

--- a/doc/configuration/README.md
+++ b/doc/configuration/README.md
@@ -29,7 +29,10 @@ const config = {
   ],
   applications: [
     // ... configuration ...
-  ]
+  ],
+  logging: {
+    // ... configuration ...
+  }
 };
 
 export default config;
@@ -269,6 +272,30 @@ const endpoints = [
     },
     application: 'mySite'
   },
+```
+
+### `logging`
+
+`logging` is an object which provides fine-grained control over which
+components (subsystems) produce system logs. Each property is a "path key" that
+names a component or (with a `/*` suffix) wildcard covering a component and all
+its subcomponents, and a boolean value indicating whether or not the covered
+component(s) should produce logs. For any given component, the most-specific
+path is what controls it. And, if logging is on at all, then the default (if no
+path covers a component) is for logging to be _on_.
+
+To figure out what to turn on or off, just look at the logs produced by the
+system by default. Anything tagged with the prefix `webapp.` can be controlled,
+with the path to use here being everything after that prefix, with dots replaced
+with slashes. So, `webapp.service.myService` in the logs would be controlled by
+the key `/service/myService`.
+
+```js
+const logging = {
+  '/endpoints/*':              false,
+  '/endpoints/loggedEndpoint': true,
+  // ... more ...
+};
 ```
 
 ## Custom Applications and Services

--- a/src/compy/export/BaseRootComponent.js
+++ b/src/compy/export/BaseRootComponent.js
@@ -1,7 +1,9 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { TreeMap } from '@this/collections';
 import { IntfLogger } from '@this/loggy-intf';
+import { MustBe } from '@this/typey';
 
 import { BaseComponent } from '#x/BaseComponent';
 import { Names } from '#x/Names';
@@ -49,6 +51,28 @@ export class BaseRootComponent extends BaseComponent {
   static _impl_configClass() {
     return class Config extends super.prototype.constructor.CONFIG_CLASS {
       // @defaultConstructor
+
+      /**
+       * Logging control.
+       *
+       * @param {?object|TreeMap} [value] Proposed configuration value. Default
+       *   `null`.
+       * @returns {?TreeMap} Accepted configuration value.
+       */
+      _config_logging(value = null) {
+        if ((value instanceof TreeMap) || (value === null)) {
+          return value;
+        }
+
+        const result = new TreeMap();
+        for (const [k, v] of Object.entries(value)) {
+          const path = Names.parsePath(k, true);
+          MustBe.boolean(v);
+          result.set(path, v);
+        }
+
+        return result;
+      }
 
       /**
        * Component name. This is an override of the base class in order to force

--- a/src/compy/export/BaseRootComponent.js
+++ b/src/compy/export/BaseRootComponent.js
@@ -68,7 +68,7 @@ export class BaseRootComponent extends BaseComponent {
         for (const [k, v] of Object.entries(value)) {
           const path = Names.parsePath(k, true);
           MustBe.boolean(v);
-          result.set(path, v);
+          result.add(path, v);
         }
 
         return result;

--- a/src/compy/export/BaseRootComponent.js
+++ b/src/compy/export/BaseRootComponent.js
@@ -29,15 +29,15 @@ export class BaseRootComponent extends BaseComponent {
    */
   constructor(rawConfig = null) {
     // We need to recapitulate the config parsing our superclass would have done
-    // so that we will only get a valid `rootLogger` value. (That is, if we're
-    // passed a bogus `rawConfig`, the `eval()` call will throw.)
-    rawConfig = new.target.CONFIG_CLASS.eval(rawConfig, {
+    // so that we can pass the parsed config to the `RootControlContext`
+    // constructor.
+    const config = new.target.CONFIG_CLASS.eval(rawConfig, {
       targetClass: new.target
     });
 
-    const context = new RootControlContext(rawConfig.rootLogger);
+    const context = new RootControlContext(config);
 
-    super(rawConfig, context);
+    super(config, context);
   }
 
 

--- a/src/compy/export/ControlContext.js
+++ b/src/compy/export/ControlContext.js
@@ -121,13 +121,7 @@ export class ControlContext {
   /** @returns {?IntfLogger} Logger to use, or `null` to not do any logging. */
   get logger() {
     if (this.#logger === false) {
-      let logger = this.#root.rootLogger ?? null;
-      if (logger) {
-        for (const k of this.#namePath.path) {
-          logger = logger[k];
-        }
-      }
-      this.#logger = logger;
+      this.#logger = this.#root.getLoggerForPath(this.#namePath);
     }
 
     return this.#logger;

--- a/src/compy/export/RootControlContext.js
+++ b/src/compy/export/RootControlContext.js
@@ -32,7 +32,8 @@ export class RootControlContext extends ControlContext {
   /**
    * Constructs an instance. It initially has no `associate`.
    *
-   * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
+   * @param {?IntfLogger} logger Root logger to use as the base for all logging,
+   *   or `null` to not do any logging in this hierarchy.
    */
   constructor(logger) {
     super('root', null);

--- a/src/compy/export/RootControlContext.js
+++ b/src/compy/export/RootControlContext.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { TreeMap } from '@this/collections';
+import { PathKey, TreeMap } from '@this/collections';
 import { IntfLogger } from '@this/loggy-intf';
 
 import { ControlContext } from '#x/ControlContext';
@@ -80,5 +80,27 @@ export class RootControlContext extends ControlContext {
       const names = `[${classes.map((c) => c.name).join(', ')}]`;
       throw new Error(`${errPrefix} classes: ${names}`);
     }
+  }
+
+  /**
+   * Gets the logger to use for the given component path.
+   *
+   * @param {PathKey} componentPath The component path.
+   * @returns {?IntfLogger} The logger, or `null` if the indicated component
+   *   should not do logging.
+   */
+  getLoggerForPath(componentPath) {
+    const rootLogger = this.#rootLogger;
+
+    if (!rootLogger) {
+      return null;
+    }
+
+    let logger = rootLogger;
+    for (const k of componentPath.path) {
+      logger = logger[k];
+    }
+
+    return logger;
   }
 }

--- a/src/compy/export/RootControlContext.js
+++ b/src/compy/export/RootControlContext.js
@@ -96,7 +96,18 @@ export class RootControlContext extends ControlContext {
       return null;
     }
 
+    const loggingMap = this.#rootConfig.logging;
+
+    if (loggingMap) {
+      const found = loggingMap.find(componentPath);
+      if (found?.value === false) {
+        // The match indicates that logging should be off for this component.
+        return null;
+      }
+    }
+
     let logger = rootLogger;
+
     for (const k of componentPath.path) {
       logger = logger[k];
     }

--- a/src/compy/export/RootControlContext.js
+++ b/src/compy/export/RootControlContext.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PathKey, TreeMap } from '@this/collections';
+import { BaseConfig } from '@this/data-values';
 import { IntfLogger } from '@this/loggy-intf';
 
 import { ControlContext } from '#x/ControlContext';
@@ -15,12 +16,12 @@ import { ThisModule } from '#p/ThisModule';
  */
 export class RootControlContext extends ControlContext {
   /**
-   * The "root" logger to use, or `null` if the hierarchy isn't doing logging at
-   * all.
+   * The configuration object for the root component. This notably contains
+   * logging-related info needed by this class.
    *
-   * @type {?IntfLogger}
+   * @type {BaseConfig}
    */
-  #rootLogger;
+  #rootConfig;
 
   /**
    * Tree which maps each component path to its context instance.
@@ -32,13 +33,12 @@ export class RootControlContext extends ControlContext {
   /**
    * Constructs an instance. It initially has no `associate`.
    *
-   * @param {?IntfLogger} logger Root logger to use as the base for all logging,
-   *   or `null` to not do any logging in this hierarchy.
+   * @param {BaseConfig} config Root component configuration.
    */
-  constructor(logger) {
+  constructor(config) {
     super('root', null);
 
-    this.#rootLogger = logger;
+    this.#rootConfig = config;
   }
 
   /**
@@ -47,7 +47,7 @@ export class RootControlContext extends ControlContext {
    * hierarchy is _not_ doing logging at all.
    */
   get rootLogger() {
-    return this.#rootLogger;
+    return this.#rootConfig.rootLogger;
   }
 
   /**
@@ -90,7 +90,7 @@ export class RootControlContext extends ControlContext {
    *   should not do logging.
    */
   getLoggerForPath(componentPath) {
-    const rootLogger = this.#rootLogger;
+    const rootLogger = this.rootLogger;
 
     if (!rootLogger) {
       return null;

--- a/src/compy/tests/Names.test.js
+++ b/src/compy/tests/Names.test.js
@@ -1,0 +1,70 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { Names } from '@this/compy';
+
+describe.each`
+methodName      | throws
+${'checkName'}  | ${true}
+${'isName'}     | ${false}
+`('$methodName()', ({ methodName, throws }) => {
+  // Non-string errors. Always expected to throw.
+  test.each`
+  arg
+  ${null}
+  ${undefined}
+  ${false}
+  ${true}
+  ${123}
+  ${['x']}
+  ${{ a: 'x' }}
+  `('throws given $arg', ({ arg }) => {
+    expect(() => Names[methodName](arg)).toThrow();
+  });
+
+  // Invalid strings.
+  test.each`
+  arg
+  ${''}
+  ${'#'}    // Invalid character at start.
+  ${'x^'}   // ...at end.
+  ${'x&y'}  // ...in the middle.
+  ${'.xyz'} // Can't start with a dot.
+  ${'abc.'} // ...or end with one.
+  ${'-xyz'} // Can't start with a dash.
+  ${'abc-'} // ...or end with one.
+  `('rejects `$arg`', ({ arg }) => {
+    if (throws) {
+      expect(() => Names[methodName](arg)).toThrow();
+    } else {
+      expect(Names[methodName](arg)).toBeFalse();
+    }
+  });
+
+  // Valid strings.
+  test.each`
+  arg
+  ${'a'}
+  ${'A'}
+  ${'0'}
+  ${'_'}
+  ${'_abc'}
+  ${'abc_'}
+  ${'_abc_'}
+  ${'abc_def'}
+  ${'a-b'}
+  ${'a.b'}
+  ${'foo-bar.baz_biff'}
+  `('accepts `$arg`', ({ arg }) => {
+    if (throws) {
+      expect(() => Names[methodName](arg)).not.toThrow();
+    }
+
+    const got = Names[methodName](arg);
+    if (throws) {
+      expect(got).toBe(arg);
+    } else {
+      expect(got).toBeTrue();
+    }
+  });
+});

--- a/src/compy/tests/Names.test.js
+++ b/src/compy/tests/Names.test.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { PathKey } from '@this/collections';
 import { Names } from '@this/compy';
 
 describe.each`
@@ -66,5 +67,81 @@ ${'isName'}     | ${false}
     } else {
       expect(got).toBeTrue();
     }
+  });
+});
+
+describe('parsePath()', () => {
+  const wildKey    = new PathKey(['a', 'b', 'c'], true);
+  const nonWildKey = new PathKey(['cd', 'ef'], false);
+
+  function nonWildcardCases(allowWildcard) {
+    test.each`
+    arg             | expected
+    ${'/'}          | ${[]}
+    ${'/a'}         | ${['a']}
+    ${'/a/b'}       | ${['a', 'b']}
+    ${'/a/b/c'}     | ${['a', 'b', 'c']}
+    ${'/boop/beep'} | ${['boop', 'beep']}
+    ${[]}           | ${[]}
+    ${['zz']}       | ${['zz']}
+    ${['zz', 'yy']} | ${['zz', 'yy']}
+    ${nonWildKey}   | ${['cd', 'ef']}
+    `('works given $arg', ({ arg, expected }) => {
+      const args = (allowWildcard === null)
+        ? [arg]
+        : [arg, allowWildcard];
+      const got = Names.parsePath(...args);
+      expect(got.wildcard).toBeFalse();
+      expect(got.path).toEqual(expected);
+    });
+  }
+
+  function wildcardCases(allowWildcard) {
+    const msg = allowWildcard
+      ? 'works given $arg'
+      : 'throws given $arg';
+    test.each`
+    arg                  | expected
+    ${'/*'}              | ${[]}
+    ${'/a/*'}            | ${['a']}
+    ${'/a/b/*'}          | ${['a', 'b']}
+    ${'/a/b/c/*'}        | ${['a', 'b', 'c']}
+    ${'/boop/beep/*'}    | ${['boop', 'beep']}
+    ${['*']}             | ${[]}
+    ${['bop', '*']}      | ${['bop']}
+    ${['bop', 'z', '*']} | ${['bop', 'z']}
+    ${wildKey}           | ${['a', 'b', 'c']}
+    `(msg, ({ arg, expected }) => {
+      if (allowWildcard) {
+        const got = Names.parsePath(arg, true);
+        expect(got.wildcard).toBeTrue();
+        expect(got.path).toEqual(expected);
+      } else if (allowWildcard === null) {
+        expect(() => Names.parsePath(arg)).toThrow();
+      } else {
+        expect(() => Names.parsePath(arg, false)).toThrow();
+      }
+    });
+  }
+
+  describe('with default `allowWildcard` (of `false`)', () => {
+    nonWildcardCases(null);
+    wildcardCases(null);
+
+    // TODO: error cases.
+  });
+
+  describe('with `allowWildcard === false`', () => {
+    nonWildcardCases(false);
+    wildcardCases(false);
+
+    // TODO: error cases.
+  });
+
+  describe('with `allowWildcard === true`', () => {
+    nonWildcardCases(true);
+    wildcardCases(true);
+
+    // TODO: error cases.
   });
 });


### PR DESCRIPTION
It is now possible to exert fine-grained control over which components in the system produce system logs.

I'd wanted to have this since practically day one but wasn't sure about how to go about getting it done until recently. More specifically, I like the idea of having very chatty components, but I know that most of the time it either doesn't matter (at best) or is so noisy that it obscures real problems (at worst).

With the controls now in place, I suspect there will be a bunch of follow-ups where the component hierarchy is tweaked for even better control. (For example, I know there are services which produce useful logs, and right now I don't think it's possible to squelch the plumbing-related logging about those components without _also_ squelching the stuff one might more enthusiastically care about.)
