### PR TITLE
More standard `Sexp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Breaking changes:
 * `codec`:
   * Renamed several classes to match with the (relatively) new module name.
   * Dropped the `options` property from `Sexp`, making it now effectively
-    identical to a "classic" s-expression.
+    identical to a classic s-expression.
 
 Other notable changes:
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
-* `codec`: Renamed several classes to match with the (relatively) new module
-  name.
+* `codec`:
+  * Renamed several classes to match with the (relatively) new module name.
+  * Dropped the `options` property from `Sexp`, making it now effectively
+    identical to a "classic" s-expression.
 
 Other notable changes:
 * None.

--- a/src/codec/export/Sexp.js
+++ b/src/codec/export/Sexp.js
@@ -223,26 +223,4 @@ export class Sexp extends BaseDataClass {
       return functor;
     }
   }
-
-
-  //
-  // Static members
-  //
-
-  /**
-   * Converts an `options` value passed into the constructor into its proper
-   * form.
-   *
-   * @param {*} options Original options value.
-   * @returns {object} The converted form.
-   */
-  static #fixOptions(options) {
-    if (options === null) {
-      return Object.freeze({});
-    } else if (AskIf.plainObject(options) && Object.isFrozen(options)) {
-      return options;
-    } else {
-      return Object.freeze({ ...options });
-    }
-  }
 }

--- a/src/codec/export/Sexp.js
+++ b/src/codec/export/Sexp.js
@@ -3,7 +3,7 @@
 
 import * as util from 'node:util';
 
-import { AskIf, MustBe } from '@this/typey';
+import { MustBe } from '@this/typey';
 
 import { BaseDataClass } from '#x/BaseDataClass';
 

--- a/src/codec/export/Sexp.js
+++ b/src/codec/export/Sexp.js
@@ -53,7 +53,7 @@ export class Sexp extends BaseDataClass {
   constructor(functor, options = 'NO-OPTS', ...args) {
     super();
 
-    if (!options && (options !== 'NO-OPTS')) {
+    if (options !== 'NO-OPTS') {
       throw new Error('#### HEY!! FIX THIS!!!');
     } else {
       options = null;
@@ -119,13 +119,12 @@ export class Sexp extends BaseDataClass {
    * @param {object} options The new options.
    */
   set options(options) {
-    this.#frozenCheck();
-    this.#options = Sexp.#fixOptions(options);
+    throw new Error('##### NO SETTING THIS ANYMORE!');
   }
 
   /** @override */
   toEncodableValue() {
-    return [this.#functor, this.#options, ...this.#args];
+    return [this.#functor, 'NO-OPTS', ...this.#args];
   }
 
   /**

--- a/src/codec/export/Sexp.js
+++ b/src/codec/export/Sexp.js
@@ -27,13 +27,6 @@ export class Sexp extends BaseDataClass {
   #functor;
 
   /**
-   * Named "options" of the structure.
-   *
-   * @type {object}
-   */
-  #options;
-
-  /**
    * Positional "arguments" of the structure.
    *
    * @type {Array<*>}
@@ -59,7 +52,6 @@ export class Sexp extends BaseDataClass {
     }
 
     this.#functor = functor;
-    this.#options = Sexp.#fixOptions(options);
     this.#args    = Object.freeze(args);
   }
 
@@ -108,7 +100,7 @@ export class Sexp extends BaseDataClass {
    * a frozen plain object.
    */
   get options() {
-    return this.#options;
+    throw new Error('###### NO LONGER AVAILABLE');
   }
 
   /**
@@ -148,22 +140,16 @@ export class Sexp extends BaseDataClass {
    */
   toJSON() {
     const args    = this.#args;
-    const options = this.#options;
     const functor = this.#jsonFunctor();
 
     const hasStringFunc = (typeof functor === 'string');
-    const hasOptions    = (Object.keys(options).length !== 0);
-    const hasArgs       = (args.length !== 0);
 
     if (hasStringFunc) {
-      if (hasOptions && hasArgs) return { [functor]: { options, args } };
-      else if (hasArgs)          return { [functor]: args };
-      else                       return { [functor]: options };
+      return { [functor]: args };
     } else {
-      if (hasOptions && hasArgs) return { '@sexp': { functor, options, args } };
-      else if (hasArgs)          return { '@sexp': { functor, args } };
-      else if (hasOptions)       return { '@sexp': { functor, options } };
-      else                       return { '@sexp': { functor } };
+      return (args.length === 0)
+        ? { '@sexp': { functor } }
+        : { '@sexp': { functor, args } };
     }
   }
 
@@ -205,15 +191,6 @@ export class Sexp extends BaseDataClass {
         parts.push(', ');
       }
       parts.push(inspect(arg, innerOptions));
-    }
-
-    for (const [key, value] of Object.entries(this.#options)) {
-      if (first) {
-        first = false;
-      } else {
-        parts.push(', ');
-      }
-      parts.push(key, ': ', inspect(value, innerOptions));
     }
 
     parts.push(' }');

--- a/src/codec/export/Sexp.js
+++ b/src/codec/export/Sexp.js
@@ -42,10 +42,6 @@ export class Sexp extends BaseDataClass {
   constructor(functor, ...args) {
     super();
 
-    if (args[0] === 'NO-OPTS') {
-      throw new Error('#### HEY!! FIX THIS!!!');
-    }
-
     this.#functor = functor;
     this.#args    = Object.freeze(args);
   }
@@ -91,24 +87,6 @@ export class Sexp extends BaseDataClass {
   set functor(functor) {
     this.#frozenCheck();
     this.#functor = functor;
-  }
-
-  /**
-   * @returns {object} Named "options" of the structure, if any. This is always
-   * a frozen plain object.
-   */
-  get options() {
-    throw new Error('###### NO LONGER AVAILABLE');
-  }
-
-  /**
-   * Sets the named "options." This is only allowed if this instance is not
-   * frozen.
-   *
-   * @param {object} options The new options.
-   */
-  set options(options) {
-    throw new Error('##### NO SETTING THIS ANYMORE!');
   }
 
   /** @override */

--- a/src/codec/export/Sexp.js
+++ b/src/codec/export/Sexp.js
@@ -50,8 +50,14 @@ export class Sexp extends BaseDataClass {
    *   If `null`, becomes a frozen version of `{}` (the empty object).
    * @param {...*} args Positional "arguments" of the structure.
    */
-  constructor(functor, options = null, ...args) {
+  constructor(functor, options = 'NO-OPTS', ...args) {
     super();
+
+    if (!options && (options !== 'NO-OPTS')) {
+      throw new Error('#### HEY!! FIX THIS!!!');
+    } else {
+      options = null;
+    }
 
     this.#functor = functor;
     this.#options = Sexp.#fixOptions(options);

--- a/src/codec/export/Sexp.js
+++ b/src/codec/export/Sexp.js
@@ -10,11 +10,10 @@ import { BaseDataClass } from '#x/BaseDataClass';
 
 /**
  * Data value that represents a free-form would-be method call (or
- * method-call-like thing). This is nearly equivalent to what is historically
- * sometimes called an "s expression" or more tersely a "sexp," hence the name
- * of this class. _This_ class has a little more structure than a classic sexp,
- * to be clear. Instances of this class are commonly used as bearers of
- * "distillate" data of behavior-bearing class instances.
+ * method-call-like thing). This is more or less equivalent to what is
+ * historically sometimes called an "s-expression" or more tersely a "sexp,"
+ * hence the name of this class. Instances of this class are commonly used as
+ * bearers of "distillate" data of behavior-bearing class instances.
  *
  * Instances of this class react to `Object.freeze()` in an analogous way to how
  * plain arrays and objects do.

--- a/src/codec/export/Sexp.js
+++ b/src/codec/export/Sexp.js
@@ -37,18 +37,13 @@ export class Sexp extends BaseDataClass {
    * Constructs an instance.
    *
    * @param {*} functor Value representing the thing-that-is-to-be-called.
-   * @param {?object} [options] Named "options" of the structure, if any. If
-   *   non-`null` and not a frozen plain object, it will get cloned and frozen.
-   *   If `null`, becomes a frozen version of `{}` (the empty object).
    * @param {...*} args Positional "arguments" of the structure.
    */
-  constructor(functor, options = 'NO-OPTS', ...args) {
+  constructor(functor, ...args) {
     super();
 
-    if (options !== 'NO-OPTS') {
+    if (args[0] === 'NO-OPTS') {
       throw new Error('#### HEY!! FIX THIS!!!');
-    } else {
-      options = null;
     }
 
     this.#functor = functor;
@@ -66,6 +61,9 @@ export class Sexp extends BaseDataClass {
   /**
    * Sets the positional "arguments." This is only allowed if this instance is
    * not frozen.
+   *
+   * **Note:** The contents of `args` are copied into a fresh array on this
+   * instance. That is, `this.args = x; return this.args === x;` is `false`.
    *
    * @param {Array<*>} args The new arguments.
    */
@@ -115,7 +113,7 @@ export class Sexp extends BaseDataClass {
 
   /** @override */
   toEncodableValue() {
-    return [this.#functor, 'NO-OPTS', ...this.#args];
+    return [this.#functor, ...this.#args];
   }
 
   /**

--- a/src/codec/export/StackTrace.js
+++ b/src/codec/export/StackTrace.js
@@ -81,7 +81,7 @@ export class StackTrace {
    * @returns {Sexp} Encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(StackTrace, 'NO-OPTS', this.#frames);
+    return new Sexp(StackTrace, this.#frames);
   }
 
 

--- a/src/codec/export/StackTrace.js
+++ b/src/codec/export/StackTrace.js
@@ -81,7 +81,7 @@ export class StackTrace {
    * @returns {Sexp} Encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(StackTrace, null, this.#frames);
+    return new Sexp(StackTrace, 'NO-OPTS', this.#frames);
   }
 
 

--- a/src/codec/private/ConvError.js
+++ b/src/codec/private/ConvError.js
@@ -65,8 +65,8 @@ export class ConvError extends BaseCodec {
     if (!main.stack) delete main.stack;
 
     return (Object.getOwnPropertyNames(rest).length === 0)
-      ? new Sexp(type, 'NO-OPTS', main)
-      : new Sexp(type, 'NO-OPTS', main, rest);
+      ? new Sexp(type, main)
+      : new Sexp(type, main, rest);
   }
 
   /**

--- a/src/codec/private/ConvError.js
+++ b/src/codec/private/ConvError.js
@@ -64,7 +64,9 @@ export class ConvError extends BaseCodec {
     if (!main.code)  delete main.code;
     if (!main.stack) delete main.stack;
 
-    return new Sexp(type, rest, main);
+    return (Object.getOwnPropertyNames(rest).length === 0)
+      ? new Sexp(type, 'NO-OPTS', main)
+      : new Sexp(type, 'NO-OPTS', main, rest);
   }
 
   /**

--- a/src/codec/tests/Codec.test.js
+++ b/src/codec/tests/Codec.test.js
@@ -290,7 +290,7 @@ describe('encode()', () => {
 
     describe('on instances of data classes', () => {
       test('self-represent when directly converted', () => {
-        const value1 = Object.freeze(new Sexp('x', 'NO-OPTS', 1, 2, 3));
+        const value1 = Object.freeze(new Sexp('x', 1, 2, 3));
         const value2 = new Ref(['blort']);
 
         const conv = new Codec();
@@ -300,7 +300,7 @@ describe('encode()', () => {
       });
 
       test('self-represent when embedded in compound objects', () => {
-        const value1 = Object.freeze(new Sexp('x', 'NO-OPTS', 1, 2, 3));
+        const value1 = Object.freeze(new Sexp('x', 1, 2, 3));
         const value2 = new Ref(['blort', 'fleep']);
 
         const data = {
@@ -319,7 +319,7 @@ describe('encode()', () => {
       });
 
       test('copies a non-frozen `Sexp` that requires no inner encoding', () => {
-        const value = new Sexp('floop', 'NO-OPTS', 1, 2, 3);
+        const value = new Sexp('floop', 1, 2, 3);
         const conv  = new Codec();
         const got   = conv.encode(value);
 

--- a/src/codec/tests/Codec.test.js
+++ b/src/codec/tests/Codec.test.js
@@ -290,7 +290,7 @@ describe('encode()', () => {
 
     describe('on instances of data classes', () => {
       test('self-represent when directly converted', () => {
-        const value1 = Object.freeze(new Sexp('x', null, 1, 2, 3));
+        const value1 = Object.freeze(new Sexp('x', 'NO-OPTS', 1, 2, 3));
         const value2 = new Ref(['blort']);
 
         const conv = new Codec();
@@ -300,7 +300,7 @@ describe('encode()', () => {
       });
 
       test('self-represent when embedded in compound objects', () => {
-        const value1 = Object.freeze(new Sexp('x', { x: 123 }, 1, 2, 3));
+        const value1 = Object.freeze(new Sexp('x', 'NO-OPTS', 1, 2, 3));
         const value2 = new Ref(['blort', 'fleep']);
 
         const data = {
@@ -319,7 +319,7 @@ describe('encode()', () => {
       });
 
       test('copies a non-frozen `Sexp` that requires no inner encoding', () => {
-        const value = new Sexp('floop', { a: 10, b: 20 }, 1, 2, 3);
+        const value = new Sexp('floop', 'NO-OPTS', 1, 2, 3);
         const conv  = new Codec();
         const got   = conv.encode(value);
 
@@ -363,9 +363,9 @@ describe('encode()', () => {
         expect(got).toBeInstanceOf(Sexp);
         expect(got.functor).toBeInstanceOf(Ref);
         expect(got.functor.value).toBe(Error);
-        expect(got.args).toBeArrayOfSize(1);
+        expect(got.args).toBeArrayOfSize(2);
         expect(got.args[0]).toContainAllKeys(['cause', 'code', 'message', 'name', 'stack']);
-        expect(got.options).toStrictEqual({ blueberries: true });
+        expect(got.args[1]).toStrictEqual({ blueberries: true });
 
         const { cause: convCause, code, message, name, stack } = got.args[0];
         expect(code).toBe(err.code);

--- a/src/codec/tests/Codec.test.js
+++ b/src/codec/tests/Codec.test.js
@@ -327,7 +327,6 @@ describe('encode()', () => {
         expect(got).toBeFrozen();
         expect(got.functor).toBe(value.functor);
         expect(got.args).toStrictEqual(value.args);
-        expect(got.options).toStrictEqual(value.options);
       });
     });
 

--- a/src/codec/tests/Sexp.test.js
+++ b/src/codec/tests/Sexp.test.js
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Sexp } from '@this/codec';
-import { AskIf } from '@this/typey';
 
 
 describe('constructor()', () => {

--- a/src/codec/tests/Sexp.test.js
+++ b/src/codec/tests/Sexp.test.js
@@ -103,7 +103,7 @@ describe('.toJSON()', () => {
   describe('with an at-string for `functor`', () => {
     test('does not include `args` when it is empty', () => {
       const sexp     = new Sexp('@x');
-      const expected = { '@x': {} };
+      const expected = { '@x': [] };
 
       expect(sexp.toJSON()).toEqual(expected);
     });
@@ -135,13 +135,13 @@ describe('.toJSON()', () => {
   });
 
   test('prefixes a string functor with an at-sign if it doesn\'t already have one', () => {
-    expect(new Sexp('florp').toJSON()).toEqual({ '@florp': {} });
+    expect(new Sexp('florp').toJSON()).toEqual({ '@florp': [] });
   });
 
   test('converts a function functor (including a class) to its name with an at-prefix', () => {
     function florp() { return null; }
 
-    expect(new Sexp(Map).toJSON()).toEqual({ '@Map': {} });
-    expect(new Sexp(florp).toJSON()).toEqual({ '@florp': {} });
+    expect(new Sexp(Map).toJSON()).toEqual({ '@Map': [] });
+    expect(new Sexp(florp).toJSON()).toEqual({ '@florp': [] });
   });
 });

--- a/src/codec/tests/Sexp.test.js
+++ b/src/codec/tests/Sexp.test.js
@@ -7,15 +7,15 @@ import { AskIf } from '@this/typey';
 
 describe('constructor()', () => {
   test('does not throw given no args', () => {
-    expect(() => new Sexp('x', 'NO-OPTS')).not.toThrow();
+    expect(() => new Sexp('x')).not.toThrow();
   });
 
   test('does not throw given one arg', () => {
-    expect(() => new Sexp('x', 'NO-OPTS', 123)).not.toThrow();
+    expect(() => new Sexp('x', 123)).not.toThrow();
   });
 
   test('produces a non-frozen instance', () => {
-    expect(new Sexp(['y'], 'NO-OPTS')).not.toBeFrozen();
+    expect(new Sexp(['y'])).not.toBeFrozen();
   });
 });
 
@@ -25,21 +25,21 @@ describe('.functor', () => {
     const func2 = { name: 'blort' };
     const func3 = 'stuff';
 
-    expect(new Sexp(func1, 'NO-OPTS').functor).toBe(func1);
-    expect(new Sexp(func2, 'NO-OPTS', 'yes').functor).toBe(func2);
-    expect(new Sexp(func3, 'NO-OPTS', 123, true).functor).toBe(func3);
+    expect(new Sexp(func1).functor).toBe(func1);
+    expect(new Sexp(func2, 'yes').functor).toBe(func2);
+    expect(new Sexp(func3, 123, true).functor).toBe(func3);
   });
 });
 
 describe('.functor =', () => {
   test('is disallowed on a frozen instance', () => {
-    const sexp = new Sexp('boop', 'NO-OPTS');
+    const sexp = new Sexp('boop');
     Object.freeze(sexp);
     expect(() => { sexp.functor = 'florp'; }).toThrow();
   });
 
   test('is allowed on a non-frozen instance, and affects the getter', () => {
-    const sexp = new Sexp('boop', 'NO-OPTS');
+    const sexp = new Sexp('boop');
     expect(() => { sexp.functor = 'florp'; }).not.toThrow();
     expect(sexp.functor).toBe('florp');
   });
@@ -47,13 +47,13 @@ describe('.functor =', () => {
 
 describe('.args', () => {
   test('is an array', () => {
-    expect(new Sexp('x', 'NO-OPTS').args).toBeArray();
-    expect(new Sexp('x', 'NO-OPTS', 1).args).toBeArray();
+    expect(new Sexp('x').args).toBeArray();
+    expect(new Sexp('x', 1).args).toBeArray();
   });
 
   test('is frozen', () => {
-    expect(new Sexp('x', 'NO-OPTS', 'a', 'b').args).toBeFrozen();
-    expect(new Sexp('x', 'NO-OPTS', 'a', 'b', 'c').args).toBeFrozen();
+    expect(new Sexp('x', 'a', 'b').args).toBeFrozen();
+    expect(new Sexp('x', 'a', 'b', 'c').args).toBeFrozen();
   });
 
   const argses = [
@@ -69,7 +69,7 @@ describe('.args', () => {
       argsAt = (argsAt + 1) % argsAt.length;
     }
     test(`works with ${count} argument(s)`, () => {
-      const got = new Sexp('x', 'NO-OPTS', ...args).args;
+      const got = new Sexp('x', ...args).args;
       expect(got).toBeArray();
       expect(got).toBeFrozen();
       expect(got).toStrictEqual(args);
@@ -79,19 +79,19 @@ describe('.args', () => {
 
 describe('.args =', () => {
   test('is disallowed on a frozen instance', () => {
-    const sexp = new Sexp('boop', 'NO-OPTS');
+    const sexp = new Sexp('boop');
     Object.freeze(sexp);
     expect(() => { sexp.args = [1, 2, 3]; }).toThrow();
   });
 
   test('throws if passed a non-array', () => {
-    const sexp = new Sexp('boop', 'NO-OPTS');
+    const sexp = new Sexp('boop');
     expect(() => { sexp.args = 'blorp'; }).toThrow();
   });
 
   test('is allowed on a non-frozen instance, and affects the getter', () => {
     const newArgs = [1, 2, 3];
-    const sexp    = new Sexp('boop', 'NO-OPTS', 4, 5, 6);
+    const sexp    = new Sexp('boop', 4, 5, 6);
     expect(() => { sexp.args = newArgs; }).not.toThrow();
     expect(sexp.args).toStrictEqual(newArgs);
     expect(sexp.args).not.toBe(newArgs);
@@ -109,7 +109,7 @@ describe('.toJSON()', () => {
     });
 
     test('includes non-empty `args`', () => {
-      const sexp     = new Sexp('@x', 'NO-OPTS', 'a', 'b', 123);
+      const sexp     = new Sexp('@x', 'a', 'b', 123);
       const expected = { '@x': ['a', 'b', 123] };
 
       expect(sexp.toJSON()).toEqual(expected);
@@ -127,7 +127,7 @@ describe('.toJSON()', () => {
 
     test('includes `functor` and non-empty `args`', () => {
       const functor  = 12345;
-      const sexp     = new Sexp(functor, 'NO-OPTS', 'a', 'b', 123);
+      const sexp     = new Sexp(functor, 'a', 'b', 123);
       const expected = { '@sexp': { functor, args: ['a', 'b', 123] } };
 
       expect(sexp.toJSON()).toEqual(expected);

--- a/src/codec/tests/Sexp.test.js
+++ b/src/codec/tests/Sexp.test.js
@@ -6,12 +6,16 @@ import { AskIf } from '@this/typey';
 
 
 describe('constructor()', () => {
-  test('does not throw', () => {
-    expect(() => new Sexp('x', null)).not.toThrow();
+  test('does not throw given no args', () => {
+    expect(() => new Sexp('x', 'NO-OPTS')).not.toThrow();
+  });
+
+  test('does not throw given one arg', () => {
+    expect(() => new Sexp('x', 'NO-OPTS', 123)).not.toThrow();
   });
 
   test('produces a non-frozen instance', () => {
-    expect(new Sexp(['y'], {})).not.toBeFrozen();
+    expect(new Sexp(['y'], 'NO-OPTS')).not.toBeFrozen();
   });
 });
 
@@ -21,21 +25,21 @@ describe('.functor', () => {
     const func2 = { name: 'blort' };
     const func3 = 'stuff';
 
-    expect(new Sexp(func1, {}).functor).toBe(func1);
-    expect(new Sexp(func2, { a: 'boop' }, 'yes').functor).toBe(func2);
-    expect(new Sexp(func3, null, 123, true).functor).toBe(func3);
+    expect(new Sexp(func1, 'NO-OPTS').functor).toBe(func1);
+    expect(new Sexp(func2, 'NO-OPTS', 'yes').functor).toBe(func2);
+    expect(new Sexp(func3, 'NO-OPTS', 123, true).functor).toBe(func3);
   });
 });
 
 describe('.functor =', () => {
   test('is disallowed on a frozen instance', () => {
-    const sexp = new Sexp('boop', null);
+    const sexp = new Sexp('boop', 'NO-OPTS');
     Object.freeze(sexp);
     expect(() => { sexp.functor = 'florp'; }).toThrow();
   });
 
   test('is allowed on a non-frozen instance, and affects the getter', () => {
-    const sexp = new Sexp('boop', null);
+    const sexp = new Sexp('boop', 'NO-OPTS');
     expect(() => { sexp.functor = 'florp'; }).not.toThrow();
     expect(sexp.functor).toBe('florp');
   });
@@ -43,13 +47,13 @@ describe('.functor =', () => {
 
 describe('.args', () => {
   test('is an array', () => {
-    expect(new Sexp('x', null).args).toBeArray();
-    expect(new Sexp('x', {}, 1).args).toBeArray();
+    expect(new Sexp('x', 'NO-OPTS').args).toBeArray();
+    expect(new Sexp('x', 'NO-OPTS', 1).args).toBeArray();
   });
 
   test('is frozen', () => {
-    expect(new Sexp('x', null, 'a', 'b').args).toBeFrozen();
-    expect(new Sexp('x', { y: null }, 'a', 'b', 'c').args).toBeFrozen();
+    expect(new Sexp('x', 'NO-OPTS', 'a', 'b').args).toBeFrozen();
+    expect(new Sexp('x', 'NO-OPTS', 'a', 'b', 'c').args).toBeFrozen();
   });
 
   const argses = [
@@ -65,7 +69,7 @@ describe('.args', () => {
       argsAt = (argsAt + 1) % argsAt.length;
     }
     test(`works with ${count} argument(s)`, () => {
-      const got = new Sexp('x', null, ...args).args;
+      const got = new Sexp('x', 'NO-OPTS', ...args).args;
       expect(got).toBeArray();
       expect(got).toBeFrozen();
       expect(got).toStrictEqual(args);
@@ -75,19 +79,19 @@ describe('.args', () => {
 
 describe('.args =', () => {
   test('is disallowed on a frozen instance', () => {
-    const sexp = new Sexp('boop', null);
+    const sexp = new Sexp('boop', 'NO-OPTS');
     Object.freeze(sexp);
     expect(() => { sexp.args = [1, 2, 3]; }).toThrow();
   });
 
   test('throws if passed a non-array', () => {
-    const sexp = new Sexp('boop', null);
+    const sexp = new Sexp('boop', 'NO-OPTS');
     expect(() => { sexp.args = 'blorp'; }).toThrow();
   });
 
   test('is allowed on a non-frozen instance, and affects the getter', () => {
     const newArgs = [1, 2, 3];
-    const sexp    = new Sexp('boop', null, 4, 5, 6);
+    const sexp    = new Sexp('boop', 'NO-OPTS', 4, 5, 6);
     expect(() => { sexp.args = newArgs; }).not.toThrow();
     expect(sexp.args).toStrictEqual(newArgs);
     expect(sexp.args).not.toBe(newArgs);
@@ -95,140 +99,36 @@ describe('.args =', () => {
   });
 });
 
-describe('.options', () => {
-  test.each`
-  opts
-  ${null}
-  ${{}}
-  ${{ x: 10 }}
-  ${new Map()}
-  `('is a plain object, given $opts', ({ opts }) => {
-    const sexp = new Sexp('x', opts);
-    expect(sexp.options).toBeObject();
-    expect(AskIf.plainObject(sexp.options)).toBeTrue();
-  });
-
-  test('is frozen', () => {
-    expect(new Sexp('x', null).options).toBeFrozen();
-    expect(new Sexp('x', { y: null }, 'a').options).toBeFrozen();
-  });
-
-  test('is the same object as passed in, if given a frozen plain object', () => {
-    const opts = Object.freeze({ yes: 'indeed' });
-    expect(new Sexp('x', opts).options).toBe(opts);
-  });
-
-  test('is not the same object as passed in, if not given a plain object', () => {
-    const opts = Object.freeze(new Map());
-    expect(new Sexp('x', opts).options).not.toBe(opts);
-  });
-
-  test('is not the same object as passed in, if not given a frozen object', () => {
-    const opts = { no: 'siree' };
-    expect(new Sexp('x', opts).options).not.toBe(opts);
-  });
-
-  const extraProps = new Set();
-  extraProps.whee = 'yay';
-
-  test.each`
-  label                                  | opts          | expected
-  ${'null'}                              | ${null}       | ${{}}
-  ${'{}'}                                | ${{}}         | ${{}}
-  ${'{ x: 10 }'}                         | ${{ x: 10 }}  | ${{ x: 10 }}
-  ${'instance with no extra properties'} | ${new Map()}  | ${{}}
-  ${'instance with extra properties'}    | ${extraProps} | ${{ whee: 'yay' }}
-  `('converts $label as expected', ({ opts, expected }) => {
-    const sexp = new Sexp('x', opts);
-    expect(sexp.options).toStrictEqual(expected);
-  });
-});
-
-describe('.options =', () => {
-  test('is disallowed on a frozen instance', () => {
-    const sexp = new Sexp('boop', null);
-    Object.freeze(sexp);
-    expect(() => { sexp.options = { a: 10 }; }).toThrow();
-  });
-
-  test('is allowed on a non-frozen instance, and affects the getter', () => {
-    const newOpts = { a: 10, b: 20 };
-    const sexp    = new Sexp('boop', { c: 30 }, 123);
-    expect(() => { sexp.options = newOpts; }).not.toThrow();
-    expect(sexp.options).toStrictEqual(newOpts);
-    expect(sexp.options).not.toBe(newOpts);
-    expect(sexp.options).toBeFrozen();
-  });
-});
-
 describe('.toJSON()', () => {
   describe('with an at-string for `functor`', () => {
-    test('includes neither `args` nor `options` when both are empty', () => {
-      const sexp1    = new Sexp('@x', null);
-      const sexp2    = new Sexp('@x', {});
-      const sexp3    = new Sexp('@x');
+    test('does not include `args` when it is empty', () => {
+      const sexp     = new Sexp('@x');
       const expected = { '@x': {} };
 
-      expect(sexp1.toJSON()).toEqual(expected);
-      expect(sexp2.toJSON()).toEqual(expected);
-      expect(sexp3.toJSON()).toEqual(expected);
-    });
-
-    test('includes just non-empty `options` when `args` is empty', () => {
-      const sexp     = new Sexp('@x', { a: 12 });
-      const expected = { '@x': { a: 12 } };
-
       expect(sexp.toJSON()).toEqual(expected);
     });
 
-    test('includes just non-empty `args` when `options` is empty', () => {
-      const sexp     = new Sexp('@x', null, 'a', 'b', 123);
+    test('includes non-empty `args`', () => {
+      const sexp     = new Sexp('@x', 'NO-OPTS', 'a', 'b', 123);
       const expected = { '@x': ['a', 'b', 123] };
-
-      expect(sexp.toJSON()).toEqual(expected);
-    });
-
-    test('includes a sub-object with both `args` and `options` when both are non-empty', () => {
-      const sexp     = new Sexp('@x', { xyz: true }, 'a', 'b', 123);
-      const expected = { '@x': { args: ['a', 'b', 123], options: { xyz: true } } };
 
       expect(sexp.toJSON()).toEqual(expected);
     });
   });
 
   describe('with an arbitrary value (not otherwise covered) for `functor`', () => {
-    test('includes just `functor` when both `args` and `options` are empty', () => {
+    test('includes just `functor` when `args` is empty', () => {
       const functor  = ['non', 'string', 'functor'];
-      const sexp1    = new Sexp(functor, null);
-      const sexp2    = new Sexp(functor, {});
-      const sexp3    = new Sexp(functor);
+      const sexp     = new Sexp(functor);
       const expected = { '@sexp': { functor } };
 
-      expect(sexp1.toJSON()).toEqual(expected);
-      expect(sexp2.toJSON()).toEqual(expected);
-      expect(sexp3.toJSON()).toEqual(expected);
-    });
-
-    test('includes just `functor` and non-empty `options` when `args` is empty', () => {
-      const functor  = false;
-      const sexp     = new Sexp(functor, { a: 12 });
-      const expected = { '@sexp': { functor, options: { a: 12 } } };
-
       expect(sexp.toJSON()).toEqual(expected);
     });
 
-    test('includes just `functor` and non-empty `args` when `options` is empty', () => {
+    test('includes `functor` and non-empty `args`', () => {
       const functor  = 12345;
-      const sexp     = new Sexp(functor, null, 'a', 'b', 123);
+      const sexp     = new Sexp(functor, 'NO-OPTS', 'a', 'b', 123);
       const expected = { '@sexp': { functor, args: ['a', 'b', 123] } };
-
-      expect(sexp.toJSON()).toEqual(expected);
-    });
-
-    test('includes a sub-object with all bits when both `args` and `options` are non-empty', () => {
-      const functor  = { zoiks: 'a-functor' };
-      const sexp     = new Sexp(functor, { xyz: true }, 'a', 'b', 123);
-      const expected = { '@sexp': { functor, args: ['a', 'b', 123], options: { xyz: true } } };
 
       expect(sexp.toJSON()).toEqual(expected);
     });

--- a/src/collections/export/PathKey.js
+++ b/src/collections/export/PathKey.js
@@ -105,7 +105,7 @@ export class PathKey {
    * @returns {Sexp} The encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(PathKey, 'NO-OPTS', this.#path, this.#wildcard);
+    return new Sexp(PathKey, this.#path, this.#wildcard);
   }
 
   /**

--- a/src/collections/export/PathKey.js
+++ b/src/collections/export/PathKey.js
@@ -100,7 +100,7 @@ export class PathKey {
   }
 
   /**
-   * Standard `quant` method to produce an encoded version of this instance.
+   * Implementation of `codec` custom-encode protocol.
    *
    * @returns {Sexp} The encoded form.
    */

--- a/src/collections/export/PathKey.js
+++ b/src/collections/export/PathKey.js
@@ -105,7 +105,7 @@ export class PathKey {
    * @returns {Sexp} The encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(PathKey, null, this.#path, this.#wildcard);
+    return new Sexp(PathKey, 'NO-OPTS', this.#path, this.#wildcard);
   }
 
   /**

--- a/src/collections/tests/PathKey.test.js
+++ b/src/collections/tests/PathKey.test.js
@@ -185,7 +185,6 @@ describe('[BaseCodec.ENCODE]()', () => {
 
     expect(got).toBeInstanceOf(Sexp);
     expect(got.functor).toBe(PathKey);
-    expect(got.options).toEqual({});
     expect(got.args).toEqual(args);
   });
 });

--- a/src/host/export/Host.js
+++ b/src/host/export/Host.js
@@ -178,7 +178,7 @@ export class Host {
   /**
    * Helper for {@link #shutdownDisposition}, which converts a single `problem`
    * binding. This relies on assumed details of how `Error` instances get
-   * encoded by the `quant` module.
+   * encoded by the `codec` module.
    *
    * @param {*} problem The problem, typically an `Error`.
    * @param {Codec} converter Codec instance to use for encoding.

--- a/src/host/export/Host.js
+++ b/src/host/export/Host.js
@@ -156,7 +156,7 @@ export class Host {
     const fixed = {
       class: encoded.functor,
       ...encoded.args[0],
-      ...(encoded.options ?? {})
+      ...(encoded.args[1] ?? {})
     };
 
     if (fixed.name === fixed.functor) {

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -90,13 +90,8 @@ export class LogPayload extends EventPayload {
    * @returns {Sexp} Encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(LogPayload, {
-      when:  this.#when,
-      tag:   this.#tag,
-      stack: this.#stack,
-      type:  this.type,
-      args:  this.args
-    });
+    return new Sexp(LogPayload, 'NO-OPTS',
+      this.#stack, this.#when, this.#tag, this.type, ...this.args);
   }
 
   /**

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -133,18 +133,6 @@ export class LogPayload extends EventPayload {
   }
 
   /**
-   * Gets a new instance just like this one except without any arguments. If
-   * this instance already lacked arguments, this will return this instance.
-   *
-   * @returns {LogPayload} An appropriately-constructed instance.
-   */
-  withoutArgs() {
-    return (this.args.length === 0)
-      ? this
-      : new LogPayload(this.#stack, this.#when, this.#tag, this.type);
-  }
-
-  /**
    * Appends the human form of {@link #payload} to the given array of parts (to
    * ultimately `join()`).
    *

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -117,6 +117,34 @@ export class LogPayload extends EventPayload {
   }
 
   /**
+   * Gets a plain object representing this instance. The result has named
+   * properties for each of the properties available on instances.
+   *
+   * @returns {object} The plain object representation of this instance.
+   */
+  toPlainObject() {
+    return {
+      stack: this.#stack,
+      when:  this.#when,
+      tag:   this.#tag,
+      type:  this.type,
+      args:  this.args
+    };
+  }
+
+  /**
+   * Gets a new instance just like this one except without any arguments. If
+   * this instance already lacked arguments, this will return this instance.
+   *
+   * @returns {LogPayload} An appropriately-constructed instance.
+   */
+  withoutArgs() {
+    return (this.args.length === 0)
+      ? this
+      : new LogPayload(this.#stack, this.#when, this.#tag, this.type);
+  }
+
+  /**
    * Appends the human form of {@link #payload} to the given array of parts (to
    * ultimately `join()`).
    *

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -90,7 +90,7 @@ export class LogPayload extends EventPayload {
    * @returns {Sexp} Encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(LogPayload, 'NO-OPTS',
+    return new Sexp(LogPayload,
       this.#stack, this.#when, this.#tag, this.type, ...this.args);
   }
 

--- a/src/loggy-intf/export/LogTag.js
+++ b/src/loggy-intf/export/LogTag.js
@@ -170,7 +170,7 @@ export class LogTag {
    * @returns {Sexp} Encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(LogTag, 'NO-OPTS', this.#main, ...this.#context);
+    return new Sexp(LogTag, this.#main, ...this.#context);
   }
 
 

--- a/src/loggy-intf/export/LogTag.js
+++ b/src/loggy-intf/export/LogTag.js
@@ -170,7 +170,7 @@ export class LogTag {
    * @returns {Sexp} Encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(LogTag, null, this.#main, ...this.#context);
+    return new Sexp(LogTag, 'NO-OPTS', this.#main, ...this.#context);
   }
 
 

--- a/src/loggy-intf/tests/LogPayload.test.js
+++ b/src/loggy-intf/tests/LogPayload.test.js
@@ -27,20 +27,14 @@ describe('constructor', () => {
 });
 
 describe('[BaseCodec.ENCODE]()', () => {
-  test('produces a `Sexp` with the constructor arguments as options', () => {
-    const payload = new LogPayload(someStack, someMoment, someTag, 'whee', 10, 20, 'thirty');
+  test('produces a `Sexp` with the constructor arguments as the arguments', () => {
+    const args    = [someStack, someMoment, someTag, 'whee', 10, 20, 'thirty'];
+    const payload = new LogPayload(...args);
     const got     = payload[BaseCodec.ENCODE]();
 
     expect(got).toBeInstanceOf(Sexp);
     expect(got.functor).toBe(LogPayload);
-    expect(got.options).toEqual({
-      stack: someStack,
-      when:  someMoment,
-      tag:   someTag,
-      type:  'whee',
-      args:  [10, 20, 'thirty']
-    });
-    expect(got.args).toEqual([]);
+    expect(got.args).toEqual(args);
   });
 });
 

--- a/src/loggy-intf/tests/LogPayload.test.js
+++ b/src/loggy-intf/tests/LogPayload.test.js
@@ -90,6 +90,21 @@ describe('toHuman()', () => {
   });
 });
 
+describe('toPlainObject()', () => {
+  test('has the expected properties, set from the equivalent bits of the instance', () => {
+    const payload = new LogPayload(
+      someStack, someMoment, someTag, 'bonk', 123, { a: 10 }, ['x']);
+    const got = payload.toPlainObject();
+
+    expect(got).toContainAllKeys(['stack', 'when', 'tag', 'type', 'args']);
+    expect(got.stack).toBe(someStack);
+    expect(got.when).toBe(someMoment);
+    expect(got.tag).toBe(someTag);
+    expect(got.type).toBe('bonk');
+    expect(got.args).toEqual([123, { a: 10 }, ['x']]);
+  });
+});
+
 //
 // Static members
 //

--- a/src/loggy-intf/tests/LogTag.test.js
+++ b/src/loggy-intf/tests/LogTag.test.js
@@ -246,7 +246,6 @@ describe('[BaseCodec.ENCODE]()', () => {
 
     expect(result).toBeInstanceOf(Sexp);
     expect(result.functor).toBe(LogTag);
-    expect(result.options).toStrictEqual({});
     expect(result.args).toStrictEqual(expected);
   };
 

--- a/src/loggy/export/TextFileSink.js
+++ b/src/loggy/export/TextFileSink.js
@@ -177,14 +177,14 @@ export class TextFileSink extends EventSink {
     // What's going on: We assume that the `args` payload is already
     // sufficiently encoded (because that would have / should have happened
     // synchronously while logging), but we want to generically encode
-    // everything else. So, we do a top-level encode of the payload, tweak it,
-    // let the normal encode mechanism do it's thing, and then tweak it back.
+    // everything else. So, we convert the plain-object form except with `args`
+    // set to `null`, and then we thwack back in the presumed-good `args`.
 
-    const encodedPayload = payload[BaseCodec.ENCODE]();
-    const objToEncode    = { ...encodedPayload.options, args: null };
-    const encoded        = this.#CONVERTER_FOR_JSON.encode(objToEncode);
+    const plainObj = payload.toPlainObject();
+    const encoded  = this.#CONVERTER_FOR_JSON.encode({ ...plainObj, args: null });
 
-    encoded.args = encodedPayload.options.args;
+    encoded.args = plainObj.args;
+
     return JSON.stringify(encoded);
   }
 }

--- a/src/loggy/export/TextFileSink.js
+++ b/src/loggy/export/TextFileSink.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { EventSink, LinkedEvent } from '@this/async';
-import { BaseCodec, Codec, CodecConfig } from '@this/codec';
+import { Codec, CodecConfig } from '@this/codec';
 import { FileAppender } from '@this/fs-util';
 import { LogPayload } from '@this/loggy-intf';
 import { Duration } from '@this/quant';

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -64,7 +64,7 @@ export class DispatchInfo {
    * @returns {Sexp} The encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(DispatchInfo, null, this.#base, this.#extra);
+    return new Sexp(DispatchInfo, 'NO-OPTS', this.#base, this.#extra);
   }
 
   /**

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -59,7 +59,7 @@ export class DispatchInfo {
   }
 
   /**
-   * Standard `quant` method to produce an encoded version of this instance.
+   * Implementation of `codec` custom-encode protocol.
    *
    * @returns {Sexp} The encoded form.
    */

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -64,7 +64,7 @@ export class DispatchInfo {
    * @returns {Sexp} The encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(DispatchInfo, 'NO-OPTS', this.#base, this.#extra);
+    return new Sexp(DispatchInfo, this.#base, this.#extra);
   }
 
   /**

--- a/src/quant/export/ByteCount.js
+++ b/src/quant/export/ByteCount.js
@@ -53,7 +53,7 @@ export class ByteCount extends UnitQuantity {
     // an instance.
     const str = this.toString();
 
-    return new Sexp(ByteCount, 'NO-OPTS', this.byte, str);
+    return new Sexp(ByteCount, this.byte, str);
   }
 
 

--- a/src/quant/export/ByteCount.js
+++ b/src/quant/export/ByteCount.js
@@ -53,7 +53,7 @@ export class ByteCount extends UnitQuantity {
     // an instance.
     const str = this.toString();
 
-    return new Sexp(ByteCount, null, this.byte, str);
+    return new Sexp(ByteCount, 'NO-OPTS', this.byte, str);
   }
 
 

--- a/src/quant/export/ByteRate.js
+++ b/src/quant/export/ByteRate.js
@@ -54,7 +54,7 @@ export class ByteRate extends UnitQuantity {
     // an instance.
     const str = this.toString();
 
-    return new Sexp(ByteRate, null, this.bytePerSec, str);
+    return new Sexp(ByteRate, 'NO-OPTS', this.bytePerSec, str);
   }
 
 

--- a/src/quant/export/ByteRate.js
+++ b/src/quant/export/ByteRate.js
@@ -54,7 +54,7 @@ export class ByteRate extends UnitQuantity {
     // an instance.
     const str = this.toString();
 
-    return new Sexp(ByteRate, 'NO-OPTS', this.bytePerSec, str);
+    return new Sexp(ByteRate, this.bytePerSec, str);
   }
 
 

--- a/src/quant/export/Duration.js
+++ b/src/quant/export/Duration.js
@@ -75,7 +75,7 @@ export class Duration extends UnitQuantity {
     // an instance.
     const str = Duration.stringFromSec(this.sec);
 
-    return new Sexp(Duration, 'NO-OPTS', this.sec, str);
+    return new Sexp(Duration, this.sec, str);
   }
 
 

--- a/src/quant/export/Duration.js
+++ b/src/quant/export/Duration.js
@@ -75,7 +75,7 @@ export class Duration extends UnitQuantity {
     // an instance.
     const str = Duration.stringFromSec(this.sec);
 
-    return new Sexp(Duration, null, this.sec, str);
+    return new Sexp(Duration, 'NO-OPTS', this.sec, str);
   }
 
 

--- a/src/quant/export/Moment.js
+++ b/src/quant/export/Moment.js
@@ -229,7 +229,7 @@ export class Moment {
     // an instance.
     const str = this.toString({ decimals: 6 });
 
-    return new Sexp(Moment, 'NO-OPTS', this.#atSec, str);
+    return new Sexp(Moment, this.#atSec, str);
   }
 
 

--- a/src/quant/export/Moment.js
+++ b/src/quant/export/Moment.js
@@ -229,7 +229,7 @@ export class Moment {
     // an instance.
     const str = this.toString({ decimals: 6 });
 
-    return new Sexp(Moment, null, this.#atSec, str);
+    return new Sexp(Moment, 'NO-OPTS', this.#atSec, str);
   }
 
 

--- a/src/quant/export/UnitQuantity.js
+++ b/src/quant/export/UnitQuantity.js
@@ -115,7 +115,7 @@ export class UnitQuantity {
    * @returns {Sexp} Encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(this.constructor, null,
+    return new Sexp(this.constructor, 'NO-OPTS',
       this.#value, this.#numeratorUnit, this.#denominatorUnit);
   }
 

--- a/src/quant/export/UnitQuantity.js
+++ b/src/quant/export/UnitQuantity.js
@@ -115,7 +115,7 @@ export class UnitQuantity {
    * @returns {Sexp} Encoded form.
    */
   [BaseCodec.ENCODE]() {
-    return new Sexp(this.constructor, 'NO-OPTS',
+    return new Sexp(this.constructor,
       this.#value, this.#numeratorUnit, this.#denominatorUnit);
   }
 


### PR DESCRIPTION
This PR changes `Sexp` so it now pretty much matches the classic definition of an s-expression. Specifically, the old version had an explicit "options arguments" (`.options`) property, which is now removed. The main motivation here is to make it so a `Sexp` instance can at least theoretically be expanded directly into a constructor call, with constructors as usually defined in JavaScript.