### PR TITLE
J'accuse `pem`!

### DIFF
--- a/src/net-util/export/CertUtil.js
+++ b/src/net-util/export/CertUtil.js
@@ -3,10 +3,12 @@
 
 import * as net from 'node:net';
 
-import pem from 'pem';
+import pem from 'pem/lib/pem';
 
 import { MustBe } from '@this/typey';
 
+// Note: See <https://github.com/Dexus/pem/issues/389> about the import of
+// `pem/lib/pem`.
 
 /**
  * Utilities for handling various sorts of certificatey stuff.

--- a/src/net-util/export/CertUtil.js
+++ b/src/net-util/export/CertUtil.js
@@ -3,7 +3,7 @@
 
 import * as net from 'node:net';
 
-import pem from 'pem/lib/pem';
+import pem from 'pem/lib/pem.js';
 
 import { MustBe } from '@this/typey';
 

--- a/src/net-util/tests/CertUtil.test.js
+++ b/src/net-util/tests/CertUtil.test.js
@@ -1,6 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import process from 'node:process';
+
 import { CertUtil } from '@this/net-util';
 
 
@@ -71,5 +73,11 @@ describe('makeSelfSignedPair()', () => {
 
     expect(() => CertUtil.checkCertificateChain(got.certificate)).not.toThrow();
     expect(() => CertUtil.checkPrivateKey(got.privateKey)).not.toThrow();
+
+    // ...and also, doesn't try to override `process.emit` as inherited in
+    // `process` from `EventEmitter`. See
+    // <https://github.com/Dexus/pem/issues/389> and
+    // <https://github.com/jestjs/jest/issues/15077>.
+    expect(Object.hasOwn(process, 'emit')).toBeFalse();
   });
 });

--- a/src/net-util/tests/CertUtil.test.js
+++ b/src/net-util/tests/CertUtil.test.js
@@ -69,15 +69,21 @@ describe('makeSelfSignedPair()', () => {
   test('produces a valid-looking result, given valid arguments', async () => {
     const got = await CertUtil.makeSelfSignedPair(['localhost', '127.0.0.1', '::1', '*.foo.bar']);
 
+    // ...and also, doesn't try to override `process.emit` as inherited in
+    // `process` from `EventEmitter`. See
+    // <https://github.com/Dexus/pem/issues/389> and
+    // <https://github.com/jestjs/jest/issues/15077>.
+    const processEmit = process.emit;
+    const hasOwnEmit  = Object.hasOwn(process, 'emit');
+
     expect(got).toContainAllKeys(['certificate', 'privateKey']);
 
     expect(() => CertUtil.checkCertificateChain(got.certificate)).not.toThrow();
     expect(() => CertUtil.checkPrivateKey(got.privateKey)).not.toThrow();
 
-    // ...and also, doesn't try to override `process.emit` as inherited in
-    // `process` from `EventEmitter`. See
-    // <https://github.com/Dexus/pem/issues/389> and
-    // <https://github.com/jestjs/jest/issues/15077>.
-    expect(Object.hasOwn(process, 'emit')).toBeFalse();
+    expect(process.emit).toBe(processEmit);
+    if (!hasOwnEmit) {
+      expect(Object.hasOwn(process, 'emit')).toBeFalse();
+    }
   });
 });


### PR DESCRIPTION
Turns out `pem`'s main export will install its own global `process.emit` source map handler, for who-the-muffin-knows-why. But in any case, (a) it shouldn't, but thankfully (b) it's at least possible to avoid it doing that. So this PR avoids the installation and adds a test to make sure it doesn't start happening again. FWIW I was a bit wary when I started using `pem` in the first place, and this experience makes me reluctant to leave it in, in the long term.

See <https://github.com/Dexus/pem/issues/389> and <https://github.com/jestjs/jest/issues/15077> for more details. And thanks very much to @SimenB and @nwalters512 for their assistance.