### PR TITLE
`initialBurst`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ Breaking changes:
 * None.
 
 Other notable changes:
-* None.
+* configuration:
+  * For all rate-limiter components, exposed the pre-existing underlying token
+    bucket option `initialBurst`.
 
 ### v0.7.6 -- 2024-06-04 -- stable release
 

--- a/doc/configuration/2-common-configuration.md
+++ b/doc/configuration/2-common-configuration.md
@@ -133,7 +133,8 @@ These units are always each a real-world unit of some sort (as described above).
 * `flowRate` &mdash; The rate of token flow once any burst capacity is
   exhausted. The rate must be positive.
 * `initialBurst` &mdash; Optional starting amount of available token "burst"
-  before rate limiting takes effect. Minimum value `0`. Defaults to `maxBurst`.
+  before rate limiting takes effect. Minimum value `0`, and must be no larger
+  than `maxBurst`. Defaults to `maxBurst`.
 * `maxBurst` &mdash; The maximum number of tokens that can be built up for a
   "burst" before rate limiting takes effect. Minimum value `1`.
 * `maxQueue` &mdash; Optional maximum possible size of the wait queue, in

--- a/doc/configuration/2-common-configuration.md
+++ b/doc/configuration/2-common-configuration.md
@@ -132,6 +132,8 @@ These units are always each a real-world unit of some sort (as described above).
 
 * `flowRate` &mdash; The rate of token flow once any burst capacity is
   exhausted. The rate must be positive.
+* `initialBurst` &mdash; Optional starting amount of available token "burst"
+  before rate limiting takes effect. Minimum value `0`. Defaults to `maxBurst`.
 * `maxBurst` &mdash; The maximum allowed "burst" of tokens before rate limiting
   takes effect. Minimum value `1`.
 * `maxQueue` &mdash; Optional maximum possible size of the wait queue, in
@@ -152,6 +154,7 @@ const services = [
   {
     name:          'limiter',
     class:         SomeSortOfRateLimiter,
+    initialBurst:  '1 MiB',
     maxBurst:      '5 MiB',
     flowRate:      '32 KiB/sec',
     maxQueue:      '32 MiB',

--- a/doc/configuration/2-common-configuration.md
+++ b/doc/configuration/2-common-configuration.md
@@ -134,14 +134,14 @@ These units are always each a real-world unit of some sort (as described above).
   exhausted. The rate must be positive.
 * `initialBurst` &mdash; Optional starting amount of available token "burst"
   before rate limiting takes effect. Minimum value `0`. Defaults to `maxBurst`.
-* `maxBurst` &mdash; The maximum allowed "burst" of tokens before rate limiting
-  takes effect. Minimum value `1`.
+* `maxBurst` &mdash; The maximum number of tokens that can be built up for a
+  "burst" before rate limiting takes effect. Minimum value `1`.
 * `maxQueue` &mdash; Optional maximum possible size of the wait queue, in
   tokens, or `null` for no limit. Minimum value `1`. This is the number of
   tokens that are allowed to be queued up for a grant, when there is
   insufficient burst capacity to satisfy all active clients. Attempts to queue
-  up more result in token denials (e.g., network connections closed instead of
-  sending bytes). Defaults to `null`.
+  up more requests will result in token denials (e.g., network connections
+  closed instead of sending bytes). Defaults to `null`.
 * `maxQueueGrant` &mdash; Optional maximum possible size of a grant given to
   a requester in the wait queue, in tokens. Minimum value `1`. If not
   specified, it is the same as the `maxBurst`. **Note:** This configuration is

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -115,6 +115,7 @@ const services = [
     name:            'dataRateLimiter',
     class:           DataRateLimiter,
     dispatchLogging: true,
+    initialBurst:    '100 KiB',
     maxBurst:        '1 MiB',
     flowRate:        '100 KiB / sec',
     maxQueueGrant:   '50 KiB',

--- a/src/webapp-builtins/private/TemplRateLimitConfig.js
+++ b/src/webapp-builtins/private/TemplRateLimitConfig.js
@@ -49,8 +49,9 @@ export const TemplRateLimitConfig = (className, superclass, { allowMaxQueueGrant
     }
 
     /**
-     * Maximum count of items in a burst. If passed as a `string` it is parsed
-     * into an instance of the appropriate unit-count class.
+     * Maximum number of tokens that can be built up for a burst. If passed as a
+     * `string` it is parsed into an instance of the appropriate unit-count
+     * class.
      *
      * @param {string|UnitQuantity} value Proposed configuration value.
      * @returns {UnitQuantity} Accepted configuration value.

--- a/src/webapp-builtins/private/TemplRateLimitConfig.js
+++ b/src/webapp-builtins/private/TemplRateLimitConfig.js
@@ -49,6 +49,18 @@ export const TemplRateLimitConfig = (className, superclass, { allowMaxQueueGrant
     }
 
     /**
+     * Burst capacity available immediately after the instance is started. If
+     * passed as a `string` it is parsed into an instance of the appropriate
+     * unit-count class.
+     *
+     * @param {?string|UnitQuantity} [value] Proposed configuration value.
+     * @returns {UnitQuantity} Accepted configuration value.
+     */
+    _config_maxBurst(value = null) {
+      return RateLimitConfig.#parseTokenCount(value, true);
+    }
+
+    /**
      * Maximum number of tokens that can be built up for a burst. If passed as a
      * `string` it is parsed into an instance of the appropriate unit-count
      * class.

--- a/src/webapp-builtins/private/TemplRateLimitConfig.js
+++ b/src/webapp-builtins/private/TemplRateLimitConfig.js
@@ -110,6 +110,7 @@ export const TemplRateLimitConfig = (className, superclass, { allowMaxQueueGrant
         ...config,
         bucket: Object.freeze({
           flowRate:          config.flowRate,
+          initialBurstSize:  config.initialBurst,
           maxBurstSize:      config.maxBurst,
           maxQueueGrantSize: config.maxQueueGrant,
           maxQueueSize:      config.maxQueue
@@ -117,6 +118,7 @@ export const TemplRateLimitConfig = (className, superclass, { allowMaxQueueGrant
       };
 
       delete result.flowRate;
+      delete result.initialBurst;
       delete result.maxBurst;
       delete result.maxQueueGrant;
       delete result.maxQueue;

--- a/src/webapp-builtins/private/TemplRateLimitConfig.js
+++ b/src/webapp-builtins/private/TemplRateLimitConfig.js
@@ -56,7 +56,7 @@ export const TemplRateLimitConfig = (className, superclass, { allowMaxQueueGrant
      * @param {?string|UnitQuantity} [value] Proposed configuration value.
      * @returns {UnitQuantity} Accepted configuration value.
      */
-    _config_maxBurst(value = null) {
+    _config_initialBurst(value = null) {
       return RateLimitConfig.#parseTokenCount(value, true);
     }
 

--- a/src/webapp-builtins/tests/RequestRateLimiter.test.js
+++ b/src/webapp-builtins/tests/RequestRateLimiter.test.js
@@ -12,6 +12,22 @@ describe('constructor', () => {
     })).not.toThrow();
   });
 
+  test('accepts a valid configuration with non-null `initialBurst`', () => {
+    expect(() => new RequestRateLimiter({
+      flowRate:     '1000 request/min',
+      maxBurst:     '5 request',
+      initialBurst: '2 request'
+    })).not.toThrow();
+  });
+
+  test('accepts a valid configuration with `initialBurst === null`', () => {
+    expect(() => new RequestRateLimiter({
+      flowRate:     '1000 request/min',
+      maxBurst:     '5 request',
+      initialBurst: null
+    })).not.toThrow();
+  });
+
   test('accepts a valid configuration with `maxQueue`', () => {
     expect(() => new RequestRateLimiter({
       flowRate: '1000 request/min',
@@ -32,6 +48,14 @@ describe('constructor', () => {
     expect(() => new RequestRateLimiter({
       flowRate: '100_florp/splat',
       maxBurst: '10 req'
+    })).toThrow();
+  });
+
+  test('throws if given an unparseable `initialBurst`', () => {
+    expect(() => new RequestRateLimiter({
+      flowRate:     '1 req/sec',
+      maxBurst:     '10 req',
+      initialBurst: 'blorp!'
     })).toThrow();
   });
 

--- a/src/webapp-util/export/TokenBucket.js
+++ b/src/webapp-util/export/TokenBucket.js
@@ -118,7 +118,8 @@ export class TokenBucket {
    *   positive (non-zero and non-negative) value. This is a required "option."
    * @param {number} [options.initialBurstSize] The instantaneously available
    *   burst size, in tokens, at the moment of construction. Defaults to
-   *   `maxBurstSize` (that is, able to be maximally "bursted" from the get-go).
+   *   `maxBurstSize` (that is, able to be maximally "bursted" from the get-go),
+   *   and must be no larger than `maxBurstSize`.
    * @param {number} options.maxBurstSize Maximum possible instantaneous burst
    *   size (that is, the total bucket capacity in the "leaky bucket as meter"
    *   metaphor), in tokens (arbitrary volume units). This defines the

--- a/src/webapp-util/export/TokenBucket.js
+++ b/src/webapp-util/export/TokenBucket.js
@@ -26,6 +26,13 @@ import { AskIf, MustBe } from '@this/typey';
  */
 export class TokenBucket {
   /**
+   * Initially-allowed instantaneous burst, in tokens.
+   *
+   * @type {number}
+   */
+  #initialBurstSize;
+
+  /**
    * Maximum allowed instantaneous burst, in tokens. This is the "bucket
    * capacity" in the "leaky bucket as meter" metaphor.
    *
@@ -117,9 +124,9 @@ export class TokenBucket {
    *   defines the steady state "flow rate" allowed by the instance. Must be a
    *   positive (non-zero and non-negative) value. This is a required "option."
    * @param {number} [options.initialBurstSize] The instantaneously available
-   *   burst size, in tokens, at the moment of construction. Defaults to
-   *   `maxBurstSize` (that is, able to be maximally "bursted" from the get-go),
-   *   and must be no larger than `maxBurstSize`.
+   *   burst size, in tokens, at the moment of construction, or `null` for the
+   *   default. Defaults to `maxBurstSize` (that is, able to be maximally
+   *   "bursted" from the get-go), and must be no larger than `maxBurstSize`.
    * @param {number} options.maxBurstSize Maximum possible instantaneous burst
    *   size (that is, the total bucket capacity in the "leaky bucket as meter"
    *   metaphor), in tokens (arbitrary volume units). This defines the
@@ -150,7 +157,7 @@ export class TokenBucket {
   constructor(options) {
     const {
       flowRate,
-      initialBurstSize  = options.maxBurstSize,
+      initialBurstSize  = null,
       maxBurstSize,
       maxQueueGrantSize = null,
       maxQueueSize      = null,
@@ -164,6 +171,10 @@ export class TokenBucket {
     this.#maxBurstSize  = MustBe.number(maxBurstSize, { finite: true, minExclusive: 0 });
     this.#partialTokens = MustBe.boolean(partialTokens);
     this.#timeSource    = MustBe.instanceOf(timeSource, IntfTimeSource);
+
+    this.#initialBurstSize = (initialBurstSize === null)
+      ? this.#maxBurstSize
+      : MustBe.number(initialBurstSize, { minInclusive: 0, maxInclusive: this.#maxBurstSize });
 
     this.#maxQueueSize = (maxQueueSize === null)
       ? Number.POSITIVE_INFINITY
@@ -181,7 +192,7 @@ export class TokenBucket {
       this.#maxQueueGrantSize = Math.floor(this.#maxQueueGrantSize);
     }
 
-    this.#lastBurstSize = MustBe.number(initialBurstSize, { minInclusive: 0, maxInclusive: maxBurstSize });
+    this.#lastBurstSize = this.#initialBurstSize;
     this.#lastNow       = this.#timeSource.now();
   }
 
@@ -204,6 +215,7 @@ export class TokenBucket {
 
     return {
       flowRate:          this.#flowRate,
+      initialBurstSize:  this.#initialBurstSize,
       maxBurstSize:      this.#maxBurstSize,
       maxQueueGrantSize: this.#maxQueueGrantSize,
       maxQueueSize,

--- a/src/webapp-util/tests/TokenBucket.test.js
+++ b/src/webapp-util/tests/TokenBucket.test.js
@@ -129,6 +129,21 @@ describe('constructor()', () => {
     expect(() => new TokenBucket(opts)).not.toThrow();
   });
 
+  test('produces an instance with the `initialBurstSize` that was passed', () => {
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 123, initialBurstSize: 32 });
+    expect(bucket.config.initialBurstSize).toBe(32);
+  });
+
+  test('produces an instance with the default `initialBurstSize` if not passed', () => {
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 123 });
+    expect(bucket.config.initialBurstSize).toBe(123);
+  });
+
+  test('produces an instance with the default `initialBurstSize` if passed as `null`', () => {
+    const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 321, initialBurstSize: null });
+    expect(bucket.config.initialBurstSize).toBe(321);
+  });
+
   test('produces an instance with the `maxBurstSize` that was passed', () => {
     const bucket = new TokenBucket({ flowRate: FLOW_1, maxBurstSize: 123 });
     expect(bucket.config.maxBurstSize).toBe(123);
@@ -288,7 +303,6 @@ describe('constructor(<invalid>)', () => {
 
   test.each`
     initialBurstSize
-    ${null}
     ${true}
     ${'123'}
     ${[123]}
@@ -362,8 +376,8 @@ describe('.config', () => {
   test('has exactly the expected properties', () => {
     const bucket = new TokenBucket({ flowRate: FLOW_TINY, maxBurstSize: 100000 });
     expect(bucket.config).toContainAllKeys([
-      'flowRate', 'maxBurstSize', 'maxQueueGrantSize', 'maxQueueSize',
-      'partialTokens', 'timeSource'
+      'flowRate', 'initialBurstSize', 'maxBurstSize', 'maxQueueGrantSize',
+      'maxQueueSize', 'partialTokens', 'timeSource'
     ]);
   });
 });


### PR DESCRIPTION
This PR exposes `initialBurst` as a configuration option for all rate limiter components. The underlying class `TokenBucket` already had this option (or, technically, the raw-number equivalent `initialBurstSize`), but it hadn't gotten poked all the way through to the component configurations.