### PR TITLE
Miscellanea

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,15 +52,15 @@ jobs:
       - name: Ensure the cert creator still works.
         run: ./scripts/ubik make-localhost-cert
 
-      # This step is meant to help diagnose the coverage report problem noted
-      # above.
-      - name: Upload artifacts.
-        uses: actions/upload-artifact@v4
-        with:
-          name: tester-artifacts
-          path: out/tester
-          overwrite: true
-          retention-days: 30
+      # Uncomment this step if you want to upload the build as an artifact (with
+      # tweakage to select just the right part).
+      #- name: Upload artifacts.
+      #  uses: actions/upload-artifact@v4
+      #  with:
+      #    name: built-artifacts
+      #    path: out
+      #    overwrite: true
+      #    retention-days: 30
 
       #- name: Run a multi-line script.
       #  run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Breaking changes:
 * None.
 
 Other notable changes:
+* `net-util`: Found and worked around a mis-feature in the `pem` module (one of
+  our few direct dependencies).
 * testing: Added more unit tests.
 
 ### v0.7.3 -- 2024-05-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ Breaking changes:
 * None.
 
 Other notable changes:
-* `net-util`: Found and worked around a mis-feature in the `pem` module (one of
-  our few direct dependencies).
+* `net-util`:
+  * Found a major problem with the `pem` module (one of our few direct
+    dependencies). Replaced it with `selfsigned`, which also means we no longer
+    rely on an OS-installed OpenSSL.
 * testing: Added more unit tests.
 
 ### v0.7.3 -- 2024-05-16

--- a/README.md
+++ b/README.md
@@ -83,10 +83,6 @@ To build:
 
 To run (versions as above):
 * Standard-ish POSIX operating environment.
-  * Notably, it assumes `openssl` (or similar) is available in the runtime
-    environment. (This is only used when the system is asked to generate
-    self-signed certificates. If you don't need to do that, then Node's
-    built-in SSL implementation suffices.)
 * Recent-ish version of Bash.
 * Node v20 or later. This is required because the project uses:
   * The relatively new `/v` flag on regular expressions, which became available

--- a/scripts/lib/bashy-node/node-project/build-main-module
+++ b/scripts/lib/bashy-node/node-project/build-main-module
@@ -153,7 +153,6 @@ function build-project {
     && copy-scripts "${srcMainModule}" "${destDir}" \
     && copy-local-modules "${destLocalModules}" "${deps}" \
     && remove-dead-local-modules "${destLocalModules}" "${deps}" \
-    && run-postinstall-scripts "${destLocalModules}" "$(jget "${deps}" '.postinstallScripts')" \
     || return "$?"
 
     # Do `npm install`, but only if it hasn't yet been done _or_ the top-level
@@ -169,6 +168,9 @@ function build-project {
     fi
 
     cp "${destLibDir}/package-lock.json" "${srcPackageLockJson}"
+
+    run-postinstall-scripts "${destLocalModules}" "$(jget "${deps}" '.postinstallScripts')" \
+    || return "$?"
 }
 
 # Figures out the pithy commit info to associate with the build.

--- a/scripts/lib/bashy-node/node-project/build-main-module
+++ b/scripts/lib/bashy-node/node-project/build-main-module
@@ -153,6 +153,7 @@ function build-project {
     && copy-scripts "${srcMainModule}" "${destDir}" \
     && copy-local-modules "${destLocalModules}" "${deps}" \
     && remove-dead-local-modules "${destLocalModules}" "${deps}" \
+    && run-postinstall-scripts "${destLocalModules}" "$(jget "${deps}" '.postinstallScripts')" \
     || return "$?"
 
     # Do `npm install`, but only if it hasn't yet been done _or_ the top-level
@@ -401,6 +402,34 @@ function remove-dead-local-modules {
     if (( !first )); then
         progress-msg
     fi
+}
+
+# Runs any `postinstall` scripts defined by local modules.
+function run-postinstall-scripts {
+    local destLocalModules="$1"
+    local scriptModules="$2"
+
+    if [[ ${scriptModules} == '[]' ]]; then
+        return
+    fi
+
+    progress-msg 'Running local-module postinstall scripts...'
+
+    local modArray=()
+    jset-array --raw modArray "${scriptModules}"
+
+    # `(...)` to preserve the `cwd` in this process.
+    (
+        cd "${destLocalModules}"
+        local m
+        for m in "${modArray[@]}"; do
+            progress-msg "Postinstall ${m}..."
+            npm explore "${m}" -- npm run postinstall \
+            || return "$?"
+        done
+    )
+
+    progress-msg 'Done running local-module postinstall scripts.'
 }
 
 # Checks a `node_modules` directory (or similar) for "suspect" files, given a

--- a/scripts/lib/bashy-node/node-project/fix-package-json
+++ b/scripts/lib/bashy-node/node-project/fix-package-json
@@ -112,6 +112,8 @@ function do-fix {
     local pkg
     pkg="$(jval <"${filePath}" --input=read \
         deps:json="${finalDeps}" '
+    (.scripts // {}) as $scripts
+    |
     {
         name:    .name,
         version: .version,
@@ -132,6 +134,14 @@ function do-fix {
     else . + {
         BLANK_LINE_2: "",
         dependencies: $deps
+    }
+    end
+    |
+    if $scripts == {}
+    then .
+    else . + {
+      BLANK_LINE_3: "",
+      scripts: $scripts
     }
     end
     ')" \

--- a/src/compy/package.json
+++ b/src/compy/package.json
@@ -15,7 +15,9 @@
   "dependencies": {
     "@this/async": "*",
     "@this/collections": "*",
+    "@this/data-values": "*",
     "@this/loggy-intf": "*",
+    "@this/metacomp": "*",
     "@this/typey": "*"
   }
 }

--- a/src/main-lactoserv/package-lock.json
+++ b/src/main-lactoserv/package-lock.json
@@ -11,11 +11,27 @@
       "dependencies": {
         "chalk": "^5.3.0",
         "mime": "^4.0.1",
-        "pem": "^1.14.8",
         "range-parser": "^1.2.1",
+        "selfsigned": "^2.4.1",
         "statuses": "^2.0.1",
         "strip-ansi": "^7.1.0",
         "yargs": "^17.7.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+      "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/ansi-regex": {
@@ -52,14 +68,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/cliui": {
@@ -110,26 +118,10 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/es6-promisify": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-7.0.0.tgz",
-      "integrity": "sha512-ginqzK3J90Rd4/Yz7qRrqUeIpe3TwSXTPPZtPne7tGBPeAaQiU8qt4fpKApnxHcq1AwtUdHVg5P77x/yrggG8Q==",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -147,32 +139,12 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/mime": {
@@ -189,26 +161,12 @@
         "node": ">=16"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pem": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/pem/-/pem-1.14.8.tgz",
-      "integrity": "sha512-ZpbOf4dj9/fQg5tQzTqv4jSKJQsK7tPl0pm4/pvPcZVjZcJg7TMfr3PBk6gJH97lnpJDu4e4v8UUqEz5daipCg==",
-      "dependencies": {
-        "es6-promisify": "^7.0.0",
-        "md5": "^2.3.0",
-        "os-tmpdir": "^1.0.2",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/range-parser": {
@@ -225,6 +183,18 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/statuses": {
@@ -281,19 +251,10 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/src/main-tester/index.js
+++ b/src/main-tester/index.js
@@ -12,14 +12,3 @@ process.on('warning', (warning) => {
 
   console.log('%s: %s\n', warning.name, warning.message);
 });
-
-// This works around a bug in Jest's wrapping of `process`: `process.emit` is
-// normally inherited from `EventEmitter`, but `source-map-support` directly
-// adds an `emit` binding to `process`. _Sometimes_ this happens when Jest is in
-// the middle of creating a `SyntheticModule` wrapper for `process`, and if that
-// happens at just the wrong time, Node will throw `ReferenceError: Export
-// 'emit' is not defined in module`. By putting a direct binding of
-// `process.emit` here, we avoid the race (though there is still arguably an
-// underlying problem). See this issue in Jest:
-// <https://github.com/jestjs/jest/issues/15077>
-process.emit = process.emit; // eslint-disable-line no-self-assign

--- a/src/net-util/export/CertUtil.js
+++ b/src/net-util/export/CertUtil.js
@@ -114,12 +114,12 @@ export class CertUtil {
    */
   static #makePemPattern(label, multiple = false) {
     const base64Line = '[/+a-zA-Z0-9]{1,80}';
-    const body       = `(${base64Line}\n+){0,500}${base64Line}={0,2}\n+`;
+    const body       = `(${base64Line}[\r\n]+){0,500}${base64Line}={0,2}[\r\n]+`;
     const oneBlock   =
-        '\n*'
-      + `-----BEGIN ${label}-----\n+`
+        '[\r\n]*'
+      + `-----BEGIN ${label}-----[\r\n]+`
       + body
-      + `-----END ${label}-----\n+`;
+      + `-----END ${label}-----[\r\n]+`;
 
     return multiple
       ? `^(${oneBlock})+$`

--- a/src/net-util/export/CertUtil.js
+++ b/src/net-util/export/CertUtil.js
@@ -3,7 +3,7 @@
 
 import * as net from 'node:net';
 
-import pem from 'pem/lib/pem.js';
+import selfsigned from 'selfsigned';
 
 import { MustBe } from '@this/typey';
 
@@ -67,32 +67,19 @@ export class CertUtil {
       }
     }
 
-    const certConfig = `
-    [req]
-    req_extensions = v3_req
-    distinguished_name = req_distinguished_name
+    const attributes = [
+      { name: 'commonName', value: hostnames[0] }
+    ];
 
-    [req_distinguished_name]
-    commonName = ${hostnames[0]}
+    const options = {
+      keySize:   2048,
+      days:      100,
+      algorithm: 'sha256'
+    };
 
-    [v3_req]
-    keyUsage = digitalSignature
-    extendedKeyUsage = serverAuth
-    subjectAltName = @alt_names
+    const pemResult = selfsigned.generate(attributes, options);
 
-    [alt_names]
-    ${altNames.join('\n')}
-    `;
-
-    const pemResult = await pem.promisified.createCertificate({
-      selfSigned: true,
-      days:       100,
-      keyBitsize: 4096,
-      commonName: hostnames[0],
-      config:     certConfig
-    });
-
-    let { certificate, clientKey: privateKey } = pemResult;
+    let { cert: certificate, private: privateKey } = pemResult;
 
     if (!certificate.endsWith('\n')) {
       certificate = `${certificate}\n`;

--- a/src/net-util/export/CertUtil.js
+++ b/src/net-util/export/CertUtil.js
@@ -79,15 +79,7 @@ export class CertUtil {
 
     const pemResult = selfsigned.generate(attributes, options);
 
-    let { cert: certificate, private: privateKey } = pemResult;
-
-    if (!certificate.endsWith('\n')) {
-      certificate = `${certificate}\n`;
-    }
-
-    if (!privateKey.endsWith('\n')) {
-      privateKey = `${privateKey}\n`;
-    }
+    const { cert: certificate, private: privateKey } = pemResult;
 
     return { certificate, privateKey };
   }
@@ -106,7 +98,7 @@ export class CertUtil {
         '[\r\n]*'
       + `-----BEGIN ${label}-----[\r\n]+`
       + body
-      + `-----END ${label}-----[\r\n]+`;
+      + `-----END ${label}-----[\r\n]*`;
 
     return multiple
       ? `^(${oneBlock})+$`

--- a/src/net-util/export/FullResponse.js
+++ b/src/net-util/export/FullResponse.js
@@ -94,7 +94,7 @@ export class FullResponse {
   get bodyBuffer() {
     const { type, buffer } = this.#body;
 
-    return (type === 'buffer') ? new Buffer(buffer) : null;
+    return (type === 'buffer') ? Buffer.from(buffer) : null;
   }
 
   /**

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -26,6 +26,6 @@
   },
 
   "scripts": {
-    "postinstall": "pwd; ls ../../../../../../../; rm -rf ../../../../node_modules/node-forge/flash"
+    "postinstall": "rm -rf ../../../../node_modules/node-forge/flash"
   }
 }

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -26,6 +26,6 @@
   },
 
   "scripts": {
-    "postinstall": "pwd; ls ../../../../node_modules; rm -rf ../../../../node_modules/node-forge/flash"
+    "postinstall": "pwd; ls ../../../../; rm -rf ../../../../node_modules/node-forge/flash"
   }
 }

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -26,6 +26,6 @@
   },
 
   "scripts": {
-    "postinstall": "pwd; ls ../../../../; rm -rf ../../../../node_modules/node-forge/flash"
+    "postinstall": "pwd; ls ../../../../../; rm -rf ../../../../node_modules/node-forge/flash"
   }
 }

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -26,6 +26,6 @@
   },
 
   "scripts": {
-    "postinstall": "rm -rf ../../../../node_modules/node-forge/flash"
+    "postinstall": "ls ../../../../node_modules; rm -rf ../../../../node_modules/node-forge/flash"
   }
 }

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -20,8 +20,12 @@
     "@this/loggy-intf": "*",
     "@this/typey": "*",
     "mime": "^4.0.1",
-    "pem": "^1.14.8",
     "range-parser": "^1.2.1",
+    "selfsigned": "^2.4.1",
     "statuses": "^2.0.1"
+  },
+
+  "scripts": {
+    "postinstall": "rm -rf ../../../../node_modules/node-forge/flash"
   }
 }

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -26,6 +26,6 @@
   },
 
   "scripts": {
-    "postinstall": "pwd; ls ../../../../../; rm -rf ../../../../node_modules/node-forge/flash"
+    "postinstall": "pwd; ls ../../../../../../; rm -rf ../../../../node_modules/node-forge/flash"
   }
 }

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -26,6 +26,6 @@
   },
 
   "scripts": {
-    "postinstall": "ls ../../../../node_modules; rm -rf ../../../../node_modules/node-forge/flash"
+    "postinstall": "pwd; ls ../../../../node_modules; rm -rf ../../../../node_modules/node-forge/flash"
   }
 }

--- a/src/net-util/package.json
+++ b/src/net-util/package.json
@@ -26,6 +26,6 @@
   },
 
   "scripts": {
-    "postinstall": "pwd; ls ../../../../../../; rm -rf ../../../../node_modules/node-forge/flash"
+    "postinstall": "pwd; ls ../../../../../../../; rm -rf ../../../../node_modules/node-forge/flash"
   }
 }

--- a/src/net-util/tests/CertUtil.test.js
+++ b/src/net-util/tests/CertUtil.test.js
@@ -1,8 +1,6 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import process from 'node:process';
-
 import { CertUtil } from '@this/net-util';
 
 

--- a/src/net-util/tests/CertUtil.test.js
+++ b/src/net-util/tests/CertUtil.test.js
@@ -74,18 +74,15 @@ describe('makeSelfSignedPair()', () => {
     // <https://github.com/Dexus/pem/issues/389> and
     // <https://github.com/jestjs/jest/issues/15077>.
     const processEmit = process.emit;
-    const hasOwnEmit  = Object.hasOwn(process, 'emit');
+    expect(Object.hasOwn(process, 'emit')).toBeFalse();
 
     expect(got).toContainAllKeys(['certificate', 'privateKey']);
 
     expect(() => CertUtil.checkCertificateChain(got.certificate)).not.toThrow();
     expect(() => CertUtil.checkPrivateKey(got.privateKey)).not.toThrow();
 
+    // See above.
     expect(process.emit).toBe(processEmit);
-    if (!hasOwnEmit) {
-      expect(Object.hasOwn(process, 'emit')).toBeFalse();
-    } else {
-      expect(hasOwnEmit).toBeFalse(); // TEMP
-    }
+    expect(Object.hasOwn(process, 'emit')).toBeFalse();
   });
 });

--- a/src/net-util/tests/CertUtil.test.js
+++ b/src/net-util/tests/CertUtil.test.js
@@ -84,6 +84,8 @@ describe('makeSelfSignedPair()', () => {
     expect(process.emit).toBe(processEmit);
     if (!hasOwnEmit) {
       expect(Object.hasOwn(process, 'emit')).toBeFalse();
+    } else {
+      expect(hasOwnEmit).toBeFalse(); // TEMP
     }
   });
 });

--- a/src/net-util/tests/CertUtil.test.js
+++ b/src/net-util/tests/CertUtil.test.js
@@ -69,20 +69,9 @@ describe('makeSelfSignedPair()', () => {
   test('produces a valid-looking result, given valid arguments', async () => {
     const got = await CertUtil.makeSelfSignedPair(['localhost', '127.0.0.1', '::1', '*.foo.bar']);
 
-    // ...and also, doesn't try to override `process.emit` as inherited in
-    // `process` from `EventEmitter`. See
-    // <https://github.com/Dexus/pem/issues/389> and
-    // <https://github.com/jestjs/jest/issues/15077>.
-    const processEmit = process.emit;
-    expect(Object.hasOwn(process, 'emit')).toBeFalse();
-
     expect(got).toContainAllKeys(['certificate', 'privateKey']);
 
     expect(() => CertUtil.checkCertificateChain(got.certificate)).not.toThrow();
     expect(() => CertUtil.checkPrivateKey(got.privateKey)).not.toThrow();
-
-    // See above.
-    expect(process.emit).toBe(processEmit);
-    expect(Object.hasOwn(process, 'emit')).toBeFalse();
   });
 });

--- a/src/webapp-builtins/package.json
+++ b/src/webapp-builtins/package.json
@@ -22,6 +22,7 @@
     "@this/host": "*",
     "@this/loggy": "*",
     "@this/loggy-intf": "*",
+    "@this/metacomp": "*",
     "@this/net-protocol": "*",
     "@this/net-util": "*",
     "@this/typey": "*",

--- a/src/webapp-util/package.json
+++ b/src/webapp-util/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@this/async": "*",
     "@this/clocky": "*",
-    "@this/compy": "*",
     "@this/data-values": "*",
     "@this/fs-util": "*",
     "@this/loggy-intf": "*",


### PR DESCRIPTION
This PR is a compendium of miscellanea, following up on the last few days' worth of work.

Notably, this PR removes our use of the `pem` module from NPM as a dependency, replacing it with `selfsigned`. TBQH the state of `pem` is consistent with being in the early stage of a "supply chain" attack. See <https://github.com/jestjs/jest/issues/15077> and <https://github.com/Dexus/pem/issues/389> for some history / details.

