### PR TITLE
Workaround for the Jest `process.emit` binding bug.

### DIFF
--- a/src/jest.config.mjs
+++ b/src/jest.config.mjs
@@ -76,5 +76,11 @@ export default {
       `${TESTER_DIR}/lib/node_modules/jest-extended/all`,
       `${TESTER_DIR}/lib/code/node_modules/@this/main-tester`
     ]
+  },
+
+  // Test harness options.
+  ...{
+    // maxConcurrency: 1,
+    // maxWorkers: 1
   }
 };

--- a/src/main-tester/index.js
+++ b/src/main-tester/index.js
@@ -12,3 +12,14 @@ process.on('warning', (warning) => {
 
   console.log('%s: %s\n', warning.name, warning.message);
 });
+
+// This works around a bug in Jest's wrapping of `process`: `process.emit` is
+// normally inherited from `EventEmitter`, but `source-map-support` directly
+// adds an `emit` binding to `process`. _Sometimes_ this happens when Jest is in
+// the middle of creating a `SyntheticModule` wrapper for `process`, and if that
+// happens at just the wrong time, Node will throw `ReferenceError: Export
+// 'emit' is not defined in module`. By putting a direct binding of
+// `process.emit` here, we avoid the race (though there is still arguably an
+// underlying problem). See this issue in Jest:
+// <https://github.com/jestjs/jest/issues/15077>
+process.emit = process.emit; // eslint-disable-line no-self-assign


### PR DESCRIPTION
This PR is the result of like a day and a half of research, even though the actual effective diff is a single line, and a trivial-looking one at that! To wit:

```js
process.emit = process.emit;
```

But what a difference it makes! See <https://github.com/jestjs/jest/issues/15077>, which I filed on Jest, for the gory details.