### PR TITLE
`StaticFiles`: Update the not-found response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Breaking changes:
 Other notable changes:
 * Updated npm-origined dependencies for the unit test framework, based on a
   vulnerability report.
+* `StaticFiles`: Notice when the `notFoundPath` file gets changed, instead of
+  only ever setting up the not-found response during system startup.
 
 ### v0.7.7 -- 2024-06-24 -- stable release
 

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -73,14 +73,8 @@ export class StaticFiles extends BaseApplication {
     const resolved = await this.#resolvePath(dispatch);
 
     if (!resolved) {
-      if (this.#notFoundResponse) {
-        return this.#notFoundResponse;
-      } else {
-        return null;
-      }
-    }
-
-    if (resolved.redirect) {
+      return this.#notFound();
+    } else if (resolved.redirect) {
       const redirectTo = resolved.redirect;
       const response   = FullResponse.makeRedirect(redirectTo, 308);
 
@@ -151,6 +145,20 @@ export class StaticFiles extends BaseApplication {
     }
 
     await super._impl_start();
+  }
+
+  /**
+   * Updates (if necessary) and returns {@link #notFoundResponse}. This returns
+   * `null` if this instance isn't set up to directly handle not-found cases.
+   *
+   * @returns {?FullResponse} The response for a not-found situation.
+   */
+  async #notFound() {
+    if (this.#notFoundResponse) {
+      return this.#notFoundResponse;
+    } else {
+      return null;
+    }
   }
 
   /**

--- a/src/webapp-builtins/tests/StaticFiles.test.js
+++ b/src/webapp-builtins/tests/StaticFiles.test.js
@@ -199,7 +199,7 @@ describe('_impl_handleRequest()', () => {
         const sf = await makeInstance({ notFoundPath });
 
         const request  = RequestUtil.makeGet('/this/is/not/found');
-        const dispatch = new DispatchInfo(PathKey.EMPTY, request.pathname)
+        const dispatch = new DispatchInfo(PathKey.EMPTY, request.pathname);
 
         const result1 = await sf.handleRequest(request, dispatch);
         const body1   = result1._testing_getBody();

--- a/src/webapp-builtins/tests/StaticFiles.test.js
+++ b/src/webapp-builtins/tests/StaticFiles.test.js
@@ -190,33 +190,33 @@ describe('_impl_handleRequest()', () => {
         expect(result).toBeNull();
       }
     });
+  });
 
-    // Extra tests when `notFoundPath` is used
-    describe('with `notFoundPath`', () => {
-      test('notices when the file at `notFoundPath` is updated', async () => {
-        const notFoundPath = `${tmpdir()}/not-found-${process.pid}.txt`;
-        await fs.writeFile(notFoundPath, 'original');
+  // Extra tests when `notFoundPath` is used
+  describe('with `notFoundPath`', () => {
+    test('notices when the file at `notFoundPath` is updated', async () => {
+      const notFoundPath = `${tmpdir()}/not-found-${process.pid}.txt`;
+      await fs.writeFile(notFoundPath, 'original');
 
-        const sf = await makeInstance({ notFoundPath });
+      const sf = await makeInstance({ notFoundPath });
 
-        const request  = RequestUtil.makeGet('/this/is/not/found');
-        const dispatch = new DispatchInfo(PathKey.EMPTY, request.pathname);
+      const request  = RequestUtil.makeGet('/this/is/not/found');
+      const dispatch = new DispatchInfo(PathKey.EMPTY, request.pathname);
 
-        const result1 = await sf.handleRequest(request, dispatch);
-        const body1   = result1._testing_getBody();
-        expect(result1.status).toBe(404);
-        expect(body1.type).toBe('buffer');
-        expect(body1.buffer.toString()).toMatch(/original/);
+      const result1 = await sf.handleRequest(request, dispatch);
+      const body1   = result1._testing_getBody();
+      expect(result1.status).toBe(404);
+      expect(body1.type).toBe('buffer');
+      expect(body1.buffer.toString()).toMatch(/original/);
 
-        await WallClock.waitForMsec(100); // So that `mtime` will be different.
-        await fs.writeFile(notFoundPath, 'replacement');
+      await WallClock.waitForMsec(100); // So that `mtime` will be different.
+      await fs.writeFile(notFoundPath, 'replacement');
 
-        const result2 = await sf.handleRequest(request, dispatch);
-        const body2   = result2._testing_getBody();
-        expect(result2.status).toBe(404);
-        expect(body2.type).toBe('buffer');
-        expect(body2.buffer.toString()).toMatch(/replacement/);
-      });
+      const result2 = await sf.handleRequest(request, dispatch);
+      const body2   = result2._testing_getBody();
+      expect(result2.status).toBe(404);
+      expect(body2.type).toBe('buffer');
+      expect(body2.buffer.toString()).toMatch(/replacement/);
     });
   });
 

--- a/src/webapp-builtins/tests/StaticFiles.test.js
+++ b/src/webapp-builtins/tests/StaticFiles.test.js
@@ -5,6 +5,7 @@ import fs from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import process from 'node:process';
 
+import { WallClock } from '@this/clocky';
 import { PathKey } from '@this/collections';
 import { MockRootComponent } from '@this/compy/testing';
 import { DispatchInfo, FullResponse } from '@this/net-util';
@@ -207,6 +208,7 @@ describe('_impl_handleRequest()', () => {
         expect(body1.type).toBe('buffer');
         expect(body1.buffer.toString()).toMatch(/original/);
 
+        await WallClock.waitForMsec(100); // So that `mtime` will be different.
         await fs.writeFile(notFoundPath, 'replacement');
 
         const result2 = await sf.handleRequest(request, dispatch);


### PR DESCRIPTION
This PR makes `StaticFiles` start noticing when the file pointed at by `notFoundPath` changes, updating its not-found response accordingly. Before this, the system would only read the `notFoundPath` once, at system startup, which meant you had to reload (or restart) the system for it to pick up such an update.
