### PR TITLE
`DataRateLimiter`: `verboseLogging`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Other notable changes:
 * configuration / `webapp-builtins`:
   * Added `dispatchLogging` configuration to `endpoint` entries (class
     `NetworkEndpoint`).
+  * `DataRateLimiter`: Added `verboseLogging` option, off by default, to make it
+    possible to log the major stuff without getting a lot of `writing(1234)`
+    type messages.
   * `PathRouter`: Made it possible to cut off fallback search by explicitly
      binding a path to `null`.
 * `compy`:

--- a/doc/configuration/3-built-in-services.md
+++ b/doc/configuration/3-built-in-services.md
@@ -140,22 +140,28 @@ const services = [
 ## `DataRateLimiter`
 
 A service which provides data rate limiting of network traffic (specifically
-on the write side). Configuration is exactly as described by
+on the write side). Configuration is as described by
 [Rate Limiting](./2-common-configuration.md#rate-limiting), with the token unit
 being a byte (class `ByteCount`) and the flow rate unit being bytes-per-second
-(class `ByteRate`). The `maxQueueGrant` option _is_ allowed.
+(class `ByteRate`). The `maxQueueGrant` option _is_ allowed. In addition, this
+accepts the following configuration bindings:
+
+* `verboseLogging` &mdash; A boolean indicating whether the minutiae of the
+  limiter's operations should be logged. If `false`, only major actions
+  (including errors) get logged. Default `false`.
 
 ```js
 import { DataRateLimiter } from '@lactoserv/webapp-builtins';
 
 const services = [
   {
-    name:          'dataRateLimiter',
-    class:         DataRateLimiter,
-    maxBurst:      '5 MiB',
-    flowRate:      '32 KiB/sec',
-    maxQueue:      '32 MiB',
-    maxQueueGrant: '100 KiB'
+    name:           'dataRateLimiter',
+    class:          DataRateLimiter,
+    maxBurst:       '5 MiB',
+    flowRate:       '32 KiB/sec',
+    maxQueue:       '32 MiB',
+    maxQueueGrant:  '100 KiB',
+    verboseLogging: true
   }
 ];
 ```

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -118,7 +118,8 @@ const services = [
     maxBurst:        '1 MiB',
     flowRate:        '100 KiB / sec',
     maxQueueGrant:   '50 KiB',
-    maxQueue:        '2 MiB'
+    maxQueue:        '2 MiB',
+    verboseLogging:  true
   },
   {
     name:     'connectionRateLimiter',

--- a/src/webapp-builtins/export/DataRateLimiter.js
+++ b/src/webapp-builtins/export/DataRateLimiter.js
@@ -59,13 +59,17 @@ export class DataRateLimiter extends BaseService {
 
   /** @override */
   static _impl_configClass() {
-    return TemplRateLimitConfig(
-      'DataRateLimiterConfig',
+    const baseClass = TemplRateLimitConfig(
+      'DataRateJustLimiterConfig',
       BaseService.CONFIG_CLASS,
       {
         allowMaxQueueGrant: true,
         countType:          ByteCount,
         rateType:           ByteRate
       });
+
+    return class DataRateLimiterConfig extends baseClass {
+      // @defaultConstructor
+    };
   }
 }

--- a/src/webapp-builtins/export/DataRateLimiter.js
+++ b/src/webapp-builtins/export/DataRateLimiter.js
@@ -38,7 +38,7 @@ export class DataRateLimiter extends BaseService {
 
   /** @override */
   async _impl_handleCall_wrapWriter(stream, logger) {
-    return RateLimitedStream.wrapWriter(this.#bucket, stream, logger);
+    return RateLimitedStream.wrapWriter(this.#bucket, stream, logger, true);
   }
 
   /** @override */

--- a/src/webapp-builtins/export/DataRateLimiter.js
+++ b/src/webapp-builtins/export/DataRateLimiter.js
@@ -3,6 +3,7 @@
 
 import { ByteCount, ByteRate } from '@this/data-values';
 import { IntfDataRateLimiter } from '@this/net-protocol';
+import { MustBe } from '@this/typey';
 import { BaseService } from '@this/webapp-core';
 import { TokenBucket } from '@this/webapp-util';
 
@@ -38,7 +39,8 @@ export class DataRateLimiter extends BaseService {
 
   /** @override */
   async _impl_handleCall_wrapWriter(stream, logger) {
-    return RateLimitedStream.wrapWriter(this.#bucket, stream, logger, true);
+    return RateLimitedStream.wrapWriter(
+      this.#bucket, stream, logger, this.config.verboseLogging);
   }
 
   /** @override */
@@ -70,6 +72,17 @@ export class DataRateLimiter extends BaseService {
 
     return class DataRateLimiterConfig extends baseClass {
       // @defaultConstructor
+
+      /**
+       * Log the minutiae of this instance's operation? If `false` only main
+       * actions and errors will get logged.
+       *
+       * @param {boolean} [value] Proposed configuration value. Default `false`.
+       * @returns {boolean} Accepted configuration value.
+       */
+      _config_verboseLogging(value = false) {
+        return MustBe.boolean(value);
+      }
     };
   }
 }

--- a/src/webapp-builtins/private/RateLimitedStream.js
+++ b/src/webapp-builtins/private/RateLimitedStream.js
@@ -75,8 +75,8 @@ export class RateLimitedStream {
    *   service.
    * @param {Duplex|Writable} stream The stream to wrap.
    * @param {?IntfLogger} logger Logger to use.
-   * @param {boolean} verboseLogging Log the minutiae of writing? If `false`,
-   *   only major events (including errors) get logged.
+   * @param {boolean} verboseLogging Log the minutiae of the instance's
+   *   operation? If `false`, only major events (including errors) get logged.
    */
   constructor(bucket, stream, logger, verboseLogging) {
     this.#bucket        = MustBe.instanceOf(bucket, TokenBucket);
@@ -562,8 +562,8 @@ export class RateLimitedStream {
    * @param {Duplex|Writable} stream The stream to wrap.
    * @param {?IntfLogger} logger Logger to use.
    * @returns {Duplex|Writable} A rate-limited wrapper stream.
-   * @param {boolean} verboseLogging Log the minutiae of writing? If `false`,
-   *   only major events (including errors) get logged.
+   * @param {boolean} verboseLogging Log the minutiae of the instance's
+   *   operation? If `false`, only major events (including errors) get logged.
    */
   static wrapWriter(bucket, stream, logger, verboseLogging) {
     return new this(bucket, stream, logger, verboseLogging).stream;


### PR DESCRIPTION
This PR adds a `verboseLogging` configuration option to `DataRateLimiter`, so you can get logging of the major stuff without also having to get a bajillion `writing(1234)` type messages.