### PR TITLE
More visitor stuff

### DIFF
--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -102,10 +102,12 @@ export class BaseValueVisitor {
       case true: {
         return visitEntry.result;
       }
+      /* c8 ignore start */
       default: {
         // This is indicative of a bug in this class.
         throw new Error('Shouldn\'t happen.');
       }
+      /* c8 ignore stop */
     }
   }
 
@@ -257,10 +259,12 @@ export class BaseValueVisitor {
         }
       }
 
+      /* c8 ignore start */
       default: {
         // JavaScript added a new type after this code was written!
         throw new Error(`Unrecognized \`typeof\` result: ${typeof node}`);
       }
+      /* c8 ignore stop */
     }
   }
 

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -524,10 +524,40 @@ export class BaseValueVisitor {
    * Entry in a {@link #visits} map.
    */
   static #VisitEntry = class VisitEntry {
+    /**
+     * The value whose visit this entry represents.
+     *
+     * @type {*}
+     */
     node;
+
+    /**
+     * Success-or-error flag, or `null` if the visit is still in progress.
+     *
+     * @type {?boolean}
+     */
     ok = null;
+
+    /**
+     * Promise for this instance, which resolves only after the visit completes.
+     *
+     * @type {Promise<BaseValueVisitor#VisitEntry>}
+     */
     promise;
+
+    /**
+     * Error thrown by the visit, or `null` if no error has yet been thrown.
+     *
+     * @type {Error}
+     */
     error = null;
+
+    /**
+     * Successful result of the visit, or `null` if the visit is either still in
+     * progress or ended with a failure.
+     *
+     * @type {*}
+     */
     result = null;
 
     /**
@@ -539,6 +569,14 @@ export class BaseValueVisitor {
       this.node = node;
     }
 
+    /**
+     * Extracts the result or error of a visit.
+     *
+     * @returns {*} The successful result of the visit, if it was indeed
+     *   successful.
+     * @throws {Error} The error resulting from the visit, if it failed; or
+     *   an error indicating that the visit is still in progress.
+     */
     extract() {
       if (this.ok === null) {
         throw new Error('Visit not complete.');

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -540,10 +540,11 @@ export class BaseValueVisitor {
 
     /**
      * Promise for this instance, which resolves only after the visit completes.
+     * or `null` if this instance's corresponding visit hasn't yet been started.
      *
      * @type {Promise<BaseValueVisitor#VisitEntry>}
      */
-    promise;
+    promise = null;
 
     /**
      * Error thrown by the visit, or `null` if no error has yet been thrown.
@@ -579,7 +580,11 @@ export class BaseValueVisitor {
      */
     extract() {
       if (this.ok === null) {
-        throw new Error('Visit not complete.');
+        if (this.promise === null) {
+          throw new Error('Visit not yet started.');
+        } else {
+          throw new Error('Visit not yet complete.');
+        }
       } else if (this.ok) {
         return this.result;
       } else {

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -62,21 +62,12 @@ export class BaseValueVisitor {
   async visit() {
     const visitEntry = this.#visitNode(this.#value);
 
-    switch (visitEntry.ok) {
-      case null: {
-        return visitEntry.promise;
-      }
-      case false: {
-        throw visitEntry.error;
-      }
-      case true: {
-        return visitEntry.result;
-      }
-      default: {
-        // There should be no other cases in practice.
-        throw new Error('Shouldn\'t happen.');
-      }
-    }
+    // If `ok` is _either_ `null` or `false`, we just let the promise mechanics
+    // handle it, keeping things simpler (with the cost being a negligible bit
+    // of performance in the case of an error).
+    return visitEntry.ok
+      ? visitEntry.result
+      : visitEntry.promise;
   }
 
   /**
@@ -101,7 +92,7 @@ export class BaseValueVisitor {
         return visitEntry.result;
       }
       default: {
-        // There should be no other cases in practice.
+        // This is indicative of a bug in this class.
         throw new Error('Shouldn\'t happen.');
       }
     }

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -478,7 +478,7 @@ export class BaseValueVisitor {
     for (const nameOrIndex of Object.getOwnPropertyNames(node)) {
       if (!(isArray && (nameOrIndex === 'length'))) {
         const got = this.#visitNode(node[nameOrIndex]);
-        if (got instanceof Promise) {
+        if (got.ok === null) {
           promNames.push(nameOrIndex);
           result[nameOrIndex] = got.promise;
         } else if (got.ok) {

--- a/src/util/package.json
+++ b/src/util/package.json
@@ -11,5 +11,10 @@
   "imports": {
     "#x/*": "./export/*.js",
     "#tests/*": "./tests/*.js"
+  },
+
+  "dependencies": {
+    "@this/async": "*",
+    "@this/typey": "*"
   }
 }

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -33,6 +33,10 @@ const EXAMPLES = [
  * Visitor subclass, with some synchronous and some asynchronous behavior.
  */
 class SubVisit extends BaseValueVisitor {
+  _impl_visitBigInt(node) {
+    throw new Error('Nope!');
+  }
+
   async _impl_visitBoolean(node) {
     await setImmediate();
     return `${node}`;
@@ -101,6 +105,13 @@ describe('visit()', () => {
     expect(PromiseState.isFulfilled(got)).toBeTrue();
     expect(await got).toBe('zonk');
   });
+
+  test('throws the error which was thrown by an `_impl_visit*()` method', async () => {
+    const vv  = new SubVisit(123n);
+    const got = vv.visit();
+
+    await expect(got).rejects.toThrow('Nope!');
+  });
 });
 
 describe('visitSync()', () => {
@@ -118,6 +129,12 @@ describe('visitSync()', () => {
     const vv  = new BaseValueVisitor(value);
     const got = vv.visitSync();
     expect(got).toBe(value);
+  });
+
+  test('throws the error which was thrown by an `_impl_visit*()` method', () => {
+    const vv  = new SubVisit(123n);
+
+    expect(() => vv.visitSync()).toThrow('Nope!');
   });
 });
 
@@ -146,6 +163,13 @@ describe('visitWrap()', () => {
     expect(got).toBeInstanceOf(BaseValueVisitor.WrappedResult);
 
     expect(got.value).toBe(value);
+  });
+
+  test('throws the error which was thrown by an `_impl_visit*()` method', async () => {
+    const vv  = new SubVisit(123n);
+    const got = vv.visitWrap();
+
+    await expect(got).rejects.toThrow('Nope!');
   });
 });
 

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -26,7 +26,9 @@ const EXAMPLES = [
   Symbol('zonk'),
   ['yo', 'there'],
   { what: 'is up?' },
-  new Set(['x', 'y', 'z'])
+  new Set(['x', 'y', 'z']),
+  (x, y) => { return x < y; },
+  class Flomp { /*empty*/ }
 ];
 
 /**

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -206,6 +206,12 @@ describe('_prot_visitArrayProperties()', () => {
     expect(got).toEqual(['false', '1', ['true', '2'], 'false']);
   });
 
+  test('synchronously propagates an error thrown by one of the sub-calls', () => {
+    const vv = new SubVisit([456n]);
+
+    expect(() => vv.visitSync()).toThrow('Nope!');
+  });
+
   test('preserves sparseness', () => {
     const UND  = undefined;
     const orig = Array(7);
@@ -288,6 +294,12 @@ describe('_prot_visitObjectProperties()', () => {
     const got  = await vv.visit();
 
     expect(got).toEqual({ x: 'false', y: '1', z: { a: 'true', b: '2' } });
+  });
+
+  test('synchronously propagates an error thrown by one of the sub-calls', () => {
+    const vv = new SubVisit({ blorp: 456n });
+
+    expect(() => vv.visitSync()).toThrow('Nope!');
   });
 
   test('handles symbol properties', () => {

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -35,7 +35,7 @@ const EXAMPLES = [
  * Visitor subclass, with some synchronous and some asynchronous behavior.
  */
 class SubVisit extends BaseValueVisitor {
-  _impl_visitBigInt(node) {
+  _impl_visitBigInt(node_unused) {
     throw new Error('Nope!');
   }
 

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -189,4 +189,37 @@ describe('_prot_visitArrayProperties()', () => {
       expect(i in got).toBe(i in orig);
     }
   });
+
+  test('handles non-numeric string properties', () => {
+    const orig = [1];
+    orig.x = 2;
+    orig.y = 3;
+
+    const expected = ['1'];
+    expected.x = '2';
+    expected.y = '3';
+
+    const vv   = new SubVisit(orig);
+    const got  = vv.visitSync();
+    expect(got).toEqual(expected);
+  });
+
+  test('handles symbol properties', () => {
+    const SYM1 = Symbol.for('x');
+    const SYM2 = Symbol('y');
+    const orig = [123];
+    orig[SYM1] = 234;
+    orig[SYM2] = 321;
+
+    const expected = ['123'];
+    expected[SYM1] = '234';
+    expected[SYM2] = '321';
+
+    const vv   = new SubVisit(orig);
+    const got  = vv.visitSync();
+    expect(got).toBeArrayOfSize(1);
+    expect(got[0]).toBe('123');
+    expect(got[SYM1]).toBe('234');
+    expect(got[SYM2]).toBe('321');
+  });
 });

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -12,6 +12,8 @@ const REJECTED_ERROR   = new Error('from-a-promise');
 const PENDING_PROMISE  = Promise.race([]);
 const RESOLVED_PROMISE = Promise.resolve(RESOLVED_VALUE);
 const REJECTED_PROMISE = Promise.reject(REJECTED_ERROR);
+
+REJECTED_ERROR.stack = 'some-stack';
 PromiseUtil.handleRejection(REJECTED_PROMISE);
 
 const EXAMPLES = [
@@ -99,6 +101,21 @@ describe('visitSync()', () => {
 
 describe('visitWrap()', () => {
   test.each(EXAMPLES)('async-returns value as-is: %o', async (value) => {
+    const vv      = new BaseValueVisitor(value);
+    const gotProm = vv.visitWrap();
+    expect(gotProm).toBeInstanceOf(Promise);
+
+    const got = await gotProm;
+    expect(got).toBeInstanceOf(BaseValueVisitor.WrappedResult);
+
+    expect(got.value).toBe(value);
+  });
+
+  test.each([
+    RESOLVED_PROMISE,
+    REJECTED_PROMISE,
+    PENDING_PROMISE
+  ])('async-returns promise as-is: %o', async (value) => {
     const vv      = new BaseValueVisitor(value);
     const gotProm = vv.visitWrap();
     expect(gotProm).toBeInstanceOf(Promise);

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -1,0 +1,49 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { BaseValueVisitor } from '@this/util';
+
+
+const EXAMPLES = [
+  undefined,
+  null,
+  true,
+  123.456,
+  567n,
+  'blorp',
+  Symbol('zonk'),
+  ['yo', 'there'],
+  { what: 'is up?' },
+  new Set(['x', 'y', 'z'])
+];
+
+describe('constructor()', () => {
+  test.each(EXAMPLES)('does not throw given value: %o', (value) => {
+    expect(() => new BaseValueVisitor()).not.toThrow();
+  });
+});
+
+describe('.value', () => {
+  test('is the value passed into the constructor', () => {
+    const value = ['yes', 'this', 'is', 'it'];
+    const vv    = new BaseValueVisitor(value);
+    expect(vv.value).toBe(value);
+  });
+});
+
+describe('visit()', () => {
+  test.each(EXAMPLES)('async-returns value as-is: %o', async (value) => {
+    const vv  = new BaseValueVisitor(value);
+    const got = vv.visit();
+    expect(got).toBeInstanceOf(Promise);
+    expect(await got).toBe(value);
+  });
+});
+
+describe('visitSync()', () => {
+  test.each(EXAMPLES)('synchronously returns value as-is: %o', (value) => {
+    const vv  = new BaseValueVisitor(value);
+    const got = vv.visitSync();
+    expect(got).toBe(value);
+  });
+});

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -48,6 +48,10 @@ class SubVisit extends BaseValueVisitor {
     return `${node}`;
   }
 
+  async _impl_visitSymbol(node_unused) {
+    throw new Error('NO');
+  }
+
   _impl_visitArray(node) {
     return this._prot_visitArrayProperties(node);
   }
@@ -108,11 +112,18 @@ describe('visit()', () => {
     expect(await got).toBe('zonk');
   });
 
-  test('throws the error which was thrown by an `_impl_visit*()` method', async () => {
+  test('throws the error which was thrown synchronously by an `_impl_visit*()` method', async () => {
     const vv  = new SubVisit(123n);
     const got = vv.visit();
 
     await expect(got).rejects.toThrow('Nope!');
+  });
+
+  test('throws the error which was thrown asynchronously by an `_impl_visit*()` method', async () => {
+    const vv  = new SubVisit(Symbol('eep'));
+    const got = vv.visit();
+
+    await expect(got).rejects.toThrow('NO');
   });
 });
 
@@ -133,7 +144,7 @@ describe('visitSync()', () => {
     expect(got).toBe(value);
   });
 
-  test('throws the error which was thrown by an `_impl_visit*()` method', () => {
+  test('throws the error which was thrown synchronously by an `_impl_visit*()` method', () => {
     const vv  = new SubVisit(123n);
 
     expect(() => vv.visitSync()).toThrow('Nope!');
@@ -167,11 +178,18 @@ describe('visitWrap()', () => {
     expect(got.value).toBe(value);
   });
 
-  test('throws the error which was thrown by an `_impl_visit*()` method', async () => {
+  test('throws the error which was thrown synchronously by an `_impl_visit*()` method', async () => {
     const vv  = new SubVisit(123n);
     const got = vv.visitWrap();
 
     await expect(got).rejects.toThrow('Nope!');
+  });
+
+  test('throws the error which was thrown asynchronously by an `_impl_visit*()` method', async () => {
+    const vv  = new SubVisit(Symbol('eep'));
+    const got = vv.visitWrap();
+
+    await expect(got).rejects.toThrow('NO');
   });
 });
 


### PR DESCRIPTION
This PR fleshes out `BaseValueVisitor` more completely, including:

* Giving it three different ways to be called:
  * synchronously, which will appropriately fail if any part of the visit turns out to be coded asynchronously.
  * asynchronously, with a visit-result promise chained to the result of the call.
  * asynchronously, with all visit results — including promises — wrapped, so that an asynchronous visit can be unambiguously differentiated from a visit that results in a promise. (Yay JavaScript!)
* Adding a bunch of tests.
* Fixing the original code which (of course) failed a number of the tests.