### PR TITLE
Proxy awareness

### DIFF
--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -228,14 +228,6 @@ const disallowedFunctionality = {
     {
       selector: 'NewExpression[callee.name=\'Date\'][arguments.length!=1]',
       message:  'Use module `clocky` or class `quant.Moment`.'
-    },
-    {
-      selector: ':not(AssignmentExpression) > MemberExpression[property.name=/^_prot_/][object.type!=ThisExpression]',
-      message:  'Only access `_prot_*` (protected method) on `this`.'
-    },
-    {
-      selector: ':not(AssignmentExpression) > MemberExpression[property.name=/^_impl_/][object.type!=ThisExpression][object.type!=Super]',
-      message:  'Only access `_impl_*` (subclass-implementation method) on `this`.'
     }
   ]
 };
@@ -254,6 +246,14 @@ const disallowedFunctionalityNonTesting = {
     {
       selector: 'ImportDeclaration[source.value=/^#tests\\u002f/]',
       message:  'Only import `#tests` classes inside other test-related files.'
+    },
+    {
+      selector: ':not(AssignmentExpression) > MemberExpression[property.name=/^_prot_/][object.type!=ThisExpression]',
+      message:  'Only access `_prot_*` (protected method) on `this`.'
+    },
+    {
+      selector: ':not(AssignmentExpression) > MemberExpression[property.name=/^_impl_/][object.type!=ThisExpression][object.type!=Super]',
+      message:  'Only access `_impl_*` (subclass-implementation method) on `this`.'
     }
   ]
 };

--- a/src/structy/tests/BaseStruct.test.js
+++ b/src/structy/tests/BaseStruct.test.js
@@ -76,7 +76,6 @@ describe('using the (base) class directly', () => {
     test('is `struct`', () => {
       const instance = new BaseStruct();
 
-      // eslint-disable-next-line no-restricted-syntax
       expect(instance._impl_propertyPrefix()).toBe('struct');
     });
   });
@@ -86,7 +85,6 @@ describe('using the (base) class directly', () => {
       const instance = new BaseStruct();
       const someObj  = { a: 'bcd' };
 
-      // eslint-disable-next-line no-restricted-syntax
       expect(instance._impl_validate(someObj)).toBe(someObj);
     });
   });

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -439,7 +439,7 @@ export class BaseValueVisitor {
 
     if ((type === 'object') || (type === 'function')) {
       // Intentionally conservative check.
-      if ((typeof result.then) === 'function') {
+      if (result && ((typeof result.then) === 'function')) {
         return new BaseValueVisitor.WrappedResult(result);
       }
     }

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -106,7 +106,7 @@ describe('.value', () => {
   });
 });
 
-// Common tests for all three `visit*()` methods.
+// Tests for all three `visit*()` methods.
 describe.each`
 methodName     | isAsync  | wraps    | canReturnPromises
 ${'visit'}     | ${true}  | ${false} | ${false}
@@ -141,11 +141,6 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
   });
 
   if (isAsync) {
-    test('throws the error which was thrown asynchronously by an `_impl_visit*()` method', async () => {
-      const value = Symbol('eep');
-      await expect(doTest(value, { cls: SubVisit })).rejects.toThrow('NO');
-    });
-
     test('returns the value which was returned asynchronously by an `_impl_visit*()` method', async () => {
       const value = true;
       await doTest(value, {
@@ -155,8 +150,23 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
         }
       });
     });
+
+    test('throws the error which was thrown asynchronously by an `_impl_visit*()` method', async () => {
+      const value = Symbol('eep');
+      await expect(doTest(value, { cls: SubVisit })).rejects.toThrow('NO');
+    });
   } else {
-    /// TODO######
+    const MSG = 'Visit did not finish synchronously.';
+
+    test('throws the right error if a will-be-successful visit did not finish synchronously', async () => {
+      const value = true;
+      await expect(doTest(value, { cls: SubVisit })).rejects.toThrow(MSG);
+    });
+
+    test('throws the right error if a will-fail visit did not finish synchronously', async () => {
+      const value = Symbol('eeeeek');
+      await expect(doTest(value, { cls: SubVisit })).rejects.toThrow(MSG);
+    });
   }
 
   if (canReturnPromises) {
@@ -221,13 +231,6 @@ describe('visit()', () => {
     await setImmediate();
     expect(PromiseState.isFulfilled(got)).toBeTrue();
     expect(await got).toBe('zonk');
-  });
-});
-
-describe('visitSync()', () => {
-  test('throws the right error if the visit did not finish synchronously', () => {
-    const vv = new SubVisit(true);
-    expect(() => vv.visitSync()).toThrow('Visit did not finish synchronously.');
   });
 });
 

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -7,15 +7,6 @@ import { ManualPromise, PromiseState, PromiseUtil } from '@this/async';
 import { BaseValueVisitor } from '@this/util';
 
 
-const RESOLVED_VALUE   = 'resolved-promise-value';
-const REJECTED_ERROR   = new Error('from-a-promise');
-const PENDING_PROMISE  = Promise.race([]);
-const RESOLVED_PROMISE = Promise.resolve(RESOLVED_VALUE);
-const REJECTED_PROMISE = Promise.reject(REJECTED_ERROR);
-
-REJECTED_ERROR.stack = 'some-stack';
-PromiseUtil.handleRejection(REJECTED_PROMISE);
-
 const EXAMPLES = [
   undefined,
   null,
@@ -36,6 +27,21 @@ const FUNCTION_PROXY = new Proxy(() => 123, {});
 const PROXY_EXAMPLES = [
   OBJECT_PROXY,
   FUNCTION_PROXY
+];
+
+const RESOLVED_VALUE   = 'resolved-promise-value';
+const REJECTED_ERROR   = new Error('from-a-promise');
+const PENDING_PROMISE  = Promise.race([]);
+const RESOLVED_PROMISE = Promise.resolve(RESOLVED_VALUE);
+const REJECTED_PROMISE = Promise.reject(REJECTED_ERROR);
+
+REJECTED_ERROR.stack = 'some-stack';
+PromiseUtil.handleRejection(REJECTED_PROMISE);
+
+const PROMISE_EXAMPLES = [
+  PENDING_PROMISE,
+  RESOLVED_PROMISE,
+  REJECTED_PROMISE
 ];
 
 /**
@@ -82,7 +88,7 @@ class ProxyAwareVisitor extends BaseValueVisitor {
 }
 
 describe('constructor()', () => {
-  const CASES = [...EXAMPLES, ...PROXY_EXAMPLES];
+  const CASES = [...EXAMPLES, ...PROXY_EXAMPLES, ...PROMISE_EXAMPLES];
   test.each(CASES)('does not throw given value: %o', (value) => {
     expect(() => new BaseValueVisitor(value)).not.toThrow();
   });

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -474,4 +474,21 @@ describe('_prot_wrapResult()', () => {
     expect(got).toBeInstanceOf(BaseValueVisitor.WrappedResult);
     expect(got.value).toBe(value);
   });
+
+  test('wraps a "thenable"', () => {
+    const value = { then: () => true };
+    const vv    = new BaseValueVisitor(null);
+    const got   = vv._prot_wrapResult(value);
+
+    expect(got).toBeInstanceOf(BaseValueVisitor.WrappedResult);
+    expect(got.value).toBe(value);
+  });
+
+  test('does not wrap an object with a non-function `then`', () => {
+    const value = { then: 'bonk' };
+    const vv    = new BaseValueVisitor(null);
+    const got   = vv._prot_wrapResult(value);
+
+    expect(got).toBe(value);
+  });
 });

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -140,6 +140,25 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
     await doTest(value);
   });
 
+  if (isAsync) {
+    test('throws the error which was thrown asynchronously by an `_impl_visit*()` method', async () => {
+      const value = Symbol('eep');
+      await expect(doTest(value, { cls: SubVisit })).rejects.toThrow('NO');
+    });
+
+    test('returns the value which was returned asynchronously by an `_impl_visit*()` method', async () => {
+      const value = true;
+      await doTest(value, {
+        cls: SubVisit,
+        check: (got) => {
+          expect(got).toBe('true');
+        }
+      });
+    });
+  } else {
+    /// TODO######
+  }
+
   if (canReturnPromises) {
     test.each([
       RESOLVED_PROMISE,
@@ -149,6 +168,11 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
       await doTest(value);
     });
   }
+
+  test('throws the error which was thrown synchronously by an `_impl_visit*()` method', async () => {
+    const value = 123n;
+    await expect(doTest(value, { cls: SubVisit })).rejects.toThrow('Nope!');
+  });
 
   describe('when `_impl_proxyAware() === false`', () => {
     test.each(PROXY_EXAMPLES)('returns the given value as-is: %o', async (value) => {
@@ -198,47 +222,12 @@ describe('visit()', () => {
     expect(PromiseState.isFulfilled(got)).toBeTrue();
     expect(await got).toBe('zonk');
   });
-
-  test('throws the error which was thrown synchronously by an `_impl_visit*()` method', async () => {
-    const vv  = new SubVisit(123n);
-    const got = vv.visit();
-
-    await expect(got).rejects.toThrow('Nope!');
-  });
-
-  test('throws the error which was thrown asynchronously by an `_impl_visit*()` method', async () => {
-    const vv  = new SubVisit(Symbol('eep'));
-    const got = vv.visit();
-
-    await expect(got).rejects.toThrow('NO');
-  });
 });
 
 describe('visitSync()', () => {
-  test('throws the error which was thrown synchronously by an `_impl_visit*()` method', () => {
-    const vv = new SubVisit(123n);
-    expect(() => vv.visitSync()).toThrow('Nope!');
-  });
-
   test('throws the right error if the visit did not finish synchronously', () => {
     const vv = new SubVisit(true);
     expect(() => vv.visitSync()).toThrow('Visit did not finish synchronously.');
-  });
-});
-
-describe('visitWrap()', () => {
-  test('throws the error which was thrown synchronously by an `_impl_visit*()` method', async () => {
-    const vv  = new SubVisit(123n);
-    const got = vv.visitWrap();
-
-    await expect(got).rejects.toThrow('Nope!');
-  });
-
-  test('throws the error which was thrown asynchronously by an `_impl_visit*()` method', async () => {
-    const vv  = new SubVisit(Symbol('eep'));
-    const got = vv.visitWrap();
-
-    await expect(got).rejects.toThrow('NO');
   });
 });
 

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -24,9 +24,13 @@ const EXAMPLES = [
 
 const OBJECT_PROXY   = new Proxy({ a: 'florp' }, {});
 const FUNCTION_PROXY = new Proxy(() => 123, {});
+const CLASS_PROXY    = new Proxy(class Florp {}, {});
+const ARRAY_PROXY    = new Proxy(['array'], {});
 const PROXY_EXAMPLES = [
   OBJECT_PROXY,
-  FUNCTION_PROXY
+  FUNCTION_PROXY,
+  CLASS_PROXY,
+  ARRAY_PROXY
 ];
 
 const RESOLVED_VALUE   = 'resolved-promise-value';


### PR DESCRIPTION
This PR changes `BaseValueVisitor` so that proxy awareness is optional. This also does a major DRY-out overhaul of its unit test file, along with expanding the test cases a bit.