### PR TITLE
Methods for `StaticFiles` and `SimpleResponse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Other notable changes:
   * Defined a base class, `BaseResponse` for the two concrete response classes.
   * Added a handful of static getters to `StatusResponse`.
   * Various other tweaks and fixes, motivated by a downstream project.
+* `webapp-builtins`:
+  * Make `StaticFiles` and `SimpleResponse` only respond successfully to `GET`
+    and `HEAD` requests.
 
 ### v0.7.8 -- 2024-07-30 -- stable release
 

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -480,6 +480,9 @@ There are a few notable things which _aren't_ configurable for this application.
 These may be configurable in a future version, if there is sufficient and
 reasonable demand:
 
+* Methods:
+  * This app only responds successfully to the method `GET`. Other methods
+    will result in a 401 ("Forbidden") response.
 * Content types:
   * The `Content-Type` headers are based on the file extensions of the files
     being served.

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -434,6 +434,9 @@ There are a few notable things which _aren't_ configurable for this application.
 These may be configurable in a future version, if there is sufficient and
 reasonable demand:
 
+* Methods:
+  * This app only responds successfully to the methods `GET` and `HEAD`. Other
+    methods will result in a 403 ("Forbidden") response.
 * Content types:
   * The mapping from extensions to MIME types is not configurable.
 * Caching:
@@ -481,8 +484,8 @@ These may be configurable in a future version, if there is sufficient and
 reasonable demand:
 
 * Methods:
-  * This app only responds successfully to the method `GET`. Other methods
-    will result in a 401 ("Forbidden") response.
+  * This app only responds successfully to the methods `GET` and `HEAD`. Other
+    methods will result in a 403 ("Forbidden") response.
 * Content types:
   * The `Content-Type` headers are based on the file extensions of the files
     being served.

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -408,6 +408,18 @@ export class IncomingRequest {
   }
 
   /**
+   * Indicates whether the method of this request is either `get` or `head`.
+   * This is a common enough (dual) case that it's worth it to have this
+   * convenience method.
+   *
+   * @returns {boolean} `true` iff the request method is either `get` or `head`.
+   */
+  isGetOrHead() {
+    const method = this.#requestMethod;
+    return (method === 'get') || (method === 'head');
+  }
+
+  /**
    * @returns {object} {@link #parsedTargetObject}, filling it out first if it
    * had not already been set up. This is a private getter because the return
    * value is pretty ad-hoc, and we don't want to expose it as part of this

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -5,7 +5,7 @@ import fs from 'node:fs/promises';
 
 import { WallClock } from '@this/clocky';
 import { Paths, Statter } from '@this/fs-util';
-import { EtagGenerator, FullResponse, HttpUtil, MimeTypes }
+import { EtagGenerator, FullResponse, HttpUtil, MimeTypes, StatusResponse }
   from '@this/net-util';
 import { AskIf, MustBe } from '@this/typey';
 import { BaseApplication } from '@this/webapp-core';
@@ -36,7 +36,9 @@ export class SimpleResponse extends BaseApplication {
     const { headers, method } = request;
     const response            = this.#response;
 
-    if (this.#allowAdjustment) {
+    if (!request.isGetOrHead()) {
+      return StatusResponse.FORBIDDEN;
+    } else if (this.#allowAdjustment) {
       return response.adjustFor(method, headers, { conditional: true, range: true });
     } else {
       return response;

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -80,7 +80,7 @@ export class StaticFiles extends BaseApplication {
 
   /** @override */
   async _impl_handleRequest(request, dispatch) {
-    if (request.method !== 'get') {
+    if (!request.isGetOrHead()) {
       return StatusResponse.FORBIDDEN;
     }
 

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -4,7 +4,8 @@
 import fs from 'node:fs/promises';
 
 import { Paths, Statter } from '@this/fs-util';
-import { DispatchInfo, EtagGenerator, FullResponse, HttpUtil, MimeTypes }
+import { DispatchInfo, EtagGenerator, FullResponse, HttpUtil, MimeTypes,
+  StatusResponse }
   from '@this/net-util';
 import { AskIf } from '@this/typey';
 import { BaseApplication } from '@this/webapp-core';
@@ -79,6 +80,10 @@ export class StaticFiles extends BaseApplication {
 
   /** @override */
   async _impl_handleRequest(request, dispatch) {
+    if (request.method !== 'get') {
+      return StatusResponse.FORBIDDEN;
+    }
+
     const resolved = await this.#resolvePath(dispatch);
 
     if (!resolved) {


### PR DESCRIPTION
This PR makes it so that `StaticFiles` and `SimpleResponse` only respond successfully for `GET` and `HEAD` requests. Other request methods cause a 403 ("Forbidden") response.