### PR TITLE
Reïntegrate `Sexp`

### DIFF
--- a/src/collections/export/PathKey.js
+++ b/src/collections/export/PathKey.js
@@ -3,7 +3,7 @@
 
 import * as util from 'node:util';
 
-import { IntfDeconstructable } from '@this/decon';
+import { IntfDeconstructable, Sexp } from '@this/decon';
 import { MustBe } from '@this/typey';
 
 import { TreeMap } from '#x/TreeMap';
@@ -103,7 +103,7 @@ export class PathKey extends IntfDeconstructable {
 
   /** @override */
   deconstruct() {
-    return [PathKey, this.#path, this.#wildcard];
+    return new Sexp(PathKey, this.#path, this.#wildcard);
   }
 
   /**

--- a/src/collections/tests/PathKey.test.js
+++ b/src/collections/tests/PathKey.test.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PathKey } from '@this/collections';
+import { Sexp } from '@this/decon';
 
 
 describe('constructor()', () => {
@@ -177,13 +178,13 @@ describe('.EMPTY', () => {
 });
 
 describe('deconstruct()', () => {
-  test('produces an array of the constructor class and arguments', () => {
+  test('produces an appropriate `Sexp`', () => {
     const args = [['beep', 'boop'], true];
     const key = new PathKey(...args);
     const got = key.deconstruct();
 
-    expect(got).toBeArray();
-    expect(got).toStrictEqual([PathKey, ...args]);
+    expect(got).toBeInstanceOf(Sexp);
+    expect(got.toArray()).toStrictEqual([PathKey, ...args]);
   });
 });
 

--- a/src/decon/export/IntfDeconstructable.js
+++ b/src/decon/export/IntfDeconstructable.js
@@ -3,6 +3,8 @@
 
 import { Methods } from '@this/typey';
 
+import { Sexp } from '#x/Sexp';
+
 
 /**
  * Interface which indicates that an instance can be "deconstructed" into a

--- a/src/decon/export/IntfDeconstructable.js
+++ b/src/decon/export/IntfDeconstructable.js
@@ -25,7 +25,7 @@ export class IntfDeconstructable {
    * ```
    *
    * @abstract
-   * @returns {Array} Reconstruction class and arguments.
+   * @returns {Sexp} Reconstruction class and arguments.
    */
   deconstruct() {
     throw Methods.abstract();

--- a/src/decon/export/Sexp.js
+++ b/src/decon/export/Sexp.js
@@ -110,7 +110,11 @@ export class Sexp {
       }
 
       case 'string': {
-        return functor;
+        if (functor !== '') {
+          return functor;
+        }
+
+        break;
       }
     }
 

--- a/src/decon/export/Sexp.js
+++ b/src/decon/export/Sexp.js
@@ -142,6 +142,26 @@ export class Sexp {
   }
 
   /**
+   * Implementation of the standard `JSON.stringify()` replacement interface.
+   *
+   * **Note:** This is not intended for high-fidelity data encoding, in that the
+   * result is ambiguous with plain objects that happen to have the same shape
+   * as this method's results, and in that the conversion of the {@link
+   * #functor} is lossy unless it is a string per se. The main intended use
+   * case for this is logging.
+   *
+   * @param {?string} key_unused The property name / stringified index where the
+   *   instance was fetched from.
+   * @returns {*} The replacement form to encode.
+   */
+  toJSON(key_unused) {
+    const name      = this.functorName;
+    const finalName = (name === '<anonymous>') ? '@' : `@${name}`;
+
+    return { [finalName]: this.#args };
+  }
+
+  /**
    * Custom inspector for instances of this class.
    *
    * @param {number} depth Maximum depth to inspect to.

--- a/src/decon/export/Sexp.js
+++ b/src/decon/export/Sexp.js
@@ -86,6 +86,38 @@ export class Sexp {
   }
 
   /**
+   * @returns {string} A reasonably-suggestive "name" for {@link #functor}. If
+   * {@link #functor} is a string, then this is that string. Otherwise, if it is
+   * a function or object with a string `.name` property, it is that property
+   * name. Otherwise, it is `<anonymous>`.
+   */
+  get functorName() {
+    const functor = this.#functor;
+
+    switch (typeof functor) {
+      case 'function':
+      case 'object': {
+        if ((functor === null) || (functor === '')) {
+          break;
+        }
+
+        const name = functor.name;
+        if (typeof name === 'string') {
+          return name;
+        }
+
+        break;
+      }
+
+      case 'string': {
+        return functor;
+      }
+    }
+
+    return '<anonymous>';
+  }
+
+  /**
    * Standard iteration protocol. For this class, it iterates over (what would
    * be) the result of a call to {@link #toArray} at the moment this method was
    * called.

--- a/src/decon/tests/Sexp.test.js
+++ b/src/decon/tests/Sexp.test.js
@@ -50,7 +50,7 @@ describe('.functorName', () => {
     expect(new Sexp(expected, 1, 2, 3).functorName).toBe(expected);
   });
 
-  test('is `.functor.name` if it is a string', () => {
+  test('is `.functor.name` if it is a non-empty string', () => {
     const expected = 'bloop';
     expect(new Sexp({ name: expected }, 1, 2, 3).functorName).toBe(expected);
   });
@@ -65,6 +65,10 @@ describe('.functorName', () => {
     expect(new Sexp(Zonk, 1, 2, 3).functorName).toBe('Zonk');
   });
 
+  test('is `<anonymous>` given the empty string for `.functor`', () => {
+    expect(new Sexp('', []).functorName).toBe('<anonymous>');
+  });
+
   test.each`
   value
   ${undefined}
@@ -76,7 +80,7 @@ describe('.functorName', () => {
   ${{ a: 123 }}
   ${['beep', 'boop']}
   ${new Set('x')}
-  `('is `<anonymous>` given `$value`', ({ value }) => {
+  `('is `<anonymous>` given `$value` for `.functor`', ({ value }) => {
     expect(new Sexp(value, 'boop').functorName).toBe('<anonymous>');
   });
 });

--- a/src/decon/tests/Sexp.test.js
+++ b/src/decon/tests/Sexp.test.js
@@ -44,6 +44,43 @@ describe('.functor =', () => {
   });
 });
 
+describe('.functorName', () => {
+  test('is `.functor` if it is a string', () => {
+    const expected = 'bloop';
+    expect(new Sexp(expected, 1, 2, 3).functorName).toBe(expected);
+  });
+
+  test('is `.functor.name` if it is a string', () => {
+    const expected = 'bloop';
+    expect(new Sexp({ name: expected }, 1, 2, 3).functorName).toBe(expected);
+  });
+
+  test('is the function name if `.functor` is a function', () => {
+    function florp() { return null; }
+    expect(new Sexp(florp, 1, 2, 3).functorName).toBe('florp');
+  });
+
+  test('is the class name if `.functor` is a class', () => {
+    class Zonk { /*empty*/ }
+    expect(new Sexp(Zonk, 1, 2, 3).functorName).toBe('Zonk');
+  });
+
+  test.each`
+  value
+  ${undefined}
+  ${null}
+  ${true}
+  ${123}
+  ${123n}
+  ${Symbol('boop')}
+  ${{ a: 123 }}
+  ${['beep', 'boop']}
+  ${new Set('x')}
+  `('is `<anonymous>` given `$value`', ({ value }) => {
+    expect(new Sexp(value, 'boop').functorName).toBe('<anonymous>');
+  });
+});
+
 describe('.args', () => {
   test('is an array', () => {
     expect(new Sexp('x').args).toBeArray();

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -268,7 +268,8 @@ export class LogPayload extends EventPayload {
    * @param {Array<string>} parts Parts array to append to.
    * @param {*} value Value to represent.
    * @param {boolean} [skipBrackets] Skip brackets at this level? This is
-   *   passed as `true` for the very top-level call to this method.
+   *   passed as `true` for the very top-level call to this method and when
+   *   processing `Sexp`s.
    */
   static #appendHumanValue(parts, value, skipBrackets = false) {
     switch (typeof value) {

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -281,6 +281,10 @@ export class LogPayload extends EventPayload {
             parts.push(' = ');
             this.#appendHumanValue(parts, value.value);
           }
+        } else if (value instanceof Sexp) {
+          parts.push('@', value.functorName, '(');
+          this.#appendHumanAggregate(parts, value.args, true);
+          parts.push(')');
         } else {
           this.#appendHumanAggregate(parts, value, skipBrackets);
         }

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -4,7 +4,7 @@
 import * as util from 'node:util';
 
 import { EventPayload, EventSource } from '@this/async';
-import { IntfDeconstructable } from '@this/decon';
+import { IntfDeconstructable, Sexp } from '@this/decon';
 import { Moment } from '@this/quant';
 import { Chalk } from '@this/text';
 import { MustBe } from '@this/typey';
@@ -89,8 +89,8 @@ export class LogPayload extends EventPayload {
 
   /** @override */
   deconstruct() {
-    return [LogPayload,
-      this.#stack, this.#when, this.#tag, this.type, ...this.args];
+    return new Sexp(LogPayload,
+      this.#stack, this.#when, this.#tag, this.type, ...this.args);
   }
 
   /**

--- a/src/loggy-intf/export/LogTag.js
+++ b/src/loggy-intf/export/LogTag.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IntfDeconstructable } from '@this/decon';
+import { IntfDeconstructable, Sexp } from '@this/decon';
 import { Chalk } from '@this/text';
 import { MustBe } from '@this/typey';
 
@@ -187,7 +187,7 @@ export class LogTag extends IntfDeconstructable {
 
   /** @override */
   deconstruct() {
-    return [LogTag, this.#main, ...this.#context];
+    return new Sexp(LogTag, this.#main, ...this.#context);
   }
 
 

--- a/src/loggy-intf/export/LoggedValueEncoder.js
+++ b/src/loggy-intf/export/LoggedValueEncoder.js
@@ -1,6 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { Sexp } from '@this/decon';
 import { AskIf } from '@this/typey';
 import { BaseValueVisitor, ErrorUtil, StackTrace } from '@this/valvis';
 
@@ -94,11 +95,9 @@ export class LoggedValueEncoder extends BaseValueVisitor {
   /** @override */
   _impl_visitInstance(node) {
     if (typeof node.deconstruct === 'function') {
-      const [cls, ...rest] = node.deconstruct();
-      const className  = `@${this._prot_nameFromValue(cls)}`;
-      const loggedForm = { [className]: rest };
-
-      return this._prot_visitObjectProperties(loggedForm);
+      const sexpArray    = node.deconstruct().toArray();
+      const visitedArray = this._prot_visitArrayProperties(sexpArray);
+      return new Sexp(...visitedArray);
     } else {
       return this._prot_labelFromValue(node);
     }

--- a/src/loggy-intf/export/LoggedValueEncoder.js
+++ b/src/loggy-intf/export/LoggedValueEncoder.js
@@ -60,7 +60,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
 
   /** @override */
   _impl_visitClass(node) {
-    return this._prot_labelFromValue(node);
+    return this._prot_nameFromValue(node);
   }
 
   /** @override */
@@ -89,7 +89,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
 
   /** @override */
   _impl_visitFunction(node) {
-    return this._prot_labelFromValue(node);
+    return this._prot_nameFromValue(node);
   }
 
   /** @override */

--- a/src/loggy-intf/tests/LogPayload.test.js
+++ b/src/loggy-intf/tests/LogPayload.test.js
@@ -3,6 +3,7 @@
 
 import stripAnsi from 'strip-ansi';
 
+import { Sexp } from '@this/decon';
 import { LogPayload, LogTag } from '@this/loggy-intf';
 import { Moment } from '@this/quant';
 import { StackTrace } from '@this/valvis';
@@ -32,8 +33,8 @@ describe('deconstruct()', () => {
     const payload = new LogPayload(...args);
     const got     = payload.deconstruct();
 
-    expect(got).toBeArray();
-    expect(got).toStrictEqual([LogPayload, ...args]);
+    expect(got).toBeInstanceOf(Sexp);
+    expect(got.toArray()).toStrictEqual([LogPayload, ...args]);
   });
 });
 

--- a/src/loggy-intf/tests/LogTag.test.js
+++ b/src/loggy-intf/tests/LogTag.test.js
@@ -3,6 +3,7 @@
 
 import stripAnsi from 'strip-ansi';
 
+import { Sexp } from '@this/decon';
 import { LogTag } from '@this/loggy-intf';
 
 
@@ -266,8 +267,8 @@ describe('deconstruct()', () => {
     const tag    = new LogTag(...expected);
     const result = tag.deconstruct();
 
-    expect(result).toBeArray();
-    expect(result).toStrictEqual([LogTag, ...expected]);
+    expect(result).toBeInstanceOf(Sexp);
+    expect(result.toArray()).toStrictEqual([LogTag, ...expected]);
   };
 
   test('works with just a main tag (no context strings)', () => {

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { PathKey } from '@this/collections';
-import { IntfDeconstructable } from '@this/decon';
+import { IntfDeconstructable, Sexp } from '@this/decon';
 import { IntfLogger } from '@this/loggy-intf';
 import { MustBe } from '@this/typey';
 
@@ -62,7 +62,7 @@ export class DispatchInfo extends IntfDeconstructable {
 
   /** @override */
   deconstruct() {
-    return [DispatchInfo, this.#base, this.#extra];
+    return new Sexp(DispatchInfo, this.#base, this.#extra);
   }
 
   /**

--- a/src/quant/export/ByteCount.js
+++ b/src/quant/export/ByteCount.js
@@ -1,6 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { Sexp } from '@this/decon';
+
 import { UnitQuantity } from '#x/UnitQuantity';
 
 
@@ -47,7 +49,7 @@ export class ByteCount extends UnitQuantity {
     // an instance.
     const str = this.toString();
 
-    return [ByteCount, this.byte, str];
+    return new Sexp(ByteCount, this.byte, str);
   }
 
 

--- a/src/quant/export/ByteRate.js
+++ b/src/quant/export/ByteRate.js
@@ -1,6 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { Sexp } from '@this/decon';
+
 import { ByteCount } from '#x/ByteCount';
 import { Frequency } from '#x/Frequency';
 import { UnitQuantity } from '#x/UnitQuantity';
@@ -48,7 +50,7 @@ export class ByteRate extends UnitQuantity {
     // an instance.
     const str = this.toString();
 
-    return [ByteRate, this.bytePerSec, str];
+    return new Sexp(ByteRate, this.bytePerSec, str);
   }
 
 

--- a/src/quant/export/Duration.js
+++ b/src/quant/export/Duration.js
@@ -1,6 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { Sexp } from '@this/decon';
+
 import { Frequency } from '#x/Frequency';
 import { UnitQuantity } from '#x/UnitQuantity';
 
@@ -69,7 +71,7 @@ export class Duration extends UnitQuantity {
     // an instance.
     const str = Duration.stringFromSec(this.sec);
 
-    return [Duration, this.sec, str];
+    return new Sexp(Duration, this.sec, str);
   }
 
 

--- a/src/quant/export/Moment.js
+++ b/src/quant/export/Moment.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IntfDeconstructable } from '@this/decon';
+import { IntfDeconstructable, Sexp } from '@this/decon';
 import { MustBe } from '@this/typey';
 
 import { Duration } from '#x/Duration';
@@ -227,7 +227,7 @@ export class Moment extends IntfDeconstructable {
     // an instance.
     const str = this.toString({ decimals: 6 });
 
-    return [Moment, this.#atSec, str];
+    return new Sexp(Moment, this.#atSec, str);
   }
 
 

--- a/src/quant/export/UnitQuantity.js
+++ b/src/quant/export/UnitQuantity.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IntfDeconstructable } from '@this/decon';
+import { IntfDeconstructable, Sexp } from '@this/decon';
 import { MustBe } from '@this/typey';
 
 
@@ -113,8 +113,8 @@ export class UnitQuantity extends IntfDeconstructable {
 
   /** @override */
   deconstruct() {
-    return [this.constructor,
-      this.#value, this.#numeratorUnit, this.#denominatorUnit];
+    return new Sexp(this.constructor,
+      this.#value, this.#numeratorUnit, this.#denominatorUnit);
   }
 
   /**

--- a/src/valvis/export/StackTrace.js
+++ b/src/valvis/export/StackTrace.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { IntfDeconstructable } from '@this/decon';
+import { IntfDeconstructable, Sexp } from '@this/decon';
 import { AskIf, MustBe } from '@this/typey';
 
 import { StackFrame } from '#x/StackFrame';
@@ -80,7 +80,7 @@ export class StackTrace extends IntfDeconstructable {
 
   /** @override */
   deconstruct() {
-    return [this.constructor, this.#frames];
+    return new Sexp(this.constructor, this.#frames);
   }
 
 

--- a/src/valvis/export/VisitDef.js
+++ b/src/valvis/export/VisitDef.js
@@ -28,9 +28,13 @@ export class VisitDef extends BaseDefRef {
   /**
    * Implementation of the standard `JSON.stringify()` replacement interface.
    *
+   * **Note:** This is not intended for high-fidelity data encoding, in that the
+   * result is ambiguous with plain objects that happen to have the same shape
+   * as this method's results. The main intended use case for this is logging.
+   *
    * @param {?string} key_unused The property name / stringified index where the
    *   instance was fetched from.
-   * @returns {string} The string form.
+   * @returns {*} The replacement form to encode.
    */
   toJSON(key_unused) {
     return { '@def': [this.index, this.value] };

--- a/src/valvis/export/VisitRef.js
+++ b/src/valvis/export/VisitRef.js
@@ -33,9 +33,13 @@ export class VisitRef extends BaseDefRef {
   /**
    * Implementation of the standard `JSON.stringify()` replacement interface.
    *
+   * **Note:** This is not intended for high-fidelity data encoding, in that the
+   * result is ambiguous with plain objects that happen to have the same shape
+   * as this method's results. The main intended use case for this is logging.
+   *
    * @param {?string} key_unused The property name / stringified index where the
    *   instance was fetched from.
-   * @returns {string} The string form.
+   * @returns {*} The replacement form to encode.
    */
   toJSON(key_unused) {
     return { '@ref': this.index };


### PR DESCRIPTION
This PR makes `Sexp` get used in more or less the same way it did before all the `codec` / `valvis` rework.