### PR TITLE
`PathRouter` `null` binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ Breaking changes:
 
 Other notable changes:
 * Stopped complaining if run with Node v22.
-* configuration:
+* configuration / `webapp-builtins`:
   * Added `dispatchLogging` configuration to `endpoint` entries (class
     `NetworkEndpoint`).
+  * `PathRouter`: Made it possible to cut off fallback search by explicitly
+     binding a path to `null`.
 * `compy`:
   * New method `BaseComponent._prot_addAll()`, for multiple children.
   * Made it possible for a component to add children before it is initialized.

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -107,9 +107,10 @@ path of the requests. This application accepts the following configuration
 bindings:
 
 * `paths` &mdash; A plain object with possibly-wildcarded paths as keys, and
-  the _names_ of other applications as values. A wildcard only covers the suffix
-  of a path; it cannot be used for prefixes or infixes. Wildcards are indicated
-  with the path suffix `/*`.
+  the _names_ of other applications as values, or `null` to indicate a path to
+  explicitly not-respond to. A wildcard only covers the suffix of a path; it
+  cannot be used for prefixes or infixes. Wildcards are indicated with the path
+  suffix `/*`.
 
 The keys in `paths` must start with a slash (`/`). (The idea is that they are
 _absolute_ paths within the scope of the router, even though they are
@@ -141,27 +142,18 @@ const applications = [
     class: PathRouter,
     paths: {
       '/*':         'myCatchAllApp',
+      '/api/2024':  'myApi',
+      '/api/*':     null, // No other `/api` URLs are handled.
       '/file':      'myFileApp',
       '/dir/':      'myDirApp',
-      '/general/*': 'myGeneralApp',
+      '/general/*': 'myGeneralApp'
     }
   },
   {
     name: 'myCatchallApp',
     // ... more ...
   },
-  {
-    name: 'myFileApp',
-    // ... more ...
-  },
-  {
-    name: 'myDirApp',
-    // ... more ...
-  },
-  {
-    name: 'myGeneralApp',
-    // ... more ...
-  }
+  // ... more ...
 ];
 ```
 

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -131,7 +131,8 @@ The routing works by starting with the most specific match to the path of an
 incoming request. If that app does not try to handle the request &mdash;
 note that it counts as a "try" to end up `throw`ing out of the handler &mdash;
 the next most specific match is asked, and so on, until there are no path
-matches left.
+matches left. If the router runs out of candidate bindings, or if a `null`
+app binding is encountered, then the router stops without handling the request.
 
 ```js
 import { PathRouter } from '@lactoserv/webapp-builtins';

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -177,7 +177,8 @@ const applications = [
       '/resp/no-body/*':    'responseNoBody',
       '/resp/dir-only/':    'responseDirOnly',
       '/resp/one':          'responseOne',
-      '/resp/two':          'responseTwo'
+      '/resp/two':          'responseTwo',
+      '/resp/*':            null
     }
   },
   {
@@ -297,11 +298,12 @@ const endpoints = [
     }
   },
   {
-    name:        'secure',
-    protocol:    'http2',
-    hostnames:   ['*'],
-    interface:   '*:8443',
-    application: 'mySite',
+    name:            'secure',
+    protocol:        'http2',
+    hostnames:       ['*'],
+    interface:       '*:8443',
+    application:     'mySite',
+    dispatchLogging: true,
     services: {
       accessLog:             'accessLog',
       dataRateLimiter:       'dataRateLimiter',

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -34,6 +34,11 @@ export class PathRouter extends BaseApplication {
         dispatch.base.concat(pathMatch.key),
         pathMatch.keyRemainder);
 
+      if (application === null) {
+        subDispatch.logger?.explicitNull(subDispatch.infoForLog);
+        break;
+      }
+
       subDispatch.logger?.dispatchingPath({
         application: application.name,
         ...(subDispatch.infoForLog)
@@ -71,7 +76,7 @@ export class PathRouter extends BaseApplication {
     const routeTree  = new TreeMap();
 
     for (const [path, name] of this.config.paths) {
-      const app = appManager.get(name);
+      const app = (name === null) ? null : appManager.get(name);
       routeTree.add(path, app);
     }
 
@@ -106,7 +111,9 @@ export class PathRouter extends BaseApplication {
         const result = new TreeMap();
 
         for (const [path, name] of Object.entries(value)) {
-          Names.checkName(name);
+          if (name !== null) {
+            Names.checkName(name);
+          }
           const key = Config.#parsePath(path);
           result.add(key, name);
         }


### PR DESCRIPTION
This PR makes it so that `PathRouter` can be told to stop looking for fallbacks, by explicitly binding a path to `null`.