### PR TITLE
Start of logging implementation rework on top of `BaseValueVisitor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ Breaking changes:
     to a classic s-expression (practically speaking, at least).
   * See also `util`.
 * `util`:
-  * Moved stack-trace-related classes from `codec` into this module.
+  * Moved stack-trace-related classes from `codec` into this module, along with
+    the `Error` stack parser.
   * New class `IntfDeconstructable` which replaces `codec.BaseCodec.ENCODE`.
-* `loggy`:
+* `loggy-intf`:
   * Removed `IntfLoggingEnviroment.logPayload()`.
+  * New class `LoggedValueEncoder`, which replaces the log-related stuff in
+    `codec`.
 
 Other notable changes:
 * `webapp-util`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Breaking changes:
 * `util`:
   * Moved stack-trace-related classes from `codec` into this module.
   * New class `IntfDeconstructable` which replaces `codec.BaseCodec.ENCODE`.
+* `loggy`:
+  * Removed `IntfLoggingEnviroment.logPayload()`.
 
 Other notable changes:
 * `webapp-util`:

--- a/src/host/package.json
+++ b/src/host/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@this/async": "*",
     "@this/clocky": "*",
-    "@this/codec": "*",
     "@this/compy": "*",
     "@this/loggy": "*",
     "@this/loggy-intf": "*",

--- a/src/loggy-intf/export/IntfLoggingEnvironment.js
+++ b/src/loggy-intf/export/IntfLoggingEnvironment.js
@@ -26,7 +26,10 @@ export class IntfLoggingEnvironment {
    * Logs a {@link #LogPayload}, which is constructed from the arguments passed
    * to this method along with a timestamp and stack trace as implemented by the
    * concrete implementation, as if by {@link #makePayload}. The so-constructed
-   * payload is then emitted, as if by {@link #logPayload}.
+   * payload is then emitted, in an implementation-dependent manner, which is
+   * _typically_ to emit an event (e.g. a `LinkedEvent`) from an event source of
+   * some sort (which is, to be clear, what the standard concrete implementation
+   * of this class does).
    *
    * @param {number} omitCount The number of caller frames to omit from the
    *   stack trace.
@@ -36,19 +39,6 @@ export class IntfLoggingEnvironment {
    */
   log(omitCount, tag, type, ...args) {
     Methods.abstract(omitCount, tag, type, args);
-  }
-
-  /**
-   * Logs a pre-constructed {@link #LogPayload}. Typically, this ends up
-   * emitting an event (e.g. a `LinkedEvent`) from an event source of some sort
-   * (which is, for example, what the standard concrete implementation of this
-   * interface does), but it is not _necessarily_ what happens (that is, it
-   * depends on the implementation).
-   *
-   * @param {LogPayload} payload What to log.
-   */
-  logPayload(payload) {
-    Methods.abstract(payload);
   }
 
   /**

--- a/src/loggy-intf/export/LoggedValueEncoder.js
+++ b/src/loggy-intf/export/LoggedValueEncoder.js
@@ -1,0 +1,96 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import { Sexp } from '@this/codec';
+import { BaseValueVisitor, ErrorUtil } from '@this/util';
+
+
+/**
+ * Standard way to encode values used in logged events, such that they become
+ * (as close as possible to) simple immutable data. This is where, e.g., class
+ * instances (that aren't special-cased) get converted into non-instance
+ * objects.
+ *
+ * The main intended interface for this class is the static method
+ * {@link #encode}, but it can also just be used directly as the concrete
+ * visitor class that it is.
+ *
+ * **Note:** This class implements a one-way encoding. It is not possible to
+ * recover the original active objects that were encoded (or even copies
+ * thereof). This is intentional; this class is just for logging, and it is
+ * specifically not appropriate to use it as part of a data storage/retrieval
+ * system, RPC mechanism, or similar.
+ */
+export class LoggedValueEncoder extends BaseValueVisitor {
+  // @defaultConstructor
+
+  /** @override */
+  _impl_isProxyAware() {
+    return true;
+  }
+
+  /** @override */
+  _impl_shouldRef(value_unused) {
+    return true;
+  }
+
+  /** @override */
+  _impl_visitArray(node) {
+    return this._prot_visitArrayProperties(node);
+  }
+
+  /** @override */
+  _impl_visitClass(node) {
+    return this._prot_nameFromValue(node);
+  }
+
+  /** @override */
+  _impl_visitError(node) {
+    const decon   = ErrorUtil.deconstructError(node);
+    const visited = this._prot_visitArrayProperties(decon);
+
+    return new Sexp(...visited);
+  }
+
+  /** @override */
+  _impl_visitFunction(node) {
+    return this._prot_nameFromValue(node);
+  }
+
+  /** @override */
+  _impl_visitInstance(node) {
+    if (typeof node.deconstruct === 'function') {
+      const decon   = node.deconstruct();
+      const visited = this._prot_visitArrayProperties(decon);
+      return new Sexp(...visited);
+    } else {
+      return this._prot_nameFromValue(node);
+    }
+  }
+
+  /** @override */
+  _impl_visitPlainObject(node) {
+    return this._prot_visitObjectProperties(node);
+  }
+
+  /** @override */
+  _impl_visitProxy(node, isFunction_unused) {
+    return this._prot_nameFromValue(node);
+  }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * Encodes an arbitrary value for use as logged data.
+   *
+   * @param {*} value The value to encode.
+   * @returns {*} The encoded form.
+   */
+  static encode(value) {
+    const visitor = new LoggedValueEncoder(value);
+    return visitor.visitSync();
+  }
+}

--- a/src/loggy-intf/export/LoggedValueEncoder.js
+++ b/src/loggy-intf/export/LoggedValueEncoder.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Sexp } from '@this/codec';
+import { AskIf } from '@this/typey';
 import { BaseValueVisitor, ErrorUtil } from '@this/util';
 
 
@@ -30,8 +31,20 @@ export class LoggedValueEncoder extends BaseValueVisitor {
   }
 
   /** @override */
-  _impl_shouldRef(value_unused) {
-    return true;
+  _impl_shouldRef(value) {
+    switch (typeof value) {
+      case 'function': {
+        return AskIf.callableFunction(value);
+      }
+
+      case 'object': {
+        return true;
+      }
+
+      default: {
+        return false;
+      }
+    }
   }
 
   /** @override */

--- a/src/loggy-intf/index.js
+++ b/src/loggy-intf/index.js
@@ -7,3 +7,4 @@ export * from '#x/IntfLogger';
 export * from '#x/IntfLoggingEnvironment';
 export * from '#x/LogPayload';
 export * from '#x/LogTag';
+export * from '#x/LoggedValueEncoder';

--- a/src/loggy/export/BaseLoggingEnvironment.js
+++ b/src/loggy/export/BaseLoggingEnvironment.js
@@ -41,12 +41,6 @@ export class BaseLoggingEnvironment extends IntfLoggingEnvironment {
   }
 
   /** @override */
-  logPayload(payload) {
-    MustBe.instanceOf(payload, LogPayload);
-    this._impl_logPayload(payload);
-  }
-
-  /** @override */
   makeId() {
     return MustBe.string(this._impl_makeId(), /^.{1,20}$/);
   }

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -591,7 +591,6 @@ describe('_prot_nameFromValue()', () => {
     const vv  = new BaseValueVisitor(null);
     const got = vv._prot_nameFromValue(value);
     expect(got).toBe(expected);
-
   });
 
   // The rest.
@@ -619,22 +618,6 @@ describe('_prot_nameFromValue()', () => {
       const got = vv._prot_nameFromValue(value);
       expect(got).toBe(expected);
     });
-  });
-
-  test.each`
-  label                               | value                           | expected
-  ${'an anonymous plain object'}      | ${{ a: 123 }}                   | ${'object {...}'}
-  ${'a named plain object'}           | ${{ name: 'flomp' }}            | ${'flomp {...}'}
-  ${'an anonymous class'}             | ${class {}}                     | ${'class <anonymous>'}
-  ${'a named class'}                  | ${class Florp {}}               | ${'class Florp'}
-  ${'an instance of anonymous class'} | ${new (class {})()}             | ${'<anonymous> {...}'}
-  ${'an instance of named class'}     | ${new (class Boop {})()}        | ${'Boop {...}'}
-  ${'an anonymous function'}          | ${() => 123}                    | ${'<anonymous>()'}
-  ${'a named function'}               | ${function bip() { return 1; }} | ${'bip()'}
-  `('derives the expected name from $label', ({ value, expected }) => {
-    const vv  = new BaseValueVisitor(null);
-    const got = vv._prot_nameFromValue(value);
-    expect(got).toBe(expected);
   });
 });
 

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -564,6 +564,44 @@ describe('_impl_visitError()', () => {
   });
 });
 
+describe('_prot_nameFromValue()', () => {
+  test.each`
+  value
+  ${null}
+  ${undefined}
+  ${true}
+  ${123}
+  ${567n}
+  ${'zonk'}
+  `('stringifies $value', ({ value }) => {
+    const vv  = new BaseValueVisitor(null);
+    const got = vv._prot_nameFromValue(value);
+    expect(got).toBe(`${value}`);
+  });
+
+  test('returns the expected form for a symbol', () => {
+    const vv  = new BaseValueVisitor(null);
+    const got = vv._prot_nameFromValue(Symbol('bonk'));
+    expect(got).toBe(`symbol {bonk}`);
+  });
+
+  test.each`
+  label                               | value                           | expected
+  ${'an anonymous plain object'}      | ${{ a: 123 }}                   | ${'object {...}'}
+  ${'a named plain object'}           | ${{ name: 'flomp' }}            | ${'flomp {...}'}
+  ${'an anonymous class'}             | ${class {}}                     | ${'class <anonymous>'}
+  ${'a named class'}                  | ${class Florp {}}               | ${'class Florp'}
+  ${'an instance of anonymous class'} | ${new (class {})()}             | ${'<anonymous> {...}'}
+  ${'an instance of named class'}     | ${new (class Boop {})()}        | ${'Boop {...}'}
+  ${'an anonymous function'}          | ${() => 123}                    | ${'<anonymous>()'}
+  ${'a named function'}               | ${function bip() { return 1; }} | ${'bip()'}
+  `('derives the expected name from $label', ({ value, expected }) => {
+    const vv  = new BaseValueVisitor(null);
+    const got = vv._prot_nameFromValue(value);
+    expect(got).toBe(expected);
+  });
+});
+
 describe('_impl_visitProxy()', () => {
   describe.each`
   type          | value


### PR DESCRIPTION
This PR is the first chunk of work to directly transition logging off of the `codec` module and onto something built on top of `util.BaseValueVisitor`. Highlights:

* Added utility methods `_prot_{label,name}FromValue()` to `BaseValueEncoder`.
* New class `LoggedValueEncoder`, which is meant to replace log-related uses of the `codec` module.
* Changed `host.Host` to use `LoggedValueEncoder` when reporting `Error`s from a `shutdownDisposition()`.

Notably, the main logging code has not yet been switched over to use `LoggedValueEncoder`. That class will almost certainly require some more tweakage before it can be used for that.