### PR TITLE
`CertUtil`

### DIFF
--- a/src/net-util/export/CertUtil.js
+++ b/src/net-util/export/CertUtil.js
@@ -36,7 +36,7 @@ export class CertUtil {
    * @throws {Error} Thrown if `value` does not match.
    */
   static checkPrivateKey(value) {
-    const pattern = this.#makePemPattern('PRIVATE KEY');
+    const pattern = this.#makePemPattern('(RSA )?PRIVATE KEY');
     return MustBe.string(value, pattern);
   }
 
@@ -90,10 +90,17 @@ export class CertUtil {
       config:     certConfig
     });
 
-    return {
-      certificate: pemResult.certificate,
-      privateKey:  pemResult.clientKey
-    };
+    let { certificate, clientKey: privateKey } = pemResult;
+
+    if (!certificate.endsWith('\n')) {
+      certificate = `${certificate}\n`;
+    }
+
+    if (!privateKey.endsWith('\n')) {
+      privateKey = `${privateKey}\n`;
+    }
+
+    return { certificate, privateKey };
   }
 
   /**

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -20,6 +20,7 @@
     "@this/loggy-intf": "*",
     "@this/typey": "*",
     "mime": "^4.0.1",
+    "pem": "^1.14.8",
     "range-parser": "^1.2.1",
     "statuses": "^2.0.1"
   }

--- a/src/net-util/tests/CertUtil.test.js
+++ b/src/net-util/tests/CertUtil.test.js
@@ -1,0 +1,36 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { CertUtil } from '@this/net-util';
+
+
+describe('checkCertificateChain()', () => {
+  test('throws given a non-string', () => {
+    expect(() => CertUtil.checkCertificateChain(12345)).toThrow();
+  });
+});
+
+describe('checkPrivateKey()', () => {
+  test('throws given a non-string', () => {
+    expect(() => CertUtil.checkPrivateKey(12345)).toThrow();
+  });
+});
+
+describe('makeSelfSignedPair()', () => {
+  test('throws given an empty array', async () => {
+    await expect(CertUtil.makeSelfSignedPair([])).toReject();
+  });
+
+  test('throws given an array of something other than strings', async () => {
+    await expect(CertUtil.makeSelfSignedPair(['foo.bar', 123, 'bar.baz'])).toReject();
+  });
+
+  test('produces a valid-looking result, given valid arguments', async () => {
+    const got = await CertUtil.makeSelfSignedPair(['localhost', '127.0.0.1', '::1', '*.foo.bar']);
+
+    expect(got).toContainAllKeys(['certificate', 'privateKey']);
+
+    expect(() => CertUtil.checkCertificateChain(got.certificate)).not.toThrow();
+    expect(() => CertUtil.checkPrivateKey(got.privateKey)).not.toThrow();
+  });
+});

--- a/src/webapp-core/package.json
+++ b/src/webapp-core/package.json
@@ -21,7 +21,6 @@
     "@this/loggy-intf": "*",
     "@this/net-protocol": "*",
     "@this/net-util": "*",
-    "@this/typey": "*",
-    "pem": "^1.14.8"
+    "@this/typey": "*"
   }
 }


### PR DESCRIPTION
This moves the self-signed cert-generation code into `CertUtil`, and adds at least a little bit of testing.