### PR TITLE
Rework on revisiting shared values.

### DIFF
--- a/scripts/lib/lactoserv/run-tests
+++ b/scripts/lib/lactoserv/run-tests
@@ -19,7 +19,7 @@ define-usage --with-help $'
       `build` -- Always build, even if there is something already built.
       `clean` -- Always do a clean build.
       `run` -- Build only if there is nothing yet built. This is the default.
-    --type=<type> :: `integration` `unit` `unit-coverage`
+    --type=<type> :: `integration` `unit` `unit-coverage` `unit-debug`
       Test type to run. By default, runs unit tests (without coverage reporting).
     --out=<dir>
       Directory where built output goes. Defaults to `out` directly under the
@@ -30,7 +30,7 @@ define-usage --with-help $'
 opt-value --var=action --default=run --enum[]='build clean run' do
 
 # Test type.
-opt-value --var=testType --default=unit --enum[]='integration unit unit-coverage' type
+opt-value --var=testType --default=unit --enum[]='integration unit unit-coverage unit-debug' type
 
 # Built output directory.
 opt-value --var=outDir out
@@ -159,6 +159,9 @@ case "${testType}" in
         ;;
     unit-coverage)
         run-unit-tests --coverage
+        ;;
+    unit-debug)
+        run-unit-tests --inspect-brk --runInBand
         ;;
     *)
         # Shouldn't happen. Bug in this script.

--- a/src/main-tester/bin/jest
+++ b/src/main-tester/bin/jest
@@ -9,10 +9,30 @@ cmdDir="${cmdName%/*}"
 cmdName="${cmdName##*/}"
 baseDir="${cmdDir%/*}"
 
+# Figure out the options to pass to Node vs. Jest. In particular, if the passed
+# options has `--inspect-brk`, pass that as a Node option, not a Jest option. As
+# for the default options: `--experimental-vm-modules` is needed by the Jest
+# runner, and `--no-warnings` is because we use our own warning printer (and
+# suppress the warning from using `--experimental-vm-modules`).
+
+NODE_OPTIONS='--experimental-vm-modules --no-warnings'
+jestArgs=()
+
+local afterOpts=0
+for arg in "$@"; do
+    if (( !afterOpts )); then
+        if [[ ${arg} == '--inspect-brk' ]]; then
+            NODE_OPTIONS+=" ${arg}"
+            continue
+        elif [[ !(${arg} =~ ^-) ]]; then
+            afterOpts=1
+        fi
+    fi
+
+    jestArgs+=("${arg}")
+done
+
 # Call through to the `jest` that got built by the main Jest dependency.
