### PR TITLE
Circularity and "refs"

### DIFF
--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -747,8 +747,8 @@ export class BaseValueVisitor {
         }
       } else if (possiblyUnfinished) {
         throw new Error('Visit did not finish synchronously.');
-      } else {
         /* c8 ignore start */
+      } else {
         // This is indicative of a bug in this class: If the caller thinks it's
         // possible that the visit hasn't finished, it should have passed `true`
         // to this method.

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -883,5 +883,13 @@ export class BaseValueVisitor {
     get originalValue() {
       return this.#entry.originalValue;
     }
+
+    /**
+     * @returns {*} The result value of the visit. This will throw an error if
+     * the visit was unsuccessful.
+     */
+    get value() {
+      return this.#entry.extractSync();
+    }
   };
 }

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -634,11 +634,12 @@ export class BaseValueVisitor {
         return this.#promise;
       }
 
-      // This is the case when a visited value has a circular reference, that
-      // is, when visiting the value causes a (non-ref) request to visit itself.
-      // More or less by definition, there is no possible way to handle this. To
-      // visit values with circular references, all circles must be broken by
-      // replacing them with refs.
+      // This is the case when a visited value has a synchronously-discovered
+      // circular reference, that is, when the synchronous portion of visiting
+      // the value causes a (non-ref) request to visit itself. More or less by
+      // definition, there is no possible way to handle this. To visit values
+      // with circular references, all circles must be broken by replacing them
+      // with refs.
       throw new Error('Visit is deadlocked due to circular reference.');
     }
 

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -274,16 +274,20 @@ export class BaseValueVisitor {
   /**
    * Indicates whether the given value, which has already been determined to be
    * referenced more than once in the graph of values being visited, should be
-   * converted into a ref object for all but the first visit. A typical use case
-   * is to return `true` for objects and functions and `false` for everything
-   * else.
+   * converted into a ref object for all but the first visit. The various
+   * `visit*()` methods will call this any time they encounter a value (of any
+   * type) which has been visited before (or is currently being visited),
+   * _except_ a ref instance (instance of {@link #VisitRef}) will never be
+   * subject to potential "re-reffing."
    *
    * Note that, for values that are visited recursively and have at least one
    * self-reference (that is, a circular reference), returning `false` will
    * cause the visit to _not_ be able to finish, in that the construction of a
    * visit result will require itself to be known before its own construction.
    *
-   * The base implementation always returns `false`.
+   * The base implementation always returns `false`. A common choice for a
+   * subclass is to return `true` for objects and functions and `false` for
+   * everything else.
    *
    * @param {*} value The value to check.
    * @returns {boolean} `true` if `value` should be converted into a reference.

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -46,7 +46,7 @@ export class BaseValueVisitor {
    *
    * @type {*}
    */
-  #value;
+  #rootValue;
 
   /**
    * Map from visited values to their visit representatives.
@@ -79,7 +79,7 @@ export class BaseValueVisitor {
    */
   constructor(value) {
     this.#proxyAware = MustBe.boolean(this._impl_isProxyAware());
-    this.#value      = value;
+    this.#rootValue  = value;
   }
 
   /**
@@ -87,7 +87,7 @@ export class BaseValueVisitor {
    * `value` passed in to the constructor of this instance.
    */
   get value() {
-    return this.#value;
+    return this.#rootValue;
   }
 
   /**
@@ -108,7 +108,7 @@ export class BaseValueVisitor {
    * processed the original `value`.
    */
   async visit() {
-    return this.#visitNode(this.#value).extractAsync(false);
+    return this.#visitRoot().extractAsync(false);
   }
 
   /**
@@ -121,7 +121,7 @@ export class BaseValueVisitor {
    * processed the original `value`.
    */
   visitSync() {
-    return this.#visitNode(this.#value).extractSync(true);
+    return this.#visitRoot().extractSync(true);
   }
 
   /**
@@ -135,7 +135,7 @@ export class BaseValueVisitor {
    * processed the original `value`.
    */
   async visitWrap() {
-    return this.#visitNode(this.#value).extractAsync(true);
+    return this.#visitRoot().extractAsync(true);
   }
 
   /**
@@ -241,6 +241,18 @@ export class BaseValueVisitor {
       }
       /* c8 ignore stop */
     }
+  }
+
+  /**
+   * Gets the entry for the root value being visited, including starting the
+   * visit (and possibly completing it) if this is the first time a `visit*()`
+   * method is being called.
+   *
+   * @returns {BaseValueVisitor#VisitEntry} Vititor entry for the root value.
+   */
+  #visitRoot() {
+    const node = this.#rootValue;
+    return this.#visits.get(node) ?? this.#visitNode(node);
   }
 
   /**

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -86,7 +86,7 @@ export class BaseValueVisitor {
    * @returns {*} The root value being visited by this instance, that is, the
    * `value` passed in to the constructor of this instance.
    */
-  get value() {
+  get rootValue() {
     return this.#rootValue;
   }
 

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -729,14 +729,14 @@ export class BaseValueVisitor {
         }
       } else if (possiblyUnfinished) {
         throw new Error('Visit did not finish synchronously.');
+      } else {
+        /* c8 ignore start */
+        // This is indicative of a bug in this class: If the caller thinks it's
+        // possible that the visit hasn't finished, it should have passed `true`
+        // to this method.
+        throw new Error('Shouldn\'t happen: Visit not yet finished.');
+        /* c8 ignore end */
       }
-
-      // This is indicative of a bug in this class: If the caller thinks it's
-      // possible that the visit hasn't finished, it should have passed `true`
-      // to this method.
-      /* c8 ignore start */
-      throw new Error('Shouldn\'t happen: Visit not yet finished.');
-      /* c8 ignore end */
     }
 
     /**

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -156,7 +156,7 @@ export class BaseValueVisitor {
       const ref = already.ref;
       if (ref) {
         return this.#visitNode(ref);
-      } else if (this._impl_shouldRef(node)) {
+      } else if (this.#shouldRef(node)) {
         const newRef =
           new BaseValueVisitor.VisitRef(already, this.#nextRefIndex);
         this.#nextRefIndex++;
@@ -535,6 +535,20 @@ export class BaseValueVisitor {
    */
   #isProxy(value) {
     return this.#proxyAware && types.isProxy(value);
+  }
+
+  /**
+   * Assuming this is its second-or-later (recursive or sibling) visit, should
+   * the given value be turned into a ref? This just defers to
+   * {@link #_impl_shouldRef}, except that refs themselves are never considered
+   * for re-(re-...)reffing.
+   *
+   * @param {*} value Value to check.
+   * @returns {boolean} `true` iff `value` should be turned into a ref.
+   */
+  #shouldRef(value) {
+    return !(value instanceof BaseValueVisitor.VisitRef)
+      && this._impl_shouldRef(value);
   }
 
   /**

--- a/src/util/export/VisitResult.js
+++ b/src/util/export/VisitResult.js
@@ -1,0 +1,42 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+
+/**
+ * Forward declaration of this class, because `import`ing it would cause a
+ * circular dependency while loading.
+ *
+ * @typedef BaseValueVisitor
+ * @type {object}
+ */
+
+/**
+ * Companion class of {@link #BaseValueVisitor}, which holds the result from a
+ * visit.
+ *
+ * This class exists to avoid ambiguity when promises are used as results-per-se
+ * from visiting, as opposed to being used because of the JavaScript execution
+ * semantics involved in implementing a visitor method as `async`.
+ */
+export class VisitResult {
+  /**
+   * The visit result value.
+   *
+   * @type {*}
+   */
+  #value;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {*} value The visit result.
+   */
+  constructor(value) {
+    this.#value = value;
+  }
+
+  /** @returns {*} The visit result. */
+  get value() {
+    return this.#value;
+  }
+}

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -3,3 +3,4 @@
 
 export * from '#x/BaseValueVisitor';
 export * from '#x/ErrorUtil';
+export * from '#x/VisitResult';

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -312,7 +312,7 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
           const gotInner  = got[0];
           const gotMiddle = got[1];
 
-          expect(got[0]).toEqual(['bonk']);
+          expect(gotInner).toEqual(['bonk']);
           expect(gotMiddle).toBeArrayOfSize(1);
 
           const gotRef = gotMiddle[0];
@@ -321,6 +321,7 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
           expect(got[2]).toBeInstanceOf(BaseValueVisitor.VisitRef);
           expect(gotRef).toBe(got[2]);
           expect(gotRef.originalValue).toBe(inner);
+          expect(gotRef.value).toBe(gotInner);
         }
       });
     });
@@ -344,6 +345,7 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
           expect(gotInner[1]).toBeInstanceOf(BaseValueVisitor.VisitRef);
           expect(gotInner[1]).toBe(gotRef);
           expect(gotRef.originalValue).toBe(inner);
+          expect(gotRef.value).toBe(gotInner);
         }
       });
     });

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -332,6 +332,7 @@ ${'_impl_visitNull'}        | ${false} | ${null}
 ${'_impl_visitNumber'}      | ${false} | ${54.321}
 ${'_impl_visitPlainObject'} | ${true}  | ${{ x: 'bonk' }}
 ${'_impl_visitProxy'}       | ${true}  | ${new Proxy({}, {})}
+${'_impl_visitRef'}         | ${false} | ${new BaseValueVisitor.VisitRef(null, 5)}
 ${'_impl_visitString'}      | ${false} | ${'florp'}
 ${'_impl_visitSymbol'}      | ${false} | ${Symbol('woo')}
 ${'_impl_visitUndefined'}   | ${false} | ${undefined}

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -153,6 +153,28 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
     await expect(doTest(value, { cls: SubVisit })).rejects.toThrow(CIRCULAR_MSG);
   });
 
+  test('handles non-circular synchronously-visited duplicate references correctly', async () => {
+    const inner  = [1];
+    const middle = [inner, inner, inner, 2];
+    const outer  = [middle, inner, middle, 3];
+
+    await doTest(outer, {
+      cls: SubVisit,
+      check: (got) => {
+        expect(got).toBeArrayOfSize(4);
+        expect(got[0]).toBe(got[2]);
+        expect(got[3]).toBe('3');
+        const gotMiddle = got[0];
+        const gotInner  = got[1];
+        expect(gotMiddle[0]).toBe(gotInner);
+        expect(gotMiddle[1]).toBe(gotInner);
+        expect(gotMiddle[2]).toBe(gotInner);
+        expect(gotMiddle[3]).toEqual('2');
+        expect(gotInner).toEqual(['1']);
+      }
+    });
+  });
+
   if (isAsync) {
     test('returns the value which was returned asynchronously by an `_impl_visit*()` method', async () => {
       const value = true;

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -167,6 +167,16 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
       const value = Symbol('eeeeek');
       await expect(doTest(value, { cls: SubVisit })).rejects.toThrow(MSG);
     });
+
+    test('throws the right error if given a value containing a circular reference', async () => {
+      const circ1 = [4];
+      const circ2 = [5, 6, circ1];
+      const value = [1, [2, 3, circ1]];
+
+      circ1.push(circ2);
+
+      await expect(doTest(value, { cls: SubVisit })).rejects.toThrow(MSG);
+    });
   }
 
   if (canReturnPromises) {

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -66,6 +66,7 @@ class SubVisit extends BaseValueVisitor {
   }
 
   async _impl_visitSymbol(node_unused) {
+    await setImmediate();
     throw new Error('NO');
   }
 

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -4,7 +4,7 @@
 import { setImmediate } from 'node:timers/promises';
 
 import { ManualPromise, PromiseState, PromiseUtil } from '@this/async';
-import { BaseValueVisitor } from '@this/util';
+import { BaseValueVisitor, VisitResult } from '@this/util';
 
 
 const EXAMPLES = [
@@ -126,7 +126,7 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
       expect(got).toBeInstanceOf(Promise);
       if (wraps) {
         const wrapper = await got;
-        expect(wrapper).toBeInstanceOf(BaseValueVisitor.WrappedResult);
+        expect(wrapper).toBeInstanceOf(VisitResult);
         check(wrapper.value);
       } else {
         check(await got);
@@ -264,7 +264,7 @@ ${'_impl_visitUndefined'}   | ${false} | ${undefined}
 
       try {
         const got = vv[methodName](value);
-        expect(got).toBeInstanceOf(BaseValueVisitor.WrappedResult);
+        expect(got).toBeInstanceOf(VisitResult);
         expect(got.value).toBe(value);
       } finally {
         delete value.then;
@@ -486,7 +486,7 @@ describe('_prot_wrapResult()', () => {
     const vv    = new BaseValueVisitor(null);
     const got   = vv._prot_wrapResult(value);
 
-    expect(got).toBeInstanceOf(BaseValueVisitor.WrappedResult);
+    expect(got).toBeInstanceOf(VisitResult);
     expect(got.value).toBe(value);
   });
 
@@ -495,7 +495,7 @@ describe('_prot_wrapResult()', () => {
     const vv    = new BaseValueVisitor(null);
     const got   = vv._prot_wrapResult(value);
 
-    expect(got).toBeInstanceOf(BaseValueVisitor.WrappedResult);
+    expect(got).toBeInstanceOf(VisitResult);
     expect(got.value).toBe(value);
   });
 

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -114,6 +114,8 @@ ${'visit'}     | ${true}  | ${false} | ${false}
 ${'visitSync'} | ${false} | ${false} | ${true}
 ${'visitWrap'} | ${true}  | ${true}  | ${true}
 `('$methodName()', ({ methodName, isAsync, wraps, canReturnPromises }) => {
+  const CIRCULAR_MSG = 'Visit is deadlocked due to circular reference.';
+
   async function doTest(value, options = {}) {
     const {
       cls = BaseValueVisitor,
@@ -141,15 +143,14 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
     await doTest(value);
   });
 
-  test('throws the right error if given a value whose visit would directly contain a circular reference', async () => {
+  test('throws the right error if given a value whose synchronous visit directly encountered a circular reference', async () => {
     const circ1 = [4];
     const circ2 = [5, 6, circ1];
     const value = [1, [2, 3, circ1]];
 
     circ1.push(circ2);
 
-    const MSG = 'Visit is deadlocked due to circular reference.';
-    await expect(doTest(value, { cls: SubVisit })).rejects.toThrow(MSG);
+    await expect(doTest(value, { cls: SubVisit })).rejects.toThrow(CIRCULAR_MSG);
   });
 
   if (isAsync) {

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -112,11 +112,11 @@ describe('constructor()', () => {
   });
 });
 
-describe('.value', () => {
+describe('.rootValue', () => {
   test('is the value passed into the constructor', () => {
     const value = ['yes', 'this', 'is', 'it'];
     const vv    = new BaseValueVisitor(value);
-    expect(vv.value).toBe(value);
+    expect(vv.rootValue).toBe(value);
   });
 });
 

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -308,14 +308,19 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
         cls: RefMakingVisitor,
         check: (got) => {
           expect(got).toBeArrayOfSize(3);
-          const gotInner = got[0];
+
+          const gotInner  = got[0];
           const gotMiddle = got[1];
+
           expect(got[0]).toEqual(['bonk']);
           expect(gotMiddle).toBeArrayOfSize(1);
+
           const gotRef = gotMiddle[0];
+
           expect(gotRef).toBeInstanceOf(BaseValueVisitor.VisitRef);
           expect(got[2]).toBeInstanceOf(BaseValueVisitor.VisitRef);
           expect(gotRef).toBe(got[2]);
+          expect(gotRef.originalValue).toBe(inner);
         }
       });
     });
@@ -338,6 +343,7 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
           expect(gotInner[0]).toEqual('bonk');
           expect(gotInner[1]).toBeInstanceOf(BaseValueVisitor.VisitRef);
           expect(gotInner[1]).toBe(gotRef);
+          expect(gotRef.originalValue).toBe(inner);
         }
       });
     });

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -140,6 +140,17 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
     await doTest(value);
   });
 
+  test('throws the right error if given a value whose visit would directly contain a circular reference', async () => {
+    const circ1 = [4];
+    const circ2 = [5, 6, circ1];
+    const value = [1, [2, 3, circ1]];
+
+    circ1.push(circ2);
+
+    const MSG = 'Visit is deadlocked due to circular reference.';
+    await expect(doTest(value, { cls: SubVisit })).rejects.toThrow(MSG);
+  });
+
   if (isAsync) {
     test('returns the value which was returned asynchronously by an `_impl_visit*()` method', async () => {
       const value = true;
@@ -165,16 +176,6 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
 
     test('throws the right error if a will-fail visit did not finish synchronously', async () => {
       const value = Symbol('eeeeek');
-      await expect(doTest(value, { cls: SubVisit })).rejects.toThrow(MSG);
-    });
-
-    test('throws the right error if given a value containing a circular reference', async () => {
-      const circ1 = [4];
-      const circ2 = [5, 6, circ1];
-      const value = [1, [2, 3, circ1]];
-
-      circ1.push(circ2);
-
       await expect(doTest(value, { cls: SubVisit })).rejects.toThrow(MSG);
     });
   }


### PR DESCRIPTION
This PR does a couple things to help with visiting circularly-referenced values and values with partially shared structure:

* Allows for shared structure to optionally be detected, converting second-and-subsequent encounters with a duplicate value to be converted into a "ref."
* Detects when a value has a circular reference which wasn't converted into a "ref," which means that a visit cannot ever be completed (because the construction of the visit result, or part of it, depends on itself having already been constructed). As such, it will cause an error to be thrown.