### PR TITLE
Visitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Breaking changes:
 Other notable changes:
 * `webapp-util`:
   * Fixed `Rotator` and `Saver` to not bother "preserving" empty files.
+* `util`:
+  * New class `BaseValueVisitor` which implements the "visitor" pattern to
+    iterate over object graphs.
 
 ### v0.8.1 -- 2024-09-26
 

--- a/src/typey/export/AskIf.js
+++ b/src/typey/export/AskIf.js
@@ -168,10 +168,13 @@ export class AskIf {
   /**
    * Checks for type "constructor function," that is whether the given value is
    * a function which will allow calling when preceded by `new`. These are of
-   * course also often just called "classes."
+   * course also often just called "classes." However, unfortunately, many "just
+   * supposed to be a function" functions in JavaScript are in fact still set up
+   * such that they don't mind getting called with `new`, and this method cannot
+   * tell the difference between those and "real" classes.
    *
-   * **Note:** This implementation is imperfect and inefficient. There is a TC39
-   * proposal that would address this problem:
+   * **Note:** This implementation is imperfect (see above) and inefficient.
+   * There is a TC39 proposal that would address this problem:
    * <https://github.com/caitp/TC39-Proposals/blob/HEAD/tc39-reflect-isconstructor-iscallable.md>
    * Unfortunately it is not (as of this writing) close to being accepted.
    *

--- a/src/typey/tests/AskIf.test.js
+++ b/src/typey/tests/AskIf.test.js
@@ -445,9 +445,10 @@ describe('constructorFunction()', () => {
     }
 
     test.each`
-    label                         | value
-    ${'an arrow function'}        | ${() => 123}
-    ${'a modern class\'s method'} | ${new Boop().beep}
+    label                           | value
+    ${'an arrow function'}          | ${() => 123}
+    ${'a built-in class\'s method'} | ${new Map().get}
+    ${'a modern class\'s method'}   | ${new Boop().beep}
     `('returns false given $label', ({ value }) => {
       expect(AskIf.constructorFunction(value)).toBeFalse();
     });
@@ -463,6 +464,8 @@ describe('constructorFunction()', () => {
     });
   });
 
+  // This is the surprising but -- alas! -- correct result due to JavaScript's
+  // historical "all functions are constructors" stance.
   test('returns true given a classic `function` function', () => {
     function florp() { return 123; }
     expect(AskIf.constructorFunction(florp)).toBeTrue();

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -254,7 +254,9 @@ export class BaseValueVisitor {
   /**
    * Visits a plain object value, that is, a non-`null` value of type `object`,
    * which has a `prototype` of either `null` or the class `Object`. The base
-   * implementation returns the given `node` as-is.
+   * implementation returns the given `node` as-is. Subclasses that wish to
+   * traverse the contents can do so by calling {@link
+   * #_prot_visitObjectProperties}.
    *
    * @param {object} node The node to visit.
    * @returns {*} Arbitrary result of visiting.
@@ -309,10 +311,10 @@ export class BaseValueVisitor {
   }
 
   /**
-   * Visits the stored values and any other properties of an array, _excluding_
-   * `length`. Returns an array consisting of all the visited values, with the
-   * same indices / property names. If the original `node` is a sparse array,
-   * the result will have the same "holes."
+   * Visits the indexed values and any other properties of an array, _excluding_
+   * `length`. Returns an array consisting of all the visited values, with
+   * indices / property names corresponding to the original. If the original
+   * `node` is a sparse array, the result will have the same "holes."
    *
    * @param {Array} node The node whose contents are to be visited.
    * @returns {Array} An array of visited results.
@@ -325,6 +327,24 @@ export class BaseValueVisitor {
       if (nameOrIndex !== 'length') {
         result[nameOrIndex] = await this.#visitNode(node[nameOrIndex]);
       }
+    }
+
+    return result;
+  }
+
+  /**
+   * Visits the property valies of an object (typically a plain object).
+   * Returns a new plain object consisting of all the visited values, with
+   * property names corresponding to the original.
+   *
+   * @param {object} node The node whose contents are to be visited.
+   * @returns {object} A `null`-prototype object with the visited results.
+   */
+  async _prot_visitObjectProperties(node) {
+    const result = Object.create(null);
+
+    for (const name of Object.getOwnPropertyNames(node)) {
+      result[name] = await this.#visitNode(node[name]);
     }
 
     return result;

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -164,8 +164,8 @@ export class BaseValueVisitor {
 
   /**
    * Visits an array. The base implementation returns the given `node` as-is.
-   * Subclasses that wish to traverse the contents can do so by calling `<TODO
-   * call to method that does not yet exist>`.
+   * Subclasses that wish to traverse the contents can do so by calling
+   * {@link #_prot_visitArrayProperties}.
    *
    * @param {Array} node The node to visit.
    * @returns {*} Arbitrary result of visiting.
@@ -306,5 +306,27 @@ export class BaseValueVisitor {
    */
   async _impl_visitUndefined() {
     return undefined;
+  }
+
+  /**
+   * Visits the stored values and any other properties of an array, _excluding_
+   * `length`. Returns an array consisting of all the visited values, with the
+   * same indices / property names. If the original `node` is a sparse array,
+   * the result will have the same "holes."
+   *
+   * @param {Array} node The node whose contents are to be visited.
+   * @returns {Array} An array of visited results.
+   */
+  async _prot_visitArrayProperties(node) {
+    const length    = node.length;
+    const result    = Array(length);
+
+    for (const nameOrIndex of Object.getOwnPropertyNames(node)) {
+      if (nameOrIndex !== 'length') {
+        result[nameOrIndex] = await this.#visitNode(node[nameOrIndex]);
+      }
+    }
+
+    return result;
   }
 }

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,4 +1,5 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+export * from '#x/BaseValueVisitor';
 export * from '#x/ErrorUtil';


### PR DESCRIPTION
This PR adds a new class `util.BaseValueVisitor`, which was extracted from `codec.Codec` as a generalization of what it does to iterate over the graph of a possibly-compound value. As of this PR it is both untested and unused; most specifically, the code in `Codec` does not yet use it. The code is also almost certainly incomplete, too, exactly because it has had no influence from any attempt to use it.