-# `--experimental-vm-modules` is needed by the Jest runner, and `--no-warnings`
-# is because we use our own warning printer (and suppress the warning from
-# using `--experimental-vm-modules`).
-NODE_OPTIONS='--experimental-vm-modules --no-warnings'  \
-    exec "${baseDir}/lib/node_modules/.bin/jest" \
-        "$@"
+
+NODE_OPTIONS="${NODE_OPTIONS}" \
+    exec "${baseDir}/lib/node_modules/.bin/jest" "${jestArgs[@]}"

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -69,19 +69,25 @@ export class BaseDefRef {
   }
 
   /**
-   * @returns {VisitDef} The def corresponding to this instance. This is `this`
+   * @returns {?VisitDef} The def corresponding to this instance. This is `this`
    * if this instance is in fact a def.
+   *
+   * **Note:** This is only ever `null` when the instance was constructed with
+   * `entry === null`.
    */
   get def() {
-    return this.#entry.def;
+    return this.#entry?.def ?? null;
   }
 
   /**
-   * @returns {VisitRef} The ref corresponding to this instance. This is `this`
+   * @returns {?VisitRef} The ref corresponding to this instance. This is `this`
    * if this instance is in fact a ref.
+   *
+   * **Note:** This is only ever `null` when the instance was constructed with
+   * `entry === null`.
    */
   get ref() {
-    return this.#entry.ref;
+    return this.#entry?.ref ?? null;
   }
 
   /**
@@ -97,7 +103,7 @@ export class BaseDefRef {
    * instance is a reference to.
    */
   get originalValue() {
-    return this.#entry.originalValue;
+    return this.#entry?.originalValue ?? null;
   }
 
   /**
@@ -106,7 +112,7 @@ export class BaseDefRef {
    *   in progress.
    */
   get value() {
-    return this.#entry.extractSync();
+    return this.#entry?.extractSync() ?? null;
   }
 
   /**
@@ -128,6 +134,6 @@ export class BaseDefRef {
    *   or `false` if it is still in-progress.
    */
   isFinished() {
-    return this.#entry.isFinished();
+    return this.#entry?.isFinished() ?? false;
   }
 }

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -58,8 +58,9 @@ export class BaseDefRef {
    * private inner class of {@link BaseValueVisitor}, and as such, this
    * constructor isn't usable publicly.
    *
-   * @param {VisitEntry} entry The visit-in-progress entry representing the
-   *   original visit.
+   * @param {?VisitEntry} entry The visit-in-progress entry representing the
+   *   original visit, or `null` if there is no associated entry. (The latter
+   *   case is mostly intended for testing scenarios.)
    * @param {number} index The reference index number.
    */
   constructor(entry, index) {
@@ -116,7 +117,7 @@ export class BaseDefRef {
    *   fact `visitor`.
    */
   isAssociatedWith(visitor) {
-    return this.#entry.isAssociatedWith(visitor);
+    return this.#entry?.isAssociatedWith(visitor) ?? false;
   }
 
   /**

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -112,7 +112,7 @@ export class BaseDefRef {
   /**
    * Is this instance associated with the given visitor?
    *
-   * @param {BaseValueVisitor} visitor
+   * @param {BaseValueVisitor} visitor The visitor in question.
    * @returns {boolean} `true` if this instance's associated visitor is in
    *   fact `visitor`.
    */

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -109,6 +109,17 @@ export class BaseDefRef {
   }
 
   /**
+   * Is this instance associated with the given visitor?
+   *
+   * @param {BaseValueVisitor} visitor
+   * @returns {boolean} `true` if this instance's associated visitor is in
+   *   fact `visitor`.
+   */
+  isAssociatedWith(visitor) {
+    return this.#entry.isAssociatedWith(visitor);
+  }
+
+  /**
    * Indicates whether or not the visit of the referenced value is finished and
    * has a result value or error.
    *

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -707,7 +707,7 @@ export class BaseValueVisitor {
     this.#visits.set(node, visitEntry);
 
     // This call synchronously calls back to `visitNode0()`.
-    visitEntry.startVisit(this);
+    visitEntry.startVisit();
 
     return visitEntry;
   }
@@ -1080,18 +1080,16 @@ export class BaseValueVisitor {
      * Starts the visit for this instance. If the visit could be synchronously
      * finished, the instance state will reflect that fact upon return. If not,
      * the visit will continue asynchronously, after this method returns.
-     *
-     * @param {BaseValueVisitor} outerThis The outer instance associated with
-     *   this instance.
      */
-    startVisit(outerThis) {
+    startVisit() {
       // Note: See the implementation of `.promise` for an important detail
       // about circular references.
       this.#promise = (async () => {
-        outerThis.#visitSet.add(this);
+        const visitor = this.#visitor;
+        visitor.#visitSet.add(this);
 
         try {
-          let result = outerThis.#visitNode0(this.#node);
+          let result = visitor.#visitNode0(this.#node);
 
           if (result instanceof Promise) {
             // This is the moment that this visit becomes "not synchronously
@@ -1108,7 +1106,7 @@ export class BaseValueVisitor {
           this.#finishWithError(e);
         }
 
-        outerThis.#visitSet.delete(this);
+        visitor.#visitSet.delete(this);
 
         return this;
       })();

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -703,7 +703,7 @@ export class BaseValueVisitor {
       }
     }
 
-    const visitEntry = new BaseValueVisitor.#VisitEntry(node);
+    const visitEntry = new BaseValueVisitor.#VisitEntry(this, node);
     this.#visits.set(node, visitEntry);
 
     // This call synchronously calls back to `visitNode0()`.
@@ -863,6 +863,13 @@ export class BaseValueVisitor {
    */
   static #VisitEntry = class VisitEntry {
     /**
+     * The associated visitor ("outer `this`").
+     *
+     * @type {BaseValueVisitor}
+     */
+    #visitor;
+
+    /**
      * The value whose visit this entry represents.
      *
      * @type {*}
@@ -917,10 +924,13 @@ export class BaseValueVisitor {
     /**
      * Constructs an instance.
      *
+     * @param {BaseValueVisitor} visitor The visitor instance ("outer `this`")
+     *   which is creating this instance.
      * @param {*} node The value whose visit is being represented.
      */
-    constructor(node) {
-      this.#node = node;
+    constructor(visitor, node) {
+      this.#visitor = visitor;
+      this.#node    = node;
     }
 
     /**
@@ -1034,6 +1044,17 @@ export class BaseValueVisitor {
      */
     isFinished() {
       return (this.#ok !== null);
+    }
+
+    /**
+     * Is this instance associated with the given visitor?
+     *
+     * @param {BaseValueVisitor} visitor
+     * @returns {boolean} `true` if this instance's associated visitor is in
+     *   fact `visitor`.
+     */
+    isAssociatedWith(visitor) {
+      return this.#visitor === visitor;
     }
 
     /**

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -5,6 +5,7 @@ import { types } from 'node:util';
 
 import { AskIf, MustBe } from '@this/typey';
 
+import { BaseDefRef } from '#x/BaseDefRef';
 import { VisitDef } from '#x/VisitDef';
 import { VisitRef } from '#x/VisitRef';
 import { VisitResult } from '#x/VisitResult';
@@ -242,6 +243,35 @@ export class BaseValueVisitor {
   }
 
   /**
+   * "Revisits" a value that has been encountered before during the visit _and_
+   * which is subject to reffing (see {@link #_impl_shouldRef}). This is called
+   * during a visit on the second and subsequent times a particular value has
+   * been encountered, including when encountered as part of a reference cycle.
+   *
+   * The return value of this method is not used to construct the ultimate visit
+   * result. Instead, this method's purpose is to enable concrete visitor
+   * classes to cause side effects in reaction to revisits. As such, the base
+   * implementation of this method does nothing.
+   *
+   * @param {*} node The original value which has now been encountered at least
+   *   twice.
+   * @param {*} resultValue The result value from the completed original visit
+   *   to node. This will be `null` if the call to this method is taking place
+   *   at the moment of reference cycle detection.
+   * @param {boolean} isCycleHead `true` if `node` has been detected as the
+   *   "head" (first-encountered value) of a reference cycle, or `false` if not.
+   *   When `false`, the `node` _might_ still be part of a cycle, but it wasn't
+   *   specifically the detected head of the cycle.
+   * @param {?VisitRef} ref The ref instance which represents `node`, if any.
+   *   This is non-`null` when {@link #_impl_shouldRef} returned `true` for
+   *   `node` _and_ this call wasn't made at the moment of reference cycle
+   *   detection.
+   */
+  _impl_revisit(node, resultValue, isCycleHead, ref) { // eslint-disable-line no-unused-vars
+    // @emptyBlock
+  }
+
+  /**
    * Indicates whether the given value, which has already been determined to be
    * referenced more than once in the graph of values being visited, should be
    * converted into a ref object for all but the first visit. The various
@@ -419,20 +449,6 @@ export class BaseValueVisitor {
    */
   _impl_visitProxy(node, isFunction) { // eslint-disable-line no-unused-vars
     return this._prot_wrapResult(node);
-  }
-
-  /**
-   * Visits a reference to a visit result from the visit currently in progress.
-   * When {@link #_impl_shouldRef} indicates that an already-seen value should
-   * become a "ref," then this is the method that ultimately gets called in
-   * order to visit that ref. The base implementation returns the given node
-   * as-is.
-   *
-   * @param {VisitRef} node The node to visit.
-   * @returns {*} Arbitrary result of visiting.
-   */
-  _impl_visitRef(node) {
-    return node;
   }
 
   /**
@@ -652,26 +668,45 @@ export class BaseValueVisitor {
     const already = this.#visits.get(node);
 
     if (already) {
-      const ref = already.ref;
-      if (ref) {
+      let ref = already.ref;
+
+      if (ref || already.shouldRef()) {
+        // We either already have a ref, or we are supposed to make a ref.
+
+        const isCycleHead = !already.isFinished();
+        const result      = isCycleHead ? null : already.extractSync();
+
+        if (!ref) {
+          already.setDefRef(this.#allRefs.length);
+          ref = already.ref;
+          this.#allRefs.push(ref);
+          this._impl_newRef(ref);
+        }
+
+        this._impl_revisit(node, result, isCycleHead, ref);
         return this.#visitNode(ref);
-      } else if (already.shouldRef()) {
-        already.setDefRef(this.#allRefs.length);
-        const newRef = already.ref;
-        this.#allRefs.push(newRef);
-        this._impl_newRef(newRef);
-        return this.#visitNode(newRef);
       } else if (this.#visitSet.has(already)) {
-        // Note that this method isn't ever supposed to throw. What we do here
-        // is mark the entry as being part of a reference cycle, which
-        // ultimately propagates the appropriate error back to the first node
-        // involved in the cycle.
+        // We have encountered the head of a reference cycle that was _not_
+        // handled by making a "ref" object for the back-reference.
+
+        // We mark the entry as circular, which ultimately propagates the
+        // appropriate error back to the first node involved in the cycle. Note
+        // that this method isn't ever supposed to throw, which is why we don't
+        // just `throw` directly here.
         already.becomeCircular();
         return already;
       } else {
+        // This is a revisit of a value for which `_impl_shouldRef()` returned
+        // `false`.
+        if (!((node instanceof BaseDefRef) && node.isAssociatedWith(this))) {
+          // Only call `revisit()` if it's not a self-associated ref/def.
+          this._impl_revisit(node, already.extractSync(), false, null);
+        }
         return already;
       }
     }
+
+    // We have not previously encountered `node` during this visit.
 
     const visitEntry = new BaseValueVisitor.#VisitEntry(this, node);
     this.#visits.set(node, visitEntry);
@@ -733,8 +768,12 @@ export class BaseValueVisitor {
           return this._impl_visitArray(node);
         } else if (AskIf.plainObject(node)) {
           return this._impl_visitPlainObject(node);
-        } else if (node instanceof VisitRef) {
-          return this._impl_visitRef(node);
+        } else if ((node instanceof BaseDefRef) && node.isAssociatedWith(this)) {
+          // Any defs or refs that are from this visit are just returned as-is.
+          // (But if they're associated with a different visitor, they're
+          // treated as regular instances, due to the `isAssociatedWith()` check
+          // above.)
+          return node;
         } else if (node instanceof Error) {
           return this._impl_visitError(node);
         } else {

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -1037,16 +1037,6 @@ export class BaseValueVisitor {
     }
 
     /**
-     * Returns an indication of whether the visit has finished.
-     *
-     * @returns {boolean} `true` if the visit of the referenced value is
-     *   finished, or `false` if it is still in-progress.
-     */
-    isFinished() {
-      return (this.#ok !== null);
-    }
-
-    /**
      * Is this instance associated with the given visitor?
      *
      * @param {BaseValueVisitor} visitor
@@ -1055,6 +1045,16 @@ export class BaseValueVisitor {
      */
     isAssociatedWith(visitor) {
       return this.#visitor === visitor;
+    }
+
+    /**
+     * Returns an indication of whether the visit has finished.
+     *
+     * @returns {boolean} `true` if the visit of the referenced value is
+     *   finished, or `false` if it is still in-progress.
+     */
+    isFinished() {
+      return (this.#ok !== null);
     }
 
     /**

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -243,10 +243,10 @@ export class BaseValueVisitor {
   }
 
   /**
-   * "Revisits" a value that has been encountered before during the visit _and_
-   * which is subject to reffing (see {@link #_impl_shouldRef}). This is called
-   * during a visit on the second and subsequent times a particular value has
-   * been encountered, including when encountered as part of a reference cycle.
+   * "Revisits" a value that has been encountered before during the visit. This
+   * is called during a visit on the second and subsequent times a particular
+   * value has been encountered, including when encountered as part of a
+   * reference cycle.
    *
    * The return value of this method is not used to construct the ultimate visit
    * result. Instead, this method's purpose is to enable concrete visitor

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -102,6 +102,10 @@ export class BaseValueVisitor {
    *   if not, or `null` if the visit is still in-progress.
    */
   hasRefs() {
+    if (!this.isFinished()) {
+      return null;
+    }
+
     const allRefs = this.#allRefs;
 
     if (this.#allRefs instanceof Map) {
@@ -121,6 +125,22 @@ export class BaseValueVisitor {
 
     this.#allRefs = refMap;
     return (refMap.size > 0);
+  }
+
+  /**
+   * Is the visit of the top-level {@link #value} finished? This returns `false`
+   * until the visit is complete. This includes returning `false` before the
+   * initial call to a `visit*()` method.
+   *
+   * @returns {boolean} `true` if the visit is finsihed, or `false` if it is
+   *   either in-progress or hasn't yet started.
+   */
+  isFinished() {
+    const entry = this.#visits.get(this.#rootValue);
+
+    return entry
+      ? entry.isFinished()
+      : false;
   }
 
   /**

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -185,7 +185,7 @@ describe('refFromResultValue()', () => {
   test('finds a root result reference', () => {
     // Note: This test can only possibly work if the root value itself
     // participates in a reference cycle.
-    const value = [123];
+    const value = [12399];
     value.push(value);
 
     const vv  = new RefMakingVisitor(value);
@@ -193,7 +193,7 @@ describe('refFromResultValue()', () => {
 
     // Baseline.
     expect(got).toBeArrayOfSize(2);
-    expect(got[0]).toBe(123);
+    expect(got[0]).toBe(12399);
     const gotRef = got[1];
     expect(gotRef).toBeInstanceOf(VisitRef);
 
@@ -204,7 +204,7 @@ describe('refFromResultValue()', () => {
   });
 
   test('finds a sub-visit result reference', () => {
-    const inner = [123];
+    const inner = [12388];
     const value = [inner, inner];
 
     const vv  = new RefMakingVisitor(value);
@@ -225,11 +225,11 @@ describe('refFromResultValue()', () => {
   });
 
   test('returns `null` given any argument if there were no refs created', () => {
-    const vv  = new BaseValueVisitor(123);
+    const vv  = new BaseValueVisitor(12377);
     const got = vv.visitSync();
 
-    expect(got).toBe(123); // Baseline
-    expect(vv.refFromResultValue(123)).toBeNull();
+    expect(got).toBe(12377); // Baseline
+    expect(vv.refFromResultValue(12377)).toBeNull();
     expect(vv.refFromResultValue('boop')).toBeNull();
   });
 

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -861,10 +861,13 @@ describe('_impl_revisit()', () => {
     const vv  = new RevisitCheckVisitor([value, value], false);
     const got = vv.visitSync();
 
-    expect(vv.calledArgs).toBeArrayOfSize(1);
+    expect(got).toBeArrayOfSize(2);
+    expect(got[0]).toBe(got[1]);
 
+    expect(vv.calledArgs).toBeArrayOfSize(1);
     expect(vv.calledArgs[0].node).toBe(value);
     expect(vv.calledArgs[0].result).toEqual(value);
+    expect(vv.calledArgs[0].result).toBe(got[0]);
     expect(vv.calledArgs[0].isCycleHead).toBeFalse();
     expect(vv.calledArgs[0].ref).toBeNull();
   });


### PR DESCRIPTION
This PR reworks what happens when a `visit*()` on a `BaseValueVisitor` encounters a shared value.

It used to call `_impl_visitRef()` in a way that was pretty much like any of the other `_impl_visit*()` methods, including the behavior of only calling it once (given a ref) and then sharing _its_ return value as a duplicate when there were two or more sub-visits that got converted to refs. And `_impl_visitRef()` was never called on values for which `_impl_shouldRef()` returned `true`.

Now, instead, `_impl_revisit()` gets called any second-or-later time the same value is visited, whether or not it got converted into a ref. This is particularly useful for concrete visitors which use side effects (e.g. appending to a result-in-progress).