### PR TITLE
`BaseValueVisitor` circular reference cleanup

### DIFF
--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -719,7 +719,10 @@ export class BaseValueVisitor {
     /**
      * @returns {Promise} A promise for `this`, which resolves once the visit
      * has been finished (whether or not successful). It is only valid to use
-     * this getter after {@link #startVisit} has been called.
+     * this getter after {@link #startVisit} has been called, and in the case
+     * where this gets called _after_ a call to {@link #startVisit} but _before_
+     * it synchronously returns, this will throw an error indicating that the
+     * visit contains a (synchronously detected) circular reference.
      */
     get promise() {
       if (this.#promise) {
@@ -804,24 +807,13 @@ export class BaseValueVisitor {
     }
 
     /**
-     * Returns an indication of whether the visit is started or finished,
-     * throwing in the case where the visit hasn't _yet_ been started.
+     * Returns an indication of whether the visit has finished.
      *
      * @returns {boolean} `false` if the visit is in progress, or `true` if it
      *   is finished.
-     * @throws {Error} Thrown if the visit hasn't yet started. This is
-     *   indicative of a bug in this class.
      */
     isFinished() {
-      if (this.#ok !== null) {
-        return true;
-      }
-
-      // This causes a "shouldn't happen" error when appropriate (hopefully
-      // never.)
-      this.#promise;
-
-      return false;
+      return (this.#ok !== null);
     }
 
     /**

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -819,8 +819,7 @@ export class BaseValueVisitor {
      */
     isFinished() {
       if (this.#ok === null) {
-        // Force a "circular reference" error if this method is called in the
-        // middle of a call to `this.startVisit()`.
+        // Force a "circular reference" error when warranted (see above).
         this.promise;
         return false;
       } else {

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -822,6 +822,7 @@ export class BaseValueVisitor {
         // Force a "circular reference" error if this method is called in the
         // middle of a call to `this.startVisit()`.
         this.promise;
+        return false;
       } else {
         return true;
       }

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -611,7 +611,7 @@ export class BaseValueVisitor {
     if (promInfo.length === 0) {
       return result;
     } else {
-      // At least one property's visit isn't finished.
+      // At least one property's visit didn't finish synchronously.
       return (async () => {
         for (const { name, entry, promise } of promInfo) {
           if (this.#waitSet.has(entry)) {

--- a/src/util/export/BaseValueVisitor.js
+++ b/src/util/export/BaseValueVisitor.js
@@ -784,8 +784,8 @@ export class BaseValueVisitor {
      *   possibility that the visit has been started but not finished?
      * @returns {*} The successful result of the visit, if it was indeed
      *   successful.
-     * @throws {Error} The error resulting from the visit, if it failed; or
-     *   an error indicating that the visit is still in progress.
+     * @throws {Error} The error resulting from the visit, if it failed; or an
+     *   error indicating that the visit is still in progress.
      */
     extractSync(possiblyUnfinished = false) {
       if (this.isFinished()) {
@@ -814,8 +814,8 @@ export class BaseValueVisitor {
      *   is finished.
      * @throws {Error} Thrown if this method is called before a call to
      *   {@link #startVisit} on this instance returns (including being called
-     *   before any call to {@link #startVisit}), which indicates that the
-     *   value being visited is involved in a circular reference.
+     *   before any call to {@link #startVisit}), which indicates that the value
+     *   being visited is involved in a circular reference.
      */
     isFinished() {
       if (this.#ok === null) {
@@ -893,8 +893,8 @@ export class BaseValueVisitor {
     }
 
     /**
-     * Sets the visit result to be an error value. This indicates that the
-     * visit has in fact finished with `ok === false`.
+     * Sets the visit result to be an error value. This indicates that the visit
+     * has in fact finished with `ok === false`.
      *
      * @param {Error} error The visit error.
      */

--- a/src/util/export/VisitRef.js
+++ b/src/util/export/VisitRef.js
@@ -18,8 +18,8 @@
  */
 
 /**
- * Companion class of {@link BaseValueVisitor}, which represents the result of
- * a visit of a value that had been visited elsewhere during a visit.
+ * Companion class of {@link BaseValueVisitor}, which represents the result of a
+ * visit of a value that had been visited elsewhere during a visit.
  *
  * Along with just having a record of the shared nature of the structure,
  * instances of this class are also instrucmental in "breaking" circular
@@ -43,8 +43,8 @@ export class VisitRef {
   #index;
 
   /**
-   * Constructs an instance. Note that the first parameter is an instance of
-   * a private inner class of {@link BaseValueVisitor}, and as such, this
+   * Constructs an instance. Note that the first parameter is an instance of a
+   * private inner class of {@link BaseValueVisitor}, and as such, this
    * constructor isn't usable publicly.
    *
    * @param {VisitEntry} entry The visit-in-progress entry representing the


### PR DESCRIPTION
This PR fixes some minorly problematic code having to do with circular reference detection.