### PR TITLE
More logging rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Breaking changes:
   * Moved stack-trace-related classes from `codec` into this module, along with
     the `Error` stack parser.
   * New class `IntfDeconstructable` which replaces `codec.BaseCodec.ENCODE`.
-* `loggy-intf`:
+* `loggy-intf` / `loggy`:
   * Removed `IntfLoggingEnviroment.logPayload()`.
   * New class `LoggedValueEncoder`, which replaces the log-related stuff in
     `codec`.

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -257,6 +257,8 @@ export class LogPayload extends EventPayload {
    * "human" form. This is akin to `util.inspect()`, though by no means
    * identical.
    *
+   * TODO: Deal with shared refs.
+   *
    * @param {Array<string>} parts Parts array to append to.
    * @param {*} value Value to represent.
    * @param {boolean} [skipBrackets] Skip brackets at this level? This is

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -117,7 +117,10 @@ export class LogPayload extends EventPayload {
   /**
    * Gets a plain object representing this instance. The result has named
    * properties for each of the properties available on instances, except that
-   * `stack` is omitted if `this.stack` is `null`.
+   * `stack` is omitted if `this.stack` is `null`. Everything except `.args` on
+   * the result is guaranteed to be JSON-encodable, and `.args` will be
+   * JSON-encodable as long as `this.args` is, since they will be the exact
+   * same object.
    *
    * @returns {object} The plain object representation of this instance.
    */

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -116,15 +116,16 @@ export class LogPayload extends EventPayload {
 
   /**
    * Gets a plain object representing this instance. The result has named
-   * properties for each of the properties available on instances.
+   * properties for each of the properties available on instances, except that
+   * `stack` is omitted if `this.stack` is `null`.
    *
    * @returns {object} The plain object representation of this instance.
    */
   toPlainObject() {
     return {
-      stack: this.#stack,
-      when:  this.#when,
-      tag:   this.#tag,
+      ...(this.#stack ? { stack: this.#stack.frames } : {}),
+      when:  this.#when.toPlainObject(),
+      tag:   this.#tag.allParts,
       type:  this.type,
       args:  this.args
     };

--- a/src/loggy-intf/export/LogTag.js
+++ b/src/loggy-intf/export/LogTag.js
@@ -36,6 +36,13 @@ export class LogTag extends IntfDeconstructable {
   #context;
 
   /**
+   * Precomputed value for {@link #allParts}, if available.
+   *
+   * @type {?Array<string>}
+   */
+  #allParts = null;
+
+  /**
    * Precomputed "human form" strings, if available.
    *
    * @type {object}
@@ -60,6 +67,18 @@ export class LogTag extends IntfDeconstructable {
     }
 
     this.#context = Object.freeze(context);
+  }
+
+  /**
+   * @returns {Array<string>} The combination of the main tag and context.
+   * Always a frozen array.
+   */
+  get allParts() {
+    if (!this.#allParts) {
+      this.#allParts = Object.freeze([this.#main, ...this.#context]);
+    }
+
+    return this.#allParts;
   }
 
   /** @returns {Array<string>} Context strings. Always a frozen array. */

--- a/src/loggy-intf/tests/LogPayload.test.js
+++ b/src/loggy-intf/tests/LogPayload.test.js
@@ -64,7 +64,7 @@ describe('toHuman()', () => {
       someStack, new Moment(1715623760.5432), someTag, 'yeah', { a: 10 },
       [1, 2, 3], 'yes!');
 
-    const expected = "20240513-18:09:20.5432 some.tag yeah({ a: 10 }, [ 1, 2, 3 ], 'yes!')";
+    const expected = "20240513-18:09:20.5432 some.tag yeah({ a: 10 }, [1, 2, 3], 'yes!')";
     const got      = payload.toHuman(...args);
 
     if (args[0] === true) {

--- a/src/loggy-intf/tests/LogPayload.test.js
+++ b/src/loggy-intf/tests/LogPayload.test.js
@@ -96,11 +96,26 @@ describe('toPlainObject()', () => {
     const got = payload.toPlainObject();
 
     expect(got).toContainAllKeys(['stack', 'when', 'tag', 'type', 'args']);
-    expect(got.stack).toBe(someStack);
-    expect(got.when).toBe(someMoment);
-    expect(got.tag).toBe(someTag);
+    expect(got.stack).toStrictEqual(someStack.frames);
+    expect(got.when).toStrictEqual(someMoment.toPlainObject());
+    expect(got.tag).toStrictEqual(someTag.allParts);
     expect(got.type).toBe('bonk');
-    expect(got.args).toEqual([123, { a: 10 }, ['x']]);
+    expect(got.args).toStrictEqual([123, { a: 10 }, ['x']]);
+  });
+
+  test('omits `stack` when `stack` is `null`', () => {
+    const payload = new LogPayload(null, someMoment, someTag, 'bonk', 123);
+    const got = payload.toPlainObject();
+
+    expect(got).toContainAllKeys(['when', 'tag', 'type', 'args']);
+  });
+
+  test('includes `args` even when `args.length === 0`', () => {
+    const payload = new LogPayload(someStack, someMoment, someTag, 'bonk');
+    const got = payload.toPlainObject();
+
+    expect(got).toContainAllKeys(['stack', 'when', 'tag', 'type', 'args']);
+    expect(got.args).toStrictEqual([]);
   });
 });
 

--- a/src/loggy-intf/tests/LogTag.test.js
+++ b/src/loggy-intf/tests/LogTag.test.js
@@ -110,6 +110,29 @@ describe('.context', () => {
   });
 });
 
+describe('.allParts', () => {
+  test('is the combination of the main tag and contexts', () => {
+    const values = ['yep', 'and', 'also', 'yeah'];
+    expect(new LogTag(...values).allParts).toStrictEqual(values);
+  });
+
+  test('works with just a main tag', () => {
+    const values = ['woo'];
+    expect(new LogTag(...values).allParts).toStrictEqual(values);
+  });
+
+  test('is a frozen array', () => {
+    const got = new LogTag('x', 'y', 'z').allParts;
+    expect(got).toBeFrozen();
+    expect(got).toBeArray();
+  });
+
+  test('is always the same instance', () => {
+    const tag = new LogTag('beep', 'boop');
+    expect(tag.allParts).toBe(tag.allParts);
+  });
+});
+
 describe('.lastContext', () => {
   test('is `null` if there is no context', () => {
     const tag = new LogTag('mainTag');

--- a/src/loggy/export/BaseLoggingEnvironment.js
+++ b/src/loggy/export/BaseLoggingEnvironment.js
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LinkedEvent } from '@this/async';
-import { Codec, CodecConfig } from '@this/codec';
-import { IntfLoggingEnvironment, LogPayload, LogTag } from '@this/loggy-intf';
+import { IntfLoggingEnvironment, LogPayload, LogTag, LoggedValueEncoder }
+  from '@this/loggy-intf';
 import { Moment } from '@this/quant';
 import { Methods, MustBe } from '@this/typey';
 import { StackTrace } from '@this/util';
@@ -20,13 +20,6 @@ import { StackTrace } from '@this/util';
  * @implements {IntfLoggingEnvironment}
  */
 export class BaseLoggingEnvironment extends IntfLoggingEnvironment {
-  /**
-   * Codec to use for encoding payload arguments.
-   *
-   * @type {Codec}
-   */
-  #encoder = new Codec(CodecConfig.makeLoggingInstance());
-
   // @defaultConstructor
 
   /** @override */
@@ -137,7 +130,7 @@ export class BaseLoggingEnvironment extends IntfLoggingEnvironment {
    */
   #makePayloadUnchecked(omitCount, tag, type, ...args) {
     const now       = this.now();
-    const fixedArgs = this.#encoder.encode(args);
+    const fixedArgs = LoggedValueEncoder.encode(args);
 
     // `+1` to omit the frame for this method.
     const trace = this.makeStackTrace(omitCount + 1);

--- a/src/loggy/package.json
+++ b/src/loggy/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@this/async": "*",
     "@this/clocky": "*",
-    "@this/codec": "*",
     "@this/fs-util": "*",
     "@this/loggy-intf": "*",
     "@this/metacomp": "*",

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -777,6 +777,15 @@ describe('_prot_visitArrayProperties()', () => {
 });
 
 describe('_prot_visitObjectProperties()', () => {
+  test('produces a `null`-prototype result', () => {
+    const orig = { x: 'foomp' };
+    const vv   = new RecursiveVisitor(orig);
+    const got  = vv.visitSync();
+
+    expect(got).toEqual(orig);
+    expect(Object.getPrototypeOf(got)).toBeNull();
+  });
+
   test('operates synchronously when possible', () => {
     const orig = { a: 10, b: 20 };
     const vv   = new RecursiveVisitor(orig);

--- a/src/util/tests/BaseValueVisitor.test.js
+++ b/src/util/tests/BaseValueVisitor.test.js
@@ -607,6 +607,10 @@ ${'_prot_nameFromValue'}  | ${'expectedName'}
     }
   }
 
+  // An instance with a `.constructor` that isn't actually a function.
+  const nonFuncConstructor = new Map();
+  nonFuncConstructor.constructor = 'florp';
+
   // The rest.
   describe.each`
   label            | doProxy
@@ -614,14 +618,15 @@ ${'_prot_nameFromValue'}  | ${'expectedName'}
   ${'a non-proxy'} | ${false}
   `('$label', ({ doProxy }) => {
     test.each`
-    label                               | value                           | expectedName     | expectedLabel
-    ${'an anonymous plain object'}      | ${{ a: 123 }}                   | ${'<anonymous>'} | ${'object {...}'}
-    ${'a named plain object'}           | ${{ name: 'flomp' }}            | ${'flomp'}       | ${'flomp {...}'}
-    ${'an instance of anonymous class'} | ${new (class {})()}             | ${'<anonymous>'} | ${'<anonymous> {...}'}
-    ${'an instance of named class'}     | ${new (class Boop {})()}        | ${'<anonymous>'} | ${'Boop {...}'}
-    ${'an instance with a `.name`'}     | ${new AvecName()}               | ${'a-name'}      | ${'AvecName a-name {...}'}
-    ${'an anonymous function'}          | ${() => 123}                    | ${'<anonymous>'} | ${'<anonymous>()'}
-    ${'a named function'}               | ${function bip() { return 1; }} | ${'bip'}         | ${'bip()'}
+    label                                           | value                           | expectedName     | expectedLabel
+    ${'an anonymous plain object'}                  | ${{ a: 123 }}                   | ${'<anonymous>'} | ${'object {...}'}
+    ${'a named plain object'}                       | ${{ name: 'flomp' }}            | ${'flomp'}       | ${'flomp {...}'}
+    ${'an instance of anonymous class'}             | ${new (class {})()}             | ${'<anonymous>'} | ${'<anonymous> {...}'}
+    ${'an instance of named class'}                 | ${new (class Boop {})()}        | ${'<anonymous>'} | ${'Boop {...}'}
+    ${'an instance with a `.name`'}                 | ${new AvecName()}               | ${'a-name'}      | ${'AvecName a-name {...}'}
+    ${'an instance with a non-func `.constructor`'} | ${nonFuncConstructor}           | ${'<anonymous>'} | ${'<anonymous> {...}'}
+    ${'an anonymous function'}                      | ${() => 123}                    | ${'<anonymous>'} | ${'<anonymous>()'}
+    ${'a named function'}                           | ${function bip() { return 1; }} | ${'bip'}         | ${'bip()'}
     `('derives the expected name from $label', ({ value, ...expected }) => {
       const vv = new BaseValueVisitor(null);
 


### PR DESCRIPTION
This PR reworks the main logging code to use the new `LoggedValueEncoder` and related bits, instead of using the `codec` module. There are still some edge cases that need to get worked out, and some rendering that ought to be improved.

As of this PR, the `codec` module is no longer used, though it hasn't yet been deleted: I believe some of the code in it will get "rescued."