### PR TITLE
Read request bodies, and related stuff.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ Breaking changes:
 
 Other notable changes:
 * `net-util`:
-  * Fixed `IncomingRequest.getHeaderOrNull()`, which was very broken.
+  * `IncomingRequest`:
+    * Made it start rejecting requests whose request method (e.g. `GET`) isn't
+      defined to take a request body but where the request actually does have a
+      body.
+    * Fixed `getHeaderOrNull()`, which had been broken for a while.
   * Defined a base class, `BaseResponse` for the two concrete response classes.
   * Added a handful of static getters to `StatusResponse`.
   * Various other tweaks and fixes, motivated by a downstream project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Other notable changes:
       defined to take a request body but where the request actually does have a
       body.
     * Fixed `getHeaderOrNull()`, which had been broken for a while.
+    * `fromNodeRequest()` now reads the request body when present, and returns
+      it in the constructed instance.
   * Defined a base class, `BaseResponse` for the two concrete response classes.
   * Added a handful of static getters to `StatusResponse`.
   * Various other tweaks and fixes, motivated by a downstream project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ versioning principles. Unstable releases do not.
 
 Breaking changes:
 * `net-util`:
-  * `IncomingRequest.fromNodeRequest()` is now an `async` method.
+  * `IncomingRequest.fromNodeRequest()` is now an `async` method, and its final
+    argument is now a catch-all `options`. ("If a function has more than two
+    arguments, you haven't discovered all of them yet." --Unknown)
 
 Other notable changes:
 * `net-util`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Breaking changes:
 Other notable changes:
 * `net-util`:
   * `IncomingRequest`:
+    * Added `body` constructor option.
     * Made it start rejecting requests whose request method (e.g. `GET`) isn't
       defined to take a request body but where the request actually does have a
       body.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
-* None.
+* `net-util`:
+  * `IncomingRequest.fromNodeRequest()` is now an `async` method.
 
 Other notable changes:
 * `net-util`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Other notable changes:
 * `webapp-builtins`:
   * Make `StaticFiles` and `SimpleResponse` only respond successfully to `GET`
     and `HEAD` requests.
+* `webapp-core` / config:
+  * Added `NetworkEndpoint` configuration `maxRequestBodySize`.
 
 ### v0.7.8 -- 2024-07-30 -- stable release
 

--- a/doc/configuration/README.md
+++ b/doc/configuration/README.md
@@ -244,6 +244,10 @@ naming and configuring one of them. Each element has the following bindings:
     already correspond to an open server socket (e.g. set up by `systemd`).
     `<fd-num>` is an arbitrary (decimal) number in the range of valid file
     descriptors.
+* `maxRequestBodySize` &mdash; Optional limit on the size of a request body,
+    specified as a byte count as described in
+    [`ByteCount`](./2-common-configuration.md#bytecount), or `null` not to have
+    a limit. It is generally advisable to have a limit.
 * `protocol` &mdash; The protocol to speak. This can be any of `http`, `https`,
   or `http2`. `http2` includes fallback to `https`.
 * `services` &mdash; An object which binds roles to system services by name.

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -288,11 +288,12 @@ const applications = [
 // Endpoint defintions, including mount points for applications.
 const endpoints = [
   {
-    name:            'insecure',
-    protocol:        'http',
-    interface:       '*:8080',
-    application:     'myRedirector',
-    dispatchLogging: true,
+    name:               'insecure',
+    protocol:           'http',
+    interface:          '*:8080',
+    application:        'myRedirector',
+    dispatchLogging:    true,
+    maxRequestBodySize: '0 byte',
     services: {
       accessLog:             'accessLog',
       dataRateLimiter:       'dataRateLimiter',
@@ -300,12 +301,13 @@ const endpoints = [
     }
   },
   {
-    name:            'secure',
-    protocol:        'http2',
-    hostnames:       ['*'],
-    interface:       '*:8443',
-    application:     'mySite',
-    dispatchLogging: true,
+    name:               'secure',
+    protocol:           'http2',
+    hostnames:          ['*'],
+    interface:          '*:8443',
+    application:        'mySite',
+    dispatchLogging:    true,
+    maxRequestBodySize: '32 byte',
     services: {
       accessLog:             'accessLog',
       dataRateLimiter:       'dataRateLimiter',
@@ -313,11 +315,12 @@ const endpoints = [
     }
   },
   {
-    name:        'alsoSecure',
-    protocol:    'https',
-    hostnames:   ['*'],
-    interface:   '*:8444',
-    application: 'mySeries',
+    name:               'alsoSecure',
+    protocol:           'https',
+    hostnames:          ['*'],
+    interface:          '*:8444',
+    application:        'mySeries',
+    maxRequestBodySize: '32 byte',
     services: {
       accessLog: 'accessLog'
     }

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -80,6 +80,13 @@ export class ProtocolWrangler {
   #interfaceObject;
 
   /**
+   * Maximum request body allowed, in bytes, or `null` if there is no limit.
+   *
+   * @type {?number}
+   */
+  #maxRequestBodyBytes;
+
+  /**
    * Value to use for the `Server` HTTP-ish response header.
    *
    * @type {string}
@@ -99,7 +106,6 @@ export class ProtocolWrangler {
    * @type {boolean}
    */
   #stopping = true;
-
 
   /**
    * Is the system about to reload (after stopping)?
@@ -130,6 +136,10 @@ export class ProtocolWrangler {
    *   * `*` is treated as the wildcard address, instead of `::` or `0.0.0.0`.
    *   * The default for `allowHalfOpen` is `true`, which is required in
    *     practice for HTTP2 (and is at least _useful_ in other contexts).
+   * @param {?number} [options.maxRequestBodyBytes] Maximum size allowed for a
+   *   request body, in bytes, or `null` not to have a limit. Note that not
+   *   having a limit is often ill-advised. If non-`null`, must be a positive
+   *   integer.
    * @param {string} options.protocol The name of the protocol to use.
    * @param {IntfRequestHandler} options.requestHandler Request handler. This is
    *   required.
@@ -143,6 +153,7 @@ export class ProtocolWrangler {
       accessLog,
       hostManager,
       interface: interfaceConfig,
+      maxRequestBodyBytes = null,
       requestHandler
     } = options;
 
@@ -156,6 +167,10 @@ export class ProtocolWrangler {
       fd:      interfaceConfig.fd      ?? null,
       port:    interfaceConfig.port    ?? null
     });
+
+    this.#maxRequestBodyBytes = (maxRequestBodyBytes === null)
+      ? null
+      : MustBe.number(maxRequestBodyBytes, { safeInteger: true, minInclusive: 1 });
   }
 
   /**

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -296,10 +296,14 @@ export class ProtocolWrangler {
    * protocol server object. This method should be called by the concrete
    * subclass in response to receiving a request.
    *
+   * **Note:** It is expected that this method is called in a context where any
+   * error becomes uncaught. As such, this method aims never to `throw`, instead
+   * logging errors and reporting error-ish statuses to the (remote) client.
+   *
    * @param {TypeNodeRequest} req Request object.
    * @param {TypeNodeResponse} res Response object.
    */
-  _prot_incomingRequest(req, res) {
+  async _prot_incomingRequest(req, res) {
     // This method performs everything that can be done synchronously as the
     // event callback that this is, and then (assuming all's well) hands things
     // off to our main `async` request handler.
@@ -345,7 +349,7 @@ export class ProtocolWrangler {
     };
 
     try {
-      request = IncomingRequest.fromNodeRequest(req, requestContext, this.#requestLogger);
+      request = await IncomingRequest.fromNodeRequest(req, requestContext, this.#requestLogger);
     } catch (e) {
       // This generally means there was something malformed about the request,
       // so we nip things in the bud here, responding with a 400 status ("Bad

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -329,7 +329,7 @@ export class ProtocolWrangler {
     // Responds to a problematic request with an error status of some sort,
     // closes the request, and logs a bit of info which might help elucidate the
     // situation.
-    const errorResponse = (e, status) => {
+    const errorResponse = (e, status, message = e.message) => {
       logger?.errorDuringIncomingRequest({
         ...context.ids,
         requestId: request?.id ?? '<unknown>',
@@ -345,6 +345,13 @@ export class ProtocolWrangler {
       });
 
       res.statusCode = status;
+
+      res.setHeader('Content-Type', 'text/plain');
+      res.write(message);
+      if (!message.endsWith('\n')) {
+        res.write('\n');
+      }
+
       res.end();
     };
 
@@ -376,7 +383,7 @@ export class ProtocolWrangler {
       // theorized to occur in practice when the socket for a request gets
       // closed after the request was received but before it managed to get
       // dispatched.
-      errorResponse(e, 500); // "Internal Server Error."
+      errorResponse(e, 500, 'Internal Server Error');
     }
   }
 

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -372,7 +372,10 @@ export class ProtocolWrangler {
 
     try {
       request = await IncomingRequest.fromNodeRequest(req, requestContext,
-        { logger: this.#requestLogger });
+        {
+          logger:              this.#requestLogger,
+          maxRequestBodyBytes: this.#maxRequestBodyBytes
+        });
     } catch (e) {
       // This generally means there was something malformed about the request,
       // so we nip things in the bud here, responding with a 400 status ("Bad

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -371,7 +371,8 @@ export class ProtocolWrangler {
     };
 
     try {
-      request = await IncomingRequest.fromNodeRequest(req, requestContext, this.#requestLogger);
+      request = await IncomingRequest.fromNodeRequest(req, requestContext,
+        { logger: this.#requestLogger });
     } catch (e) {
       // This generally means there was something malformed about the request,
       // so we nip things in the bud here, responding with a 400 status ("Bad

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -138,8 +138,8 @@ export class ProtocolWrangler {
    *     practice for HTTP2 (and is at least _useful_ in other contexts).
    * @param {?number} [options.maxRequestBodyBytes] Maximum size allowed for a
    *   request body, in bytes, or `null` not to have a limit. Note that not
-   *   having a limit is often ill-advised. If non-`null`, must be a positive
-   *   integer.
+   *   having a limit is often ill-advised. If non-`null`, must be a
+   *   non-negative integer.
    * @param {string} options.protocol The name of the protocol to use.
    * @param {IntfRequestHandler} options.requestHandler Request handler. This is
    *   required.
@@ -170,7 +170,7 @@ export class ProtocolWrangler {
 
     this.#maxRequestBodyBytes = (maxRequestBodyBytes === null)
       ? null
-      : MustBe.number(maxRequestBodyBytes, { safeInteger: true, minInclusive: 1 });
+      : MustBe.number(maxRequestBodyBytes, { safeInteger: true, minInclusive: 0 });
   }
 
   /**

--- a/src/net-util/export/HttpUtil.js
+++ b/src/net-util/export/HttpUtil.js
@@ -272,6 +272,27 @@ export class HttpUtil {
   }
 
   /**
+   * Given an HTTP-ish request method, indicates if the request is expected to
+   * have a request body (that is, "content").
+   *
+   * @param {string} method Request method, either downcased or all-caps.
+   * @returns {boolean} `true` if a request body is expected, or `false` if it
+   *   is disallowed.
+   */
+  static requestBodyIsAllowedFor(method) {
+    switch (method) {
+      case 'patch': case 'PATCH':
+      case 'post':  case 'POST':
+      case 'put':   case 'PUT': {
+        return true;
+      }
+      default: {
+        return false;
+      }
+    }
+  }
+
+  /**
    * Given an HTTP-ish response request method and status code, indicates if the
    * corresponding response _is allowed to_ include a body.
    *

--- a/src/net-util/export/HttpUtil.js
+++ b/src/net-util/export/HttpUtil.js
@@ -301,7 +301,7 @@ export class HttpUtil {
    * @returns {boolean} `true` if a request body is expected, or `false` if it
    *   is disallowed.
    */
-  static requestBodyIsAllowedFor(method) {
+  static requestBodyIsExpectedFor(method) {
     switch (method) {
       case 'patch': case 'PATCH':
       case 'post':  case 'POST':

--- a/src/net-util/export/HttpUtil.js
+++ b/src/net-util/export/HttpUtil.js
@@ -272,6 +272,28 @@ export class HttpUtil {
   }
 
   /**
+   * Given a string in the format used by `content-length` headers, returns the
+   * parsed number.
+   *
+   * @param {?string} lengthString An (alleged) `content-length` string.
+   * @returns {?number} The parsed form, or `null` if not parseable.
+   */
+  static numberFromContentLengthString(lengthString) {
+    if (lengthString === null) {
+      return null;
+    }
+
+    MustBe.string(lengthString);
+
+    if (!/^[0-9]{1,16}$/.test(lengthString)) {
+      return null;
+    }
+
+    const result = Number(lengthString);
+    return Number.isSafeInteger(result) ? result : null;
+  }
+
+  /**
    * Given an HTTP-ish request method, indicates if the request is expected to
    * have a request body (that is, "content").
    *

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -552,7 +552,7 @@ export class IncomingRequest {
     const { pseudoHeaders, headers } = IncomingRequest.#extractHeadersFrom(request);
     const requestMethod = IncomingRequest.#requestMethodFromPseudoHeaders(pseudoHeaders);
 
-    const body = HttpUtil.requestBodyIsAllowedFor(requestMethod)
+    const body = HttpUtil.requestBodyIsExpectedFor(requestMethod)
       ? await IncomingRequest.#readBody(request, maxRequestBodyBytes)
       : await IncomingRequest.#readEmptyBody(request);
 

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -534,8 +534,8 @@ export class IncomingRequest {
    *   new unique(ish) ID for the request.
    * @param {?number} [options.maxRequestBodyBytes] Maximum size allowed for a
    *   request body, in bytes, or `null` not to have a limit. Note that not
-   *   having a limit is often ill-advised. If non-`null`, must be a positive
-   *   integer.
+   *   having a limit is often ill-advised. If non-`null`, must be a
+   *   non-negative integer.
    * @returns {IncomingRequest} Instance with data based on a low-level Node
    *   request (etc.).
    */

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -658,47 +658,6 @@ export class IncomingRequest {
   }
 
   /**
-   * Checks that the given Node request has no body (content), by attempting to
-   * read it. Throws an error if there was any data to be read.
-   *
-   * @param {TypeNodeRequest} request Request object.
-   */
-  static async #readEmptyBody(request) {
-    const resultMp = new ManualPromise();
-
-    const onData = () => {
-      if (!resultMp.isSettled()) {
-        resultMp.reject(
-          new Error('Expected empty request body, but there was data.'));
-      }
-    };
-
-    const onEnd = () => {
-      if (!resultMp.isSettled()) {
-        resultMp.resolve(null);
-      }
-    };
-
-    const onError = (e) => {
-      if (!resultMp.isSettled()) {
-        resultMp.reject(e);
-      }
-    };
-
-    request.on('data',  onData);
-    request.on('end',   onEnd);
-    request.on('error', onError);
-
-    try {
-      await resultMp.promise;
-    } finally {
-      request.removeListener('data', onData);
-      request.removeListener('end', onEnd);
-      request.removeListener('error', onError);
-    }
-  }
-
-  /**
    * Extracts the two sets of headers from a low-level request object.
    *
    * @param {TypeNodeRequest} request Request object.
@@ -795,6 +754,47 @@ export class IncomingRequest {
     Object.freeze(headers);
     Object.freeze(pseudoHeaders);
     return { headers, pseudoHeaders };
+  }
+
+  /**
+   * Checks that the given Node request has no body (content), by attempting to
+   * read it. Throws an error if there was any data to be read.
+   *
+   * @param {TypeNodeRequest} request Request object.
+   */
+  static async #readEmptyBody(request) {
+    const resultMp = new ManualPromise();
+
+    const onData = () => {
+      if (!resultMp.isSettled()) {
+        resultMp.reject(
+          new Error('Expected empty request body, but there was data.'));
+      }
+    };
+
+    const onEnd = () => {
+      if (!resultMp.isSettled()) {
+        resultMp.resolve(null);
+      }
+    };
+
+    const onError = (e) => {
+      if (!resultMp.isSettled()) {
+        resultMp.reject(e);
+      }
+    };
+
+    request.on('data',  onData);
+    request.on('end',   onEnd);
+    request.on('error', onError);
+
+    try {
+      await resultMp.promise;
+    } finally {
+      request.removeListener('data', onData);
+      request.removeListener('end', onEnd);
+      request.removeListener('error', onError);
+    }
   }
 
   /**

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -664,15 +664,22 @@ export class IncomingRequest {
     const resultMp = new ManualPromise();
 
     const onData = () => {
-      resultMp.reject(new Error('Expected empty request body, but there was data.'));
+      if (!resultMp.isSettled()) {
+        resultMp.reject(
+          new Error('Expected empty request body, but there was data.'));
+      }
     };
 
     const onEnd = () => {
-      resultMp.resolve(null);
+      if (!resultMp.isSettled()) {
+        resultMp.resolve(null);
+      }
     };
 
     const onError = (e) => {
-      resultMp.reject(e);
+      if (!resultMp.isSettled()) {
+        resultMp.reject(e);
+      }
     };
 
     request.on('data',  onData);

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -515,7 +515,7 @@ export class IncomingRequest {
    * @returns {IncomingRequest} Instance with data based on a low-level Node
    *   request (etc.).
    */
-  static fromNodeRequest(request, context, logger) {
+  static async fromNodeRequest(request, context, logger) {
     // Note: It's impractical to do more thorough type checking here (and
     // probably not worth it anyway).
     MustBe.object(request);

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -510,17 +510,20 @@ export class IncomingRequest {
    * @param {TypeNodeRequest} request Request object.
    * @param {RequestContext} context Information about the request not
    *   represented in `request`.
-   * @param {?IntfLogger} logger Logger to use as a base, or `null` to not do
-   *   any logging. If passed as non-`null`, the actual logger instance will be
-   *   one that includes an additional subtag representing a new unique(ish) ID
-   *   for the request.
+   * @param {?object} [options] Miscellaneous options.
+   * @param {?IntfLogger} [options.logger] Logger to use as a base, or `null`
+   *   not to do any logging. If passed as non-`null`, the actual logger
+   *   instance will be one that includes an additional subtag representing a
+   *   new unique(ish) ID for the request.
    * @returns {IncomingRequest} Instance with data based on a low-level Node
    *   request (etc.).
    */
-  static async fromNodeRequest(request, context, logger) {
+  static async fromNodeRequest(request, context, options = null) {
     // Note: It's impractical to do more thorough type checking here (and
     // probably not worth it anyway).
     MustBe.object(request);
+
+    const { logger = null } = options ?? {};
 
     const { pseudoHeaders, headers } = IncomingRequest.#extractHeadersFrom(request);
     const requestMethod = IncomingRequest.#requestMethodFromPseudoHeaders(pseudoHeaders);

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -790,7 +790,7 @@ export class IncomingRequest {
   static async #readBody(request, maxRequestBodyBytes) {
     const max = (maxRequestBodyBytes === null)
       ? Number.POSITIVE_INFINITY
-      : max;
+      : maxRequestBodyBytes;
 
     const contentLength =
       HttpUtil.numberFromContentLengthString(request.headers['content-length']);

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -552,15 +552,12 @@ export class IncomingRequest {
     const { pseudoHeaders, headers } = IncomingRequest.#extractHeadersFrom(request);
     const requestMethod = IncomingRequest.#requestMethodFromPseudoHeaders(pseudoHeaders);
 
-    if (HttpUtil.requestBodyIsAllowedFor(requestMethod)) {
-      const body = await IncomingRequest.#readBody(request, maxRequestBodyBytes);
-      // TODO: Do something with the body.
-      console.log('##################', body.toString());
-    } else {
-      await IncomingRequest.#readEmptyBody(request);
-    }
+    const body = HttpUtil.requestBodyIsAllowedFor(requestMethod)
+      ? await IncomingRequest.#readBody(request, maxRequestBodyBytes)
+      : await IncomingRequest.#readEmptyBody(request);
 
     return new IncomingRequest({
+      body,
       context,
       headers,
       logger,

--- a/src/net-util/tests/HttpUtil.test.js
+++ b/src/net-util/tests/HttpUtil.test.js
@@ -234,7 +234,7 @@ describe('numberFromContentLengthString()', () => {
   });
 });
 
-describe('requestBodyIsAllowedFor()', () => {
+describe('requestBodyIsExpectedFor()', () => {
   test.each`
   method       | expected
   ${'connect'} | ${false}
@@ -248,8 +248,8 @@ describe('requestBodyIsAllowedFor()', () => {
   ${'trace'}   | ${false}
   `('returns `$expected` for method `$method`', ({ method, expected }) => {
     const upcased = method.toUpperCase();
-    expect(HttpUtil.requestBodyIsAllowedFor(method)).toBe(expected);
-    expect(HttpUtil.requestBodyIsAllowedFor(upcased)).toBe(expected);
+    expect(HttpUtil.requestBodyIsExpectedFor(method)).toBe(expected);
+    expect(HttpUtil.requestBodyIsExpectedFor(upcased)).toBe(expected);
   });
 });
 

--- a/src/net-util/tests/HttpUtil.test.js
+++ b/src/net-util/tests/HttpUtil.test.js
@@ -201,6 +201,39 @@ describe('msecFromDateString()', () => {
   });
 });
 
+describe('numberFromContentLengthString()', () => {
+  // Argument type errors. Expected to throw.
+  test.each`
+  arg
+  ${undefined}
+  ${true}
+  ${123}
+  ${['x']}
+  `('throws given $arg', ({ arg }) => {
+    expect(() => HttpUtil.numberFromContentLengthString(arg)).toThrow();
+  });
+
+  test.each`
+  arg                    | expected
+  ${null}                | ${null}
+  ${'who knows'}         | ${null}
+  ${'0x10'}              | ${null}
+  ${' 123'}              | ${null}
+  ${'123 '}              | ${null}
+  ${'1.'}                | ${null}
+  ${'1.0'}               | ${null}
+  ${'10000000000000000'} | ${null} // Not a safe integer.
+  ${'1000000000000000'}  | ${1000000000000000}
+  ${'1234567890'}        | ${1234567890}
+  ${'0987654321'}        | ${987654321}
+  ${'0'}                 | ${0}
+  ${'9'}                 | ${9}
+  ${'10'}                | ${10}
+  `('returns $expected for $arg', ({ arg, expected }) => {
+    expect(HttpUtil.numberFromContentLengthString(arg)).toBe(expected);
+  });
+});
+
 describe('requestBodyIsAllowedFor()', () => {
   test.each`
   method       | expected

--- a/src/net-util/tests/HttpUtil.test.js
+++ b/src/net-util/tests/HttpUtil.test.js
@@ -201,6 +201,25 @@ describe('msecFromDateString()', () => {
   });
 });
 
+describe('requestBodyIsAllowedFor()', () => {
+  test.each`
+  method       | expected
+  ${'connect'} | ${false}
+  ${'delete'}  | ${false}
+  ${'get'}     | ${false}
+  ${'head'}    | ${false}
+  ${'options'} | ${false}
+  ${'patch'}   | ${true}
+  ${'post'}    | ${true}
+  ${'put'}     | ${true}
+  ${'trace'}   | ${false}
+  `('returns `$expected` for method `$method`', ({ method, expected }) => {
+    const upcased = method.toUpperCase();
+    expect(HttpUtil.requestBodyIsAllowedFor(method)).toBe(expected);
+    expect(HttpUtil.requestBodyIsAllowedFor(upcased)).toBe(expected);
+  });
+});
+
 describe.each`
 methodName                     | expName
 ${'responseBodyIsAllowedFor'}  | ${'expAllowed'}

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -105,6 +105,7 @@ export class NetworkEndpoint extends BaseDispatched {
       application,
       hostnames,
       interface: iface,
+      maxRequestBodySize,
       protocol,
       services: {
         accessLog:             accessLogName             = null,
@@ -122,6 +123,9 @@ export class NetworkEndpoint extends BaseDispatched {
     const accessLog = accessLogName
       ? serviceManager.get(accessLogName, IntfAccessLog)
       : null;
+    const maxRequestBodyBytes = maxRequestBodySize
+      ? maxRequestBodySize.byte
+      : null;
 
     const hmOpt = {};
     if (this.config.requiresCertificates()) {
@@ -133,6 +137,7 @@ export class NetworkEndpoint extends BaseDispatched {
       accessLog,
       connectionRateLimiter,
       dataRateLimiter,
+      maxRequestBodyBytes,
       requestHandler: this,
       protocol,
       interface: iface,

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -3,6 +3,7 @@
 
 import { PathKey } from '@this/collections';
 import { Names } from '@this/compy';
+import { ByteCount } from '@this/data-values';
 import { FormatUtils } from '@this/loggy-intf';
 import { IntfAccessLog, IntfConnectionRateLimiter, IntfDataRateLimiter,
   ProtocolWrangler, ProtocolWranglers }
@@ -210,6 +211,29 @@ export class NetworkEndpoint extends BaseDispatched {
        */
       _config_interface(value) {
         return Object.freeze(HostUtil.parseInterface(value));
+      }
+
+      /**
+       * Maximum allowed size of a request body, or `null` to not have such a
+       * size limit. if so limited. If passed as a string, it is parsed by
+       * {@link ByteCount#parse}.
+       *
+       * @param {?string|ByteCount} [value] Proposed configuration value.
+       *   Default `null`.
+       * @returns {?ByteCount} Accepted configuration value.
+       */
+      _config_maxRequestBodySize(value = null) {
+        if (value === null) {
+          return null;
+        }
+
+        const result = ByteCount.parse(value, { range: { minInclusive: 0 } });
+
+        if (result === null) {
+          throw new Error(`Could not parse \`maxRequestBodySize\`: ${value}`);
+        }
+
+        return result;
       }
 
       /**


### PR DESCRIPTION
This PR adds the ability for the system to read request bodies. Before this, they were just ignored. The system now also cross-checks request methods against whether or not they're _supposed_ to have bodies, and rejects requests that don't match. Also also, you can configure a maximum allowed request body size (and you probably should, at least if you're running a server on the open internet).