### PR TITLE
Error reporting

### DIFF
--- a/src/data-values/export/ErrorUtil.js
+++ b/src/data-values/export/ErrorUtil.js
@@ -7,6 +7,55 @@
  */
 export class ErrorUtil {
   /**
+   * Collects and collates errors from a number of sources, producing a
+   * "uniqued" result (without any redundantly-listed info). The result includes
+   * an `ok` indicator (were there no errors?), a sorted array of unique error
+   * codes (extracted by {@link #extractErrorCode}), and an object like the one
+   * given as an argument, except replacing duplicate errors with string
+   * references.
+   *
+   * @param {object} errors Object which binds each key to a corresponding
+   *   error-or-nullish.
+   * @returns {{ errorCodes: Array<string>, errors: object, ok: boolean }}
+   *   Collected results.
+   */
+  static collateErrors(errors) {
+    const errorCodes   = new Set();
+    const errorMap     = new Map();
+    const resultErrors = {};
+
+    for (const [k, e] of Object.entries(errors)) {
+      if ((e === null) || (e === undefined)) {
+        continue;
+      }
+
+      const already = errorMap.get(e);
+
+      if (already) {
+        resultErrors[k] = already;
+      } else {
+        resultErrors[k] = e;
+        errorCodes.add(ErrorUtil.extractErrorCode(e));
+        errorMap.set(e, k);
+      }
+    }
+
+    if (errorCodes.size === 0) {
+      return {
+        errorCodes: [],
+        errors:     {},
+        ok:         true
+      };
+    } else {
+      return {
+        errorCodes: [...errorCodes].sort(),
+        errors:     resultErrors,
+        ok:         false
+      };
+    }
+  }
+
+  /**
    * Extracts a string error code from the given `Error`, or returns a generic
    * "unknown error" if there's nothing else reasonable.
    *

--- a/src/data-values/export/ErrorUtil.js
+++ b/src/data-values/export/ErrorUtil.js
@@ -42,15 +42,15 @@ export class ErrorUtil {
 
     if (errorCodes.size === 0) {
       return {
+        ok:         true,
         errorCodes: [],
-        errors:     {},
-        ok:         true
+        errors:     {}
       };
     } else {
       return {
+        ok:         false,
         errorCodes: [...errorCodes].sort(),
-        errors:     resultErrors,
-        ok:         false
+        errors:     resultErrors
       };
     }
   }

--- a/src/data-values/tests/ErrorUtil.test.js
+++ b/src/data-values/tests/ErrorUtil.test.js
@@ -3,6 +3,118 @@
 
 import { ErrorUtil } from '@this/data-values';
 
+describe('collateErrors()', () => {
+  function expectOk(result) {
+    expect(result).toEqual({
+      errorCodes: [],
+      errors:     {},
+      ok:         true
+    });
+  }
+
+  test('returns an empty `ok` given an empty argument', () => {
+    expectOk(ErrorUtil.collateErrors({}));
+  });
+
+  test('returns an empty `ok` given a bunch of bindings to `null` and `undefined`', () => {
+    expectOk(ErrorUtil.collateErrors({
+      one:   null,
+      two:   undefined,
+      three: null,
+      four:  undefined
+    }));
+  });
+
+  test('returns a single-error result, given a single-binding error-bearing argument (with `code`)', () => {
+    const err = new Error('Ouchie!');
+    err.code = 'FLORP_LIKE';
+
+    const got = ErrorUtil.collateErrors({ someError: err });
+    expect(got).toEqual({
+      errorCodes: ['florp-like'],
+      errors:     { someError: err },
+      ok:         false
+    });
+  });
+
+  test('returns a single-error result, given a single-binding error-bearing argument (without `code`)', () => {
+    const err = new Error('What the muffin?!');
+
+    const got = ErrorUtil.collateErrors({ bonk: err });
+    expect(got).toEqual({
+      errorCodes: ['what-the-muffin'],
+      errors:     { bonk: err },
+      ok:         false
+    });
+  });
+
+  test('returns a single-error result, given a single-binding string-bearing argument', () => {
+    const err = 'Oh no, not again!';
+
+    const got = ErrorUtil.collateErrors({ oof: err });
+    expect(got).toEqual({
+      errorCodes: ['oh-no-not-again'],
+      errors:     { oof: err },
+      ok:         false
+    });
+  });
+
+  test('deduplicates an error that occurs twice', () => {
+    const err = new Error('Ouchie!');
+    err.code = 'no-way';
+
+    const got = ErrorUtil.collateErrors({ errorA: err, errorB: err });
+    expect(got).toEqual({
+      errorCodes: ['no-way'],
+      errors:     { errorA: err, errorB: 'errorA' },
+      ok:         false
+    });
+  });
+
+  test('deduplicates an error _code_ that occurs twice in two different errors', () => {
+    const err1 = 'no-way';
+    const err2 = new Error('Ouchie!');
+    err2.code = 'no-way';
+
+    const got = ErrorUtil.collateErrors({ error1: err1, error2: err2 });
+    expect(got).toEqual({
+      errorCodes: ['no-way'],
+      errors:     { error1: err1, error2: err2 },
+      ok:         false
+    });
+  });
+
+  test('does not include `null`s and `undefined`s in an error-bearing result', () => {
+    const err = 'oy';
+    const got = ErrorUtil.collateErrors({
+      error1: null,
+      error2: undefined,
+      error3: err,
+      error4: null
+    });
+
+    expect(got).toEqual({
+      errorCodes: ['oy'],
+      errors:     { error3: err },
+      ok:         false
+    });
+  });
+
+  test('produces `errorCodes` in sorted order, uniqued', () => {
+    const err1 = 'floop';
+    const err2 = 'boop';
+    const err3 = 'zoop';
+    const err4 = new Error('floop');
+    const err5 = 'goop';
+    const got = ErrorUtil.collateErrors({ err1, err2, err3, err4, err5 });
+
+    expect(got).toEqual({
+      errorCodes: ['boop', 'floop', 'goop', 'zoop'],
+      errors:     { err1, err2, err3, err4, err5 },
+      ok:         false
+    });
+  });
+});
 
 describe('extractErrorCode()', () => {
   test('given an Error with a `.code`, returns the converted code', () => {

--- a/src/net-util/export/FullResponse.js
+++ b/src/net-util/export/FullResponse.js
@@ -272,31 +272,18 @@ export class FullResponse {
       ? (headers['content-length'] ?? null)
       : null;
 
-    const result = {
-      ok:         true,
+    return {
+      ...ErrorUtil.collateErrors({
+        connection:     connectionSocket?.errored,
+        request:        res.req?.errored,
+        requestSocket:  res.req?.socket?.errored,
+        response:       res.errored,
+        responseSocket: res[FullResponse.#RESPONSE_SOCKET_SYMBOL]?.errored
+      }),
       statusCode,
       contentLength,
-      headers:    FullResponse.#sanitizeResponseHeaders(headers),
-      errorCodes: [],
-      errors:     {}
+      headers: FullResponse.#sanitizeResponseHeaders(headers)
     };
-
-    const addErrorIfAny = (label, stream) => {
-      const error = stream?.errored;
-      if (error) {
-        result.ok = false;
-        result.errorCodes.push(ErrorUtil.extractErrorCode(error));
-        result.errors[label] = error;
-      }
-    };
-
-    addErrorIfAny('connection',     connectionSocket);
-    addErrorIfAny('request',        res.req);
-    addErrorIfAny('requestSocket',  res.req?.socket);
-    addErrorIfAny('response',       res);
-    addErrorIfAny('responseSocket', res[FullResponse.#RESPONSE_SOCKET_SYMBOL]);
-
-    return result;
   }
 
   /**


### PR DESCRIPTION
This PR makes error reporting in the access logs a bit nicer, via newly extracted and improved utility `ErrorUtil.collateErrors()`.