### PR TITLE
`BaseResponse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ Breaking changes:
 Other notable changes:
 * `net-util`:
   * Fixed `IncomingRequest.getHeaderOrNull()`, which was very broken.
-  * Added `DispatchInfo.isFile()`.
+  * Defined a base class, `BaseResponse` for the two concrete response classes.
   * Added a handful of static getters to `StatusResponse`.
-  * Various other fixes, motivated by a downstream project.
+  * Various other tweaks and fixes, motivated by a downstream project.
 
 ### v0.7.8 -- 2024-07-30 -- stable release
 

--- a/src/net-util/export/BaseResponse.js
+++ b/src/net-util/export/BaseResponse.js
@@ -1,0 +1,13 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+
+/**
+ * Base class which covers all the response object classes that are defined by
+ * this module.
+ *
+ * @abstract
+ */
+export class BaseResponse {
+  // @defaultConstructor
+}

--- a/src/net-util/export/FullResponse.js
+++ b/src/net-util/export/FullResponse.js
@@ -11,6 +11,7 @@ import { ErrorUtil, Moment } from '@this/data-values';
 import { Paths, StatsBase } from '@this/fs-util';
 import { MustBe } from '@this/typey';
 
+import { BaseResponse } from '#x/BaseResponse';
 import { HttpConditional } from '#x/HttpConditional';
 import { HttpHeaders } from '#x/HttpHeaders';
 import { HttpRange } from '#x/HttpRange';
@@ -34,7 +35,7 @@ import { TypeNodeResponse } from '#x/TypeNodeResponse';
  * up a response body that won't get sent, and (c) _not_ actually sending a
  * response body.
  */
-export class FullResponse {
+export class FullResponse extends BaseResponse {
   /**
    * The response status code, or `null` if not yet set.
    *
@@ -71,6 +72,8 @@ export class FullResponse {
    *   the instance out with nothing set.
    */
   constructor(orig = null) {
+    super();
+
     if (orig) {
       MustBe.instanceOf(orig, FullResponse);
       this.#status       = orig.#status;

--- a/src/net-util/export/StatusResponse.js
+++ b/src/net-util/export/StatusResponse.js
@@ -3,6 +3,7 @@
 
 import { MustBe } from '@this/typey';
 
+import { BaseResponse } from '#x/BaseResponse';
 import { FullResponse } from '#x/FullResponse';
 import { IncomingRequest } from '#x/IncomingRequest';
 
@@ -16,7 +17,7 @@ import { IncomingRequest } from '#x/IncomingRequest';
  *
  * Instances of this class are always frozen.
  */
-export class StatusResponse {
+export class StatusResponse extends BaseResponse {
   /**
    * The response status code, or `null` if not yet set.
    *
@@ -30,6 +31,8 @@ export class StatusResponse {
    * @param {number} status The status code of the response.
    */
   constructor(status) {
+    super();
+
     this.#status =
       MustBe.number(status, { safeInteger: true, minInclusive: 100, maxInclusive: 599 });
     Object.freeze(this);

--- a/src/net-util/index.js
+++ b/src/net-util/index.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+export * from '#x/BaseResponse';
 export * from '#x/CertUtil';
 export * from '#x/Cookies';
 export * from '#x/DispatchInfo';

--- a/src/webapp-core/export/BaseApplication.js
+++ b/src/webapp-core/export/BaseApplication.js
@@ -1,8 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { DispatchInfo, FullResponse, IncomingRequest, IntfRequestHandler,
-  StatusResponse, TypeOutgoingResponse }
+import { BaseResponse, DispatchInfo, IncomingRequest, IntfRequestHandler,
+  TypeOutgoingResponse }
   from '@this/net-util';
 import { Methods } from '@this/typey';
 
@@ -73,9 +73,7 @@ export class BaseApplication extends BaseDispatched {
       return new Error(`\`${this.name}._impl_handleRequest()\` ${msg}.`);
     };
 
-    if ((result === null)
-        || (result instanceof FullResponse)
-        || (result instanceof StatusResponse)) {
+    if ((result === null) || (result instanceof BaseResponse)) {
       return result;
     } else if (!(result instanceof Promise)) {
       if (result === undefined) {
@@ -87,9 +85,7 @@ export class BaseApplication extends BaseDispatched {
 
     const finalResult = await result;
 
-    if ((finalResult === null)
-        || (finalResult instanceof FullResponse)
-        || (finalResult instanceof StatusResponse)) {
+    if ((finalResult === null) || (finalResult instanceof BaseResponse)) {
       return finalResult;
     } else if (finalResult === undefined) {
       throw error('async-returned `undefined`; probably needs an explicit `return`');

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -7,8 +7,7 @@ import { FormatUtils } from '@this/loggy-intf';
 import { IntfAccessLog, IntfConnectionRateLimiter, IntfDataRateLimiter,
   ProtocolWrangler, ProtocolWranglers }
   from '@this/net-protocol';
-import { DispatchInfo, FullResponse, HostUtil, IntfRequestHandler,
-  StatusResponse }
+import { BaseResponse, DispatchInfo, HostUtil, IntfRequestHandler }
   from '@this/net-util';
 import { StringUtil } from '@this/typey';
 
@@ -63,7 +62,7 @@ export class NetworkEndpoint extends BaseDispatched {
 
     try {
       const result = await application.handleRequest(request, dispatch);
-      if ((result === null) || (result instanceof FullResponse) || (result instanceof StatusResponse)) {
+      if ((result === null) || (result instanceof BaseResponse)) {
         return result;
       } else {
         // Caught immediately below.


### PR DESCRIPTION
This PR defines a new base class `BaseResponse` to be the superclass of the two concrete response classes in `net-util`, which allows for a nice bit of simplification during request handling.