### PR TITLE
"Nascent" children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ Breaking changes:
 * None.
 
 Other notable changes:
-* None.
+* `compy`:
+  * New method `BaseComponent._prot_addAll()`, for multiple children.
+  * Made it possible for a component to add children before it is initialized.
 
 ### v0.7.2 -- 2024-05-08
 

--- a/src/compy/export/TemplAggregateComponent.js
+++ b/src/compy/export/TemplAggregateComponent.js
@@ -32,7 +32,7 @@ export const TemplAggregateComponent = (className, superclass) => {
      * @param {...BaseComponent|Array<BaseComponent>} children Components to
      *   add.
      */
-    async addChildren(...children) {
+    async addAll(...children) {
       const flat = children.flat(1);
 
       for (const child of flat) {

--- a/src/compy/tests/ControlContext.test.js
+++ b/src/compy/tests/ControlContext.test.js
@@ -23,11 +23,7 @@ describe('constructor', () => {
     const comp4 = new OtherName({});
     const comp5 = new OtherName({});
 
-    await root.addAll(comp1);
-    await root.addAll(comp2);
-    await root.addAll(comp3);
-    await root.addAll(comp4);
-    await root.addAll(comp5);
+    await root.addAll(comp1, comp2, comp3, comp4, comp5);
 
     expect(comp1.namePath.path).toEqual(['someName1']);
     expect(comp2.namePath.path).toEqual(['someName2']);
@@ -38,8 +34,7 @@ describe('constructor', () => {
     const comp6 = new SomeName({});
     const comp7 = new SomeName({});
 
-    await comp1.addAll(comp6);
-    await comp1.addAll(comp7);
+    await comp1.addAll(comp6, comp7);
 
     expect(comp6.namePath.path).toEqual(['someName1', 'someName1']);
     expect(comp7.namePath.path).toEqual(['someName1', 'someName2']);

--- a/src/compy/tests/ControlContext.test.js
+++ b/src/compy/tests/ControlContext.test.js
@@ -23,11 +23,11 @@ describe('constructor', () => {
     const comp4 = new OtherName({});
     const comp5 = new OtherName({});
 
-    await root.addChildren(comp1);
-    await root.addChildren(comp2);
-    await root.addChildren(comp3);
-    await root.addChildren(comp4);
-    await root.addChildren(comp5);
+    await root.addAll(comp1);
+    await root.addAll(comp2);
+    await root.addAll(comp3);
+    await root.addAll(comp4);
+    await root.addAll(comp5);
 
     expect(comp1.namePath.path).toEqual(['someName1']);
     expect(comp2.namePath.path).toEqual(['someName2']);
@@ -38,8 +38,8 @@ describe('constructor', () => {
     const comp6 = new SomeName({});
     const comp7 = new SomeName({});
 
-    await comp1.addChildren(comp6);
-    await comp1.addChildren(comp7);
+    await comp1.addAll(comp6);
+    await comp1.addAll(comp7);
 
     expect(comp6.namePath.path).toEqual(['someName1', 'someName1']);
     expect(comp7.namePath.path).toEqual(['someName1', 'someName2']);

--- a/src/webapp-builtins/tests/PathRouter.test.js
+++ b/src/webapp-builtins/tests/PathRouter.test.js
@@ -67,19 +67,19 @@ describe('_impl_handleRequest()', () => {
     };
 
     const apps = new MockComponent({ name: 'application' });
-    await root.addChildren(apps);
+    await root.addAll(apps);
 
     for (let i = 1; i <= appCount; i++) {
       const app = new MockApp({ name: `mockApp${i}` });
       if (handlerFunc) {
         app.mockHandler = handlerFunc;
       }
-      await apps.addChildren(app);
+      await apps.addAll(app);
     }
 
     const pr = new PathRouter({ name: 'myRouter', paths });
 
-    await apps.addChildren(pr);
+    await apps.addAll(pr);
 
     return pr;
   }

--- a/src/webapp-builtins/tests/RequestDelay.test.js
+++ b/src/webapp-builtins/tests/RequestDelay.test.js
@@ -84,7 +84,7 @@ describe('_impl_handleRequest()', () => {
     const rd   = new RequestDelay(opts);
 
     await root.start();
-    await root.addChildren(rd);
+    await root.addAll(rd);
 
     return rd;
   }

--- a/src/webapp-builtins/tests/RequestFilter.test.js
+++ b/src/webapp-builtins/tests/RequestFilter.test.js
@@ -72,7 +72,7 @@ describe('_impl_handleRequest()', () => {
     const rf   = new RequestFilter(opts);
 
     await root.start();
-    await root.addChildren(rf);
+    await root.addAll(rf);
 
     return rf;
   }

--- a/src/webapp-builtins/tests/SuffixRouter.test.js
+++ b/src/webapp-builtins/tests/SuffixRouter.test.js
@@ -83,19 +83,19 @@ describe('_impl_handleRequest()', () => {
     };
 
     const apps = new MockComponent({ name: 'application' });
-    await root.addChildren(apps);
+    await root.addAll(apps);
 
     for (let i = 1; i <= appCount; i++) {
       const app = new MockApp({ name: `mockApp${i}` });
       if (handlerFunc) {
         app.mockHandler = handlerFunc;
       }
-      await apps.addChildren(app);
+      await apps.addAll(app);
     }
 
     const sr = new SuffixRouter({ name: 'myRouter', ...opts });
 
-    await apps.addChildren(sr);
+    await apps.addAll(sr);
 
     return sr;
   }

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -119,10 +119,10 @@ export class WebappRoot extends BaseRootComponent {
 
     const { applications, hosts, endpoints, services } = this.config;
 
-    await this.#applicationManager.addChildren(applications);
-    await this.#hostManager.addChildren(hosts);
-    await this.#endpointManager.addChildren(endpoints);
-    await this.#serviceManager.addChildren(services);
+    await this.#applicationManager.addAll(applications);
+    await this.#hostManager.addAll(hosts);
+    await this.#endpointManager.addAll(endpoints);
+    await this.#serviceManager.addAll(services);
 
     await super._impl_init();
   }

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -108,14 +108,11 @@ export class WebappRoot extends BaseRootComponent {
 
   /** @override */
   async _impl_init() {
-    const results = [
-      this._prot_addChild(this.#serviceManager),
-      this._prot_addChild(this.#applicationManager),
-      this._prot_addChild(this.#hostManager),
-      this._prot_addChild(this.#endpointManager)
-    ];
-
-    await Promise.all(results);
+    await this._prot_addAll(
+      this.#serviceManager,
+      this.#applicationManager,
+      this.#hostManager,
+      this.#endpointManager);
 
     const { applications, hosts, endpoints, services } = this.config;
 


### PR DESCRIPTION
This PR expands when it is valid for a component to add children to itself. Previously, it could only happen after it was initialized (or during its own `_impl_init()` method. Now, it's possible to add children immediately after construction.

It's _sorta_ possible to even add children inside the constructor, but because of `async` "fun" it is arguably ill-advised.

With this PR, I think this might be as far as I can incrementally evolve the current `compy` implementation. It's clear that it ought to have some more major rework in the long term, but I think it'll be fine for now.