### PR TITLE
A bit more work on `BaseValueVisitor`.

### DIFF
--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -139,123 +139,6 @@ export class BaseValueVisitor {
   }
 
   /**
-   * Visitor for a "node" (referenced value, including possibly the root) of the
-   * graph of values being visited. If there is already an entry in
-   * {@link #visits} for the node, it is returned. Otherwise, a new entry is
-   * created, and visiting is initiated (and possibly, but not necessarily,
-   * finished).
-   *
-   * @param {*} node The node being visited.
-   * @returns {BaseValueVisitor#VisitEntry} Entry from {@link #visits} which
-   *   represents the current state of the visit.
-   */
-  #visitNode(node) {
-    const already = this.#visits.get(node);
-
-    if (already) {
-      const ref = already.ref;
-      if (ref) {
-        return this.#visitNode(ref);
-      } else if (this.#shouldRef(node)) {
-        const newRef =
-          new BaseValueVisitor.VisitRef(already, this.#nextRefIndex);
-        this.#nextRefIndex++;
-        already.ref = newRef;
-        return this.#visitNode(newRef);
-      } else {
-        return already;
-      }
-    }
-
-    const visitEntry = new BaseValueVisitor.#VisitEntry(node);
-    this.#visits.set(node, visitEntry);
-
-    // This call synchronously calls back to `visitNode0()`.
-    visitEntry.startVisit(this);
-
-    return visitEntry;
-  }
-
-  /**
-   * Helper for {@link #visitNode}, which does the actual dispatch.
-   *
-   * @param {*} node The node being visited.
-   * @returns {*} Whatever the `_impl_visit*()` method returned.
-   */
-  #visitNode0(node) {
-    switch (typeof node) {
-      case 'bigint': {
-        return this._impl_visitBigInt(node);
-      }
-
-      case 'boolean': {
-        return this._impl_visitBoolean(node);
-      }
-
-      case 'number': {
-        return this._impl_visitNumber(node);
-      }
-
-      case 'string': {
-        return this._impl_visitString(node);
-      }
-
-      case 'symbol': {
-        return this._impl_visitSymbol(node);
-      }
-
-      case 'undefined': {
-        return this._impl_visitUndefined();
-      }
-
-      case 'function': {
-        if (this.#isProxy(node)) {
-          return this._impl_visitProxy(node, true);
-        } else if (AskIf.callableFunction(node)) {
-          return this._impl_visitFunction(node);
-        } else {
-          return this._impl_visitClass(node);
-        }
-      }
-
-      case 'object': {
-        if (node === null) {
-          return this._impl_visitNull();
-        } else if (this.#isProxy(node)) {
-          return this._impl_visitProxy(node, false);
-        } else if (Array.isArray(node)) {
-          return this._impl_visitArray(node);
-        } else if (AskIf.plainObject(node)) {
-          return this._impl_visitPlainObject(node);
-        } else if (node instanceof BaseValueVisitor.VisitRef) {
-          return this._impl_visitRef(node);
-        } else {
-          return this._impl_visitInstance(node);
-        }
-      }
-
-      /* c8 ignore start */
-      default: {
-        // JavaScript added a new type after this code was written!
-        throw new Error(`Unrecognized \`typeof\` result: ${typeof node}`);
-      }
-      /* c8 ignore stop */
-    }
-  }
-
-  /**
-   * Gets the entry for the root value being visited, including starting the
-   * visit (and possibly completing it) if this is the first time a `visit*()`
-   * method is being called.
-   *
-   * @returns {BaseValueVisitor#VisitEntry} Vititor entry for the root value.
-   */
-  #visitRoot() {
-    const node = this.#rootValue;
-    return this.#visits.get(node) ?? this.#visitNode(node);
-  }
-
-  /**
    * Indicates whether this instance should be aware of proxies. If `true`,
    * visiting a proxy will cause {@link #_impl_visitProxy} to be called. If
    * `false`, visiting a proxy will cause an `_impl_visit*()` method to be
@@ -556,6 +439,111 @@ export class BaseValueVisitor {
   }
 
   /**
+   * Visitor for a "node" (referenced value, including possibly the root) of the
+   * graph of values being visited. If there is already an entry in
+   * {@link #visits} for the node, it is returned. Otherwise, a new entry is
+   * created, and visiting is initiated (and possibly, but not necessarily,
+   * finished).
+   *
+   * @param {*} node The node being visited.
+   * @returns {BaseValueVisitor#VisitEntry} Entry from {@link #visits} which
+   *   represents the current state of the visit.
+   */
+  #visitNode(node) {
+    const already = this.#visits.get(node);
+
+    if (already) {
+      const ref = already.ref;
+      if (ref) {
+        return this.#visitNode(ref);
+      } else if (this.#shouldRef(node)) {
+        const newRef =
+          new BaseValueVisitor.VisitRef(already, this.#nextRefIndex);
+        this.#nextRefIndex++;
+        already.ref = newRef;
+        return this.#visitNode(newRef);
+      } else {
+        return already;
+      }
+    }
+
+    const visitEntry = new BaseValueVisitor.#VisitEntry(node);
+    this.#visits.set(node, visitEntry);
+
+    // This call synchronously calls back to `visitNode0()`.
+    visitEntry.startVisit(this);
+
+    return visitEntry;
+  }
+
+  /**
+   * Helper for {@link #visitNode}, which does the actual dispatch.
+   *
+   * @param {*} node The node being visited.
+   * @returns {*} Whatever the `_impl_visit*()` method returned.
+   */
+  #visitNode0(node) {
+    switch (typeof node) {
+      case 'bigint': {
+        return this._impl_visitBigInt(node);
+      }
+
+      case 'boolean': {
+        return this._impl_visitBoolean(node);
+      }
+
+      case 'number': {
+        return this._impl_visitNumber(node);
+      }
+
+      case 'string': {
+        return this._impl_visitString(node);
+      }
+
+      case 'symbol': {
+        return this._impl_visitSymbol(node);
+      }
+
+      case 'undefined': {
+        return this._impl_visitUndefined();
+      }
+
+      case 'function': {
+        if (this.#isProxy(node)) {
+          return this._impl_visitProxy(node, true);
+        } else if (AskIf.callableFunction(node)) {
+          return this._impl_visitFunction(node);
+        } else {
+          return this._impl_visitClass(node);
+        }
+      }
+
+      case 'object': {
+        if (node === null) {
+          return this._impl_visitNull();
+        } else if (this.#isProxy(node)) {
+          return this._impl_visitProxy(node, false);
+        } else if (Array.isArray(node)) {
+          return this._impl_visitArray(node);
+        } else if (AskIf.plainObject(node)) {
+          return this._impl_visitPlainObject(node);
+        } else if (node instanceof BaseValueVisitor.VisitRef) {
+          return this._impl_visitRef(node);
+        } else {
+          return this._impl_visitInstance(node);
+        }
+      }
+
+      /* c8 ignore start */
+      default: {
+        // JavaScript added a new type after this code was written!
+        throw new Error(`Unrecognized \`typeof\` result: ${typeof node}`);
+      }
+      /* c8 ignore stop */
+    }
+  }
+
+  /**
    * Helper for {@link #_prot_visitArrayProperties} and
    * {@link #_prot_visitObjectProperties}, which does most of the work.
    *
@@ -612,6 +600,18 @@ export class BaseValueVisitor {
         return result;
       })();
     }
+  }
+
+  /**
+   * Gets the entry for the root value being visited, including starting the
+   * visit (and possibly completing it) if this is the first time a `visit*()`
+   * method is being called.
+   *
+   * @returns {BaseValueVisitor#VisitEntry} Vititor entry for the root value.
+   */
+  #visitRoot() {
+    const node = this.#rootValue;
+    return this.#visits.get(node) ?? this.#visitNode(node);
   }
 
 

--- a/src/util/export/VisitRef.js
+++ b/src/util/export/VisitRef.js
@@ -1,0 +1,82 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Forward declaration of this class, because `import`ing it would cause a
+ * circular dependency while loading.
+ *
+ * @typedef BaseValueVisitor
+ * @type {object}
+ */
+
+/**
+ * Declaration of the class `BaseValueVisitor.#VisitEntry` for documentation
+ * purposes. The class isn't exposed publicly.
+ *
+ * @typedef VisitEntry
+ * @type {object}
+ */
+
+/**
+ * Companion class of {@link BaseValueVisitor}, which represents the result of
+ * a visit of a value that had been visited elsewhere during a visit.
+ *
+ * Along with just having a record of the shared nature of the structure,
+ * instances of this class are also instrucmental in "breaking" circular
+ * references during visits, making it possible to fully visit values that have
+ * such circular references. See {@link BaseValueVisitor#shouldRef} for more
+ * details.
+ */
+export class VisitRef {
+  /**
+   * The entry which is being referred to.
+   *
+   * @type {VisitEntry}
+   */
+  #entry;
+
+  /**
+   * The reference index number.
+   *
+   * @type {number}
+   */
+  #index;
+
+  /**
+   * Constructs an instance. Note that the first parameter is an instance of
+   * a private inner class of {@link BaseValueVisitor}, and as such, this
+   * constructor isn't usable publicly.
+   *
+   * @param {VisitEntry} entry The visit-in-progress entry representing the
+   *   original visit.
+   * @param {number} index The reference index number.
+   */
+  constructor(entry, index) {
+    this.#entry = entry;
+    this.#index = index;
+  }
+
+  /**
+   * @returns {number} The reference index number. Each instance of this class
+   * used within a particular visitor has a unique index number.
+   */
+  get index() {
+    return this.#index;
+  }
+
+  /**
+   * @returns {*} The original value (not the visit result) which this
+   * instance is a reference to.
+   */
+  get originalValue() {
+    return this.#entry.originalValue;
+  }
+
+  /**
+   * @returns {*} The result value of the visit. This will throw an error if
+   * the visit was unsuccessful.
+   */
+  get value() {
+    return this.#entry.extractSync();
+  }
+}

--- a/src/util/export/VisitResult.js
+++ b/src/util/export/VisitResult.js
@@ -11,7 +11,7 @@
  */
 
 /**
- * Companion class of {@link #BaseValueVisitor}, which holds the result from a
+ * Companion class of {@link BaseValueVisitor}, which holds the result from a
  * visit.
  *
  * This class exists to avoid ambiguity when promises are used as results-per-se

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -3,4 +3,5 @@
 
 export * from '#x/BaseValueVisitor';
 export * from '#x/ErrorUtil';
+export * from '#x/VisitRef';
 export * from '#x/VisitResult';

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -487,6 +487,23 @@ ${'_impl_visitUndefined'}   | ${false} | ${true}   | ${undefined}
       vv[methodName] = () => expected;
       expect(vv.visitSync()).toBe(expected);
     });
+
+    test('gets called during a visit to a non-root value of the appropriate type', () => {
+      // What's going on: We use `null` as the root value as a hook to make a
+      // sub-visit on the appropriate-typed value. _Except_, if the value is
+      // `null`, then we use a string instead.
+      const rootValue = (value === null) ? 'bonk' : null;
+      const rootImpl  = (rootValue === null) ? '_impl_visitNull' : '_impl_visitString';
+      const expected  = ['this', 'is', 'it'];
+      const vv        = new BaseValueVisitor(rootValue);
+      vv[methodName]  = () => expected;
+      vv[rootImpl]    = () => vv._prot_visitArrayProperties([value]);
+
+      const got = vv.visitSync();
+      expect(got).toBeInstanceOf(Array);
+      expect(got).toBeArrayOfSize(1);
+      expect(got[0]).toBe(expected);
+    });
   }
 
   if (canWrap) {

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -457,27 +457,37 @@ describe('visit()', () => {
   });
 });
 
+// Common tests for type-specific visitors.
 describe.each`
-methodName                  | canWrap  | value
-${'_impl_visitArray'}       | ${true}  | ${[1, 2, 3]}
-${'_impl_visitBigInt'}      | ${false} | ${99988777n}
-${'_impl_visitBoolean'}     | ${false} | ${false}
-${'_impl_visitClass'}       | ${true}  | ${class Florp {}}
-${'_impl_visitFunction'}    | ${true}  | ${() => 'x'}
-${'_impl_visitInstance'}    | ${true}  | ${new Set(['woo'])}
-${'_impl_visitNull'}        | ${false} | ${null}
-${'_impl_visitNumber'}      | ${false} | ${54.321}
-${'_impl_visitPlainObject'} | ${true}  | ${{ x: 'bonk' }}
-${'_impl_visitProxy'}       | ${true}  | ${new Proxy({}, {})}
-${'_impl_visitRef'}         | ${false} | ${new VisitRef(null, 5)}
-${'_impl_visitString'}      | ${false} | ${'florp'}
-${'_impl_visitSymbol'}      | ${false} | ${Symbol('woo')}
-${'_impl_visitUndefined'}   | ${false} | ${undefined}
-`('$methodName()', ({ methodName, canWrap, value }) => {
+methodName                  | canWrap  | testVisit | value
+${'_impl_visitArray'}       | ${true}  | ${true}   | ${[1, 2, 3]}
+${'_impl_visitBigInt'}      | ${false} | ${true}   | ${99988777n}
+${'_impl_visitBoolean'}     | ${false} | ${true}   | ${false}
+${'_impl_visitClass'}       | ${true}  | ${true}   | ${class Florp {}}
+${'_impl_visitFunction'}    | ${true}  | ${true}   | ${() => 'x'}
+${'_impl_visitInstance'}    | ${true}  | ${true}   | ${new Set(['woo'])}
+${'_impl_visitNull'}        | ${false} | ${true}   | ${null}
+${'_impl_visitNumber'}      | ${false} | ${true}   | ${54.321}
+${'_impl_visitPlainObject'} | ${true}  | ${true}   | ${{ x: 'bonk' }}
+${'_impl_visitProxy'}       | ${true}  | ${false}  | ${new Proxy({}, {})}
+${'_impl_visitRef'}         | ${false} | ${true}   | ${new VisitRef(null, 5)}
+${'_impl_visitString'}      | ${false} | ${true}   | ${'florp'}
+${'_impl_visitSymbol'}      | ${false} | ${true}   | ${Symbol('woo')}
+${'_impl_visitUndefined'}   | ${false} | ${true}   | ${undefined}
+`('$methodName()', ({ methodName, canWrap, testVisit, value }) => {
   test('returns the given value as-is (default implementation)', () => {
     const vv = new BaseValueVisitor(null);
     expect(vv[methodName](value)).toBe(value);
   });
+
+  if (testVisit) {
+    test('gets called during a visit to a root value of the appropriate type', () => {
+      const expected = ['yep', 'it', 'was', 'called'];
+      const vv       = new BaseValueVisitor(value);
+      vv[methodName] = () => expected;
+      expect(vv.visitSync()).toBe(expected);
+    });
+  }
 
   if (canWrap) {
     test('returns a wrapper given a needs-wrapping value', () => {
@@ -493,6 +503,25 @@ ${'_impl_visitUndefined'}   | ${false} | ${undefined}
       }
     });
   }
+});
+
+describe('_impl_visitProxy()', () => {
+  test('does not get called during a visit when `_impl_proxyAware()` returns `false`', () => {
+    const value = new Proxy({}, {});
+    const vv    = new BaseValueVisitor(value);
+    vv._impl_visitProxy = () => 'wrong-value';
+
+    expect(vv.visitSync()).toBe(value);
+  });
+
+  test('gets called during a visit when `_impl_proxyAware()` returns `true`', () => {
+    const value    = new Proxy({}, {});
+    const expected = 'right-value';
+    const vv       = new ProxyAwareVisitor(value);
+    vv._impl_visitProxy = () => expected;
+
+    expect(vv.visitSync()).toBe(expected);
+  });
 });
 
 describe('_prot_visitArrayProperties()', () => {

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -4,7 +4,7 @@
 import { setImmediate } from 'node:timers/promises';
 
 import { ManualPromise, PromiseState, PromiseUtil } from '@this/async';
-import { BaseValueVisitor, VisitResult } from '@this/util';
+import { BaseValueVisitor, VisitRef, VisitResult } from '@this/util';
 
 
 const EXAMPLES = [
@@ -317,8 +317,8 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
 
           const gotRef = gotMiddle[0];
 
-          expect(gotRef).toBeInstanceOf(BaseValueVisitor.VisitRef);
-          expect(got[2]).toBeInstanceOf(BaseValueVisitor.VisitRef);
+          expect(gotRef).toBeInstanceOf(VisitRef);
+          expect(got[2]).toBeInstanceOf(VisitRef);
           expect(gotRef).toBe(got[2]);
           expect(gotRef.originalValue).toBe(inner);
           expect(gotRef.value).toBe(gotInner);
@@ -339,10 +339,10 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
           const gotInner = got[0];
           const gotRef   = got[1];
 
-          expect(gotRef).toBeInstanceOf(BaseValueVisitor.VisitRef);
+          expect(gotRef).toBeInstanceOf(VisitRef);
           expect(gotInner).toBeArrayOfSize(2);
           expect(gotInner[0]).toEqual('bonk');
-          expect(gotInner[1]).toBeInstanceOf(BaseValueVisitor.VisitRef);
+          expect(gotInner[1]).toBeInstanceOf(VisitRef);
           expect(gotInner[1]).toBe(gotRef);
           expect(gotRef.originalValue).toBe(inner);
           expect(gotRef.value).toBe(gotInner);
@@ -397,7 +397,7 @@ ${'_impl_visitNull'}        | ${false} | ${null}
 ${'_impl_visitNumber'}      | ${false} | ${54.321}
 ${'_impl_visitPlainObject'} | ${true}  | ${{ x: 'bonk' }}
 ${'_impl_visitProxy'}       | ${true}  | ${new Proxy({}, {})}
-${'_impl_visitRef'}         | ${false} | ${new BaseValueVisitor.VisitRef(null, 5)}
+${'_impl_visitRef'}         | ${false} | ${new VisitRef(null, 5)}
 ${'_impl_visitString'}      | ${false} | ${'florp'}
 ${'_impl_visitSymbol'}      | ${false} | ${Symbol('woo')}
 ${'_impl_visitUndefined'}   | ${false} | ${undefined}

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -372,7 +372,7 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
   });
 
   describe('when `_impl_shouldRef()` can return `true`', () => {
-    test('will make a ref for a non-circular duplicate value', async () => {
+    test('makes a ref for a non-circular duplicate value', async () => {
       const inner = ['bonk'];
       const outer = [inner, [inner], inner];
 
@@ -398,7 +398,7 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
       });
     });
 
-    test('will make a ref for a circularly-referenced value', async () => {
+    test('makes a ref for a circularly-referenced value', async () => {
       const inner = ['bonk'];
       const outer = [inner, inner];
 
@@ -421,6 +421,23 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
         }
       });
     });
+
+    test('makes refs with the expected `index`es', async () => {
+      const shared0 = ['bonk'];
+      const shared1 = ['boop'];
+      const outer   = [shared0, shared1, shared0, shared1];
+
+      await doTest(outer, {
+        cls: RefMakingVisitor,
+        check: (got) => {
+          expect(got).toBeArrayOfSize(4);
+          expect(got[2]).toBeInstanceOf(VisitRef);
+          expect(got[3]).toBeInstanceOf(VisitRef);
+          expect(got[2].index).toBe(0);
+          expect(got[3].index).toBe(1);
+        }
+      });
+    })
   });
 });
 

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -437,7 +437,7 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
           expect(got[3].index).toBe(1);
         }
       });
-    })
+    });
   });
 });
 


### PR DESCRIPTION
This PR is one more cleanup pass on `BaseValueVisitor`, along with rounding out the ref-related functionality.