### PR TITLE
Fix `IncomingRequest.getHeaderOrNull()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Breaking changes:
 * None.
 
 Other notable changes:
-* None.
+* `net-util`:
+  * Fixed `IncomingRequest.getHeaderOrNull()`, which was very broken.
 
 ### v0.7.8 -- 2024-07-30 -- stable release
 

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -398,10 +398,13 @@ export class IncomingRequest {
    *
    * @param {string} name The header name.
    * @returns {?string|Array<string>} The corresponding value, or `null` if
-   *   there was no such header.
+   *   there was no such header. The only case where an array is returned is for
+   *   the very special name `set-coookie`.
    */
   getHeaderOrNull(name) {
-    return this.headers[name] ?? null;
+    return (name === 'set-cookie')
+      ? this.headers.getSetCookie()
+      : this.headers.get(name);
   }
 
   /**

--- a/src/net-util/tests/IncomingRequest.test.js
+++ b/src/net-util/tests/IncomingRequest.test.js
@@ -1,0 +1,29 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { HttpHeaders, IncomingRequest, RequestContext } from '@this/net-util';
+
+describe('constructor()', () => {
+  test('accepts a smoke-testy set of arguments', () => {
+    const config = {
+      context: new RequestContext(
+        Object.freeze({
+          address: '127.0.0.1',
+          port:    123
+        }),
+        Object.freeze({
+          address: '10.0.0.1',
+          port:    10321
+        })),
+      headers: new HttpHeaders({}),
+      logger: null,
+      protocolName: 'http-2',
+      pseudoHeaders: new HttpHeaders({
+        method: 'get',
+        path:   '/florp'
+      })
+    };
+
+    expect(() => new IncomingRequest(config)).not.toThrow();
+  });
+});

--- a/src/net-util/tests/IncomingRequest.test.js
+++ b/src/net-util/tests/IncomingRequest.test.js
@@ -3,27 +3,74 @@
 
 import { HttpHeaders, IncomingRequest, RequestContext } from '@this/net-util';
 
+/**
+ * Makes an instance with (non-pseudo) headers constructed from the given
+ * argument.
+ *
+ * @param {*} headers Argument to pass to the {@link HttpHeaders} constructor.
+ * @returns {IncomingRequest} The constructed instance.
+ */
+function makeWithHeaders(headers) {
+  const config = {
+    context: new RequestContext(
+      Object.freeze({
+        address: '127.0.0.1',
+        port:    123
+      }),
+      Object.freeze({
+        address: '10.0.0.1',
+        port:    10321
+      })),
+    headers: new HttpHeaders(headers),
+    logger: null,
+    protocolName: 'http-2',
+    pseudoHeaders: new HttpHeaders({
+      method: 'get',
+      path:   '/florp'
+    })
+  };
+
+  return new IncomingRequest(config);
+}
+
 describe('constructor()', () => {
   test('accepts a smoke-testy set of arguments', () => {
-    const config = {
-      context: new RequestContext(
-        Object.freeze({
-          address: '127.0.0.1',
-          port:    123
-        }),
-        Object.freeze({
-          address: '10.0.0.1',
-          port:    10321
-        })),
-      headers: new HttpHeaders({}),
-      logger: null,
-      protocolName: 'http-2',
-      pseudoHeaders: new HttpHeaders({
-        method: 'get',
-        path:   '/florp'
-      })
-    };
+    expect(() => makeWithHeaders({})).not.toThrow();
+  });
+});
 
-    expect(() => new IncomingRequest(config)).not.toThrow();
+describe('cookies', () => {
+  test('parses a valid single cookie from a `cookie` header', () => {
+    const req = makeWithHeaders({
+      cookie: 'blorp=bleep'
+    });
+
+    expect(req.cookies.getValueOrNull('blorp')).toBe('bleep');
+  });
+});
+
+describe('getHeaderOrNull', () => {
+  test('finds an existing header', () => {
+    const req = makeWithHeaders({
+      beep: 'boop'
+    });
+
+    expect(req.getHeaderOrNull('beep')).toBe('boop');
+  });
+
+  test('returns `null` for a nonexistent header', () => {
+    const req = makeWithHeaders({
+      beep: 'boop'
+    });
+
+    expect(req.getHeaderOrNull('blomp')).toBeNull();
+  });
+
+  test('returns the empty array for a nonexistent `set-cookie` header', () => {
+    const req = makeWithHeaders({
+      beep: 'boop'
+    });
+
+    expect(req.getHeaderOrNull('set-cookie')).toEqual([]);
   });
 });


### PR DESCRIPTION
Fix `IncomingRequest.getHeaderOrNull()`. It never worked. Or at least, it stopped working quite a while ago.