### PR TITLE
Visitor and logging cleanup

### DIFF
--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -1,16 +1,14 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import * as util from 'node:util';
-
 import { EventPayload, EventSource } from '@this/async';
 import { IntfDeconstructable, Sexp } from '@this/decon';
 import { Moment } from '@this/quant';
 import { Chalk } from '@this/text';
 import { MustBe } from '@this/typey';
-import { BaseDefRef, BaseValueVisitor, StackTrace, VisitDef }
-  from '@this/valvis';
+import { StackTrace } from '@this/valvis';
 
+import { HumanVisitor } from '#p/HumanVisitor';
 import { LogTag } from '#x/LogTag';
 
 
@@ -144,7 +142,7 @@ export class LogPayload extends EventPayload {
    * @param {boolean} colorize Colorize the result?
    */
   #appendHumanPayload(parts, colorize) {
-    const human = new LogPayload.#HumanVisitor(this, colorize).visitSync();
+    const human = new HumanVisitor(this, colorize).visitSync();
     parts.push(...human.flat(Number.POSITIVE_INFINITY));
   }
 
@@ -152,27 +150,6 @@ export class LogPayload extends EventPayload {
   //
   // Static members
   //
-
-  /**
-   * Colorizer function to use for defs and refs.
-   *
-   * @type {Function}
-   */
-  static #COLOR_DEF_REF = chalk.magenta.bold;
-
-  /**
-   * Colorizer function to use for top-level payload type and cladding.
-   *
-   * @type {Function}
-   */
-  static #COLOR_PAYLOAD = chalk.bold;
-
-  /**
-   * Colorizer function to use for {@link Sexp} type and cladding.
-   *
-   * @type {Function}
-   */
-  static #COLOR_SEXP = chalk.ansi256(130).bold; // Dark orange, more or less.
 
   /**
    * Moment to use for "kickoff" instances.
@@ -211,220 +188,4 @@ export class LogPayload extends EventPayload {
     type ??= this.#KICKOFF_TYPE;
     return new LogPayload(null, this.#KICKOFF_MOMENT, tag, type);
   }
-
-  /**
-   * Visitor class which stringifies instances of this (outer) class and all its
-   * components. This produces an array whose elements are either strings or
-   * arrays (of strings or arrays of...), with the array nesting representing
-   * the hierarchical structure of instance.
-   */
-  static #HumanVisitor = class HumanVisitor extends BaseValueVisitor {
-    /**
-     * Should the output be colorized?
-     *
-     * @type {boolean}
-     */
-    #colorize;
-
-    /**
-     * Constructs an instance.
-     *
-     * @param {*} value The value to visit.
-     * @param {boolean} colorize Colorize the output?
-     */
-    constructor(value, colorize) {
-      super(value);
-      this.#colorize = colorize;
-    }
-
-    /** @override */
-    _impl_visitArray(node) {
-      return this.#visitAggregate(node, '[', ']', '[]');
-    }
-
-    /** @override */
-    _impl_visitBigInt(node_unused) {
-      throw this.#shouldntHappen();
-    }
-
-    /** @override */
-    _impl_visitBoolean(node) {
-      return `${node}`;
-    }
-
-    /** @override */
-    _impl_visitClass(node_unused) {
-      throw this.#shouldntHappen();
-    }
-
-    /** @override */
-    _impl_visitError(node_unused) {
-      throw this.#shouldntHappen();
-    }
-
-    /** @override */
-    _impl_visitFunction(node_unused) {
-      throw this.#shouldntHappen();
-    }
-
-    /** @override */
-    _impl_visitInstance(node) {
-      if (node instanceof LogPayload) {
-        const color          = LogPayload.#COLOR_PAYLOAD;
-        const { type, args } = node;
-        if (args.length === 0) {
-          // Avoid extra work in the easy zero-args case.
-          const text = `${type}()`;
-          return [this.#maybeColorize(text, color)];
-        } else {
-          const open  = this.#maybeColorize(`${type}(`, color);
-          const close = this.#maybeColorize(')', color);
-          return this.#visitAggregate(args, open, close, null);
-        }
-      } else if (node instanceof BaseDefRef) {
-        const color  = LogPayload.#COLOR_DEF_REF;
-        const result = [this.#maybeColorize(`#${node.index}`, color)];
-        if (node instanceof VisitDef) {
-          result.push(
-            this.#maybeColorize(' = ', color),
-            this._prot_visit(node.value).value);
-        }
-        return result;
-      } else if (node instanceof Sexp) {
-        const color                 = LogPayload.#COLOR_SEXP;
-        const { functorName, args } = node;
-        if (args.length === 0) {
-          // Avoid extra work in the easy zero-args case.
-          const text = `@${functorName}()`;
-          return [this.#maybeColorize(text, color)];
-        } else {
-          const open  = this.#maybeColorize(`@${functorName}(`, color);
-          const close = this.#maybeColorize(')', color);
-          return this.#visitAggregate(args, open, close, null);
-        }
-      } else {
-        throw this.#shouldntHappen();
-      }
-    }
-
-    /** @override */
-    _impl_visitNull() {
-      return 'null';
-    }
-
-    /** @override */
-    _impl_visitNumber(node) {
-      return this.#maybeColorize(`${node}`, chalk.yellow);
-    }
-
-    /** @override */
-    _impl_visitPlainObject(node) {
-      return this.#visitAggregate(node, '{ ', ' }', '{}');
-    }
-
-    /** @override */
-    _impl_visitProxy(node_unused, isFunction_unused) {
-      throw this.#shouldntHappen();
-    }
-
-    /** @override */
-    _impl_visitString(node) {
-      // `inspect()` to get good quoting, etc.
-      return this.#maybeColorize(util.inspect(node), chalk.green);
-    }
-
-    /** @override */
-    _impl_visitSymbol(node_unused) {
-      throw this.#shouldntHappen();
-    }
-
-    /** @override */
-    _impl_visitUndefined() {
-      throw this.#shouldntHappen();
-    }
-
-    /**
-     * Colorizes the given text, but only if this instance has been told to
-     * colorize.
-     *
-     * @param {string} text The text in question.
-     * @param {Function} func The colorizer function.
-     * @returns {string} The colorized-or-not result.
-     */
-    #maybeColorize(text, func) {
-      return this.#colorize ? func(text) : text;
-    }
-
-    /**
-     * Renders an object key, quoting and colorizing as appropriate.
-     *
-     * @param {*} key The key.
-     * @returns {string} The rendered form.
-     */
-    #renderKey(key) {
-      if ((typeof key === 'string') && /^[$_a-zA-Z][$_a-zA-Z0-9]*$/.test(key)) {
-        // It doesn't have to be quoted.
-        return key;
-      } else {
-        return this._impl_visitString(key);
-      }
-    }
-
-    /**
-     * Constructs a "shouldn't happen" error. This is used in the implementation
-     * of all the `_impl_visit*()` methods corresponding to types that aren't
-     * supposed to show up in a payload.
-     *
-     * @returns {Error} The error.
-     */
-    #shouldntHappen() {
-      return new Error('Shouldn\'t happen.');
-    }
-
-    /**
-     * Helper for various `_impl_visit*()` methods, which visits an aggregate
-     * object of some sort.
-     *
-     * @param {*} node The aggregate to visit.
-     * @param {string} open The "open" string.
-     * @param {string} close The "close" string.
-     * @param {string} ifEmpty The string to use to represent an empty
-     *   instance.
-     * @returns {Array<string>} The stringified aggregate, as an array.
-     */
-    #visitAggregate(node, open, close, ifEmpty) {
-      const isArray = Array.isArray(node);
-      const result  = [open];
-      let   first   = true;
-      let   inProps = !isArray;
-
-      const initialVisit = isArray
-        ? this._prot_visitArrayProperties(node)
-        : this._prot_visitObjectProperties(node);
-
-      for (const [k, v] of Object.entries(initialVisit)) {
-        if (!inProps && (k === 'length')) {
-          inProps = true;
-          continue;
-        } else if (first) {
-          first = false;
-        } else {
-          result.push(', ');
-        }
-
-        if (inProps) {
-          result.push(this.#renderKey(k), ': ');
-        }
-
-        result.push(v);
-      }
-
-      if (result.length === 1) {
-        return [ifEmpty];
-      } else {
-        result.push(close);
-        return result;
-      }
-    }
-  };
 }

--- a/src/loggy-intf/export/LogPayload.js
+++ b/src/loggy-intf/export/LogPayload.js
@@ -4,20 +4,12 @@
 import { EventPayload, EventSource } from '@this/async';
 import { IntfDeconstructable, Sexp } from '@this/decon';
 import { Moment } from '@this/quant';
-import { Chalk } from '@this/text';
 import { MustBe } from '@this/typey';
 import { StackTrace } from '@this/valvis';
 
 import { HumanVisitor } from '#p/HumanVisitor';
 import { LogTag } from '#x/LogTag';
 
-
-/**
- * Always-on `Chalk` instance.
- *
- * @type {Chalk}
- */
-const chalk = Chalk.ON;
 
 /**
  * The thing which is logged; it is the payload class used for events
@@ -100,18 +92,7 @@ export class LogPayload extends EventPayload {
    * @returns {string} The "human form" string.
    */
   toHuman(colorize = false) {
-    const whenString = this.#when.toString({ decimals: 4 });
-
-    const parts = [
-      colorize ? chalk.bold.blue(whenString) : whenString,
-      ' ',
-      this.#tag.toHuman(colorize),
-      ' '
-    ];
-
-    this.#appendHumanPayload(parts, colorize);
-
-    return parts.join('');
+    return HumanVisitor.payloadToHuman(this, colorize);
   }
 
   /**
@@ -132,18 +113,6 @@ export class LogPayload extends EventPayload {
       type: this.type,
       args: this.args
     };
-  }
-
-  /**
-   * Appends the human form of {@link #payload} to the given array of parts (to
-   * ultimately `join()`).
-   *
-   * @param {Array<string>} parts Parts to append to.
-   * @param {boolean} colorize Colorize the result?
-   */
-  #appendHumanPayload(parts, colorize) {
-    const human = new HumanVisitor(this, colorize).visitSync();
-    parts.push(...human.flat(Number.POSITIVE_INFINITY));
   }
 
 

--- a/src/loggy-intf/export/LoggedValueEncoder.js
+++ b/src/loggy-intf/export/LoggedValueEncoder.js
@@ -49,7 +49,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
 
   /** @override */
   _impl_visitArray(node) {
-    return this._prot_visitArrayProperties(node);
+    return this._prot_visitProperties(node);
   }
 
   /** @override */
@@ -84,7 +84,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
 
     const loggedForm = { [`@${className}`]: loggedBody };
 
-    return this._prot_visitObjectProperties(loggedForm);
+    return this._prot_visitProperties(loggedForm);
   }
 
   /** @override */
@@ -96,7 +96,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
   _impl_visitInstance(node) {
     if (typeof node.deconstruct === 'function') {
       const sexpArray    = node.deconstruct().toArray();
-      const visitedArray = this._prot_visitArrayProperties(sexpArray);
+      const visitedArray = this._prot_visitProperties(sexpArray);
       return new Sexp(...visitedArray);
     } else {
       return this._prot_labelFromValue(node);
@@ -105,7 +105,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
 
   /** @override */
   _impl_visitPlainObject(node) {
-    return this._prot_visitObjectProperties(node);
+    return this._prot_visitProperties(node);
   }
 
   /** @override */
@@ -173,13 +173,13 @@ export class LoggedValueEncoder extends BaseValueVisitor {
 
     /** @override */
     _impl_visitArray(node) {
-      const result = this._prot_visitArrayProperties(node);
+      const result = this._prot_visitProperties(node);
       return this.#makeDefIfAppropriate(node, result);
     }
 
     /** @override */
     _impl_visitPlainObject(node) {
-      const result = this._prot_visitObjectProperties(node);
+      const result = this._prot_visitProperties(node);
       return this.#makeDefIfAppropriate(node, result);
     }
 

--- a/src/loggy-intf/package.json
+++ b/src/loggy-intf/package.json
@@ -10,6 +10,7 @@
   },
   "imports": {
     "#x/*": "./export/*.js",
+    "#p/*": "./private/*.js",
     "#tests/*": "./tests/*.js"
   },
 

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -203,9 +203,9 @@ export class HumanVisitor extends BaseValueVisitor {
     let   first   = true;
     let   inProps = !isArray;
 
-    const initialVisit = this._prot_visitProperties(node); // TODO: Use entries.
+    const initialVisit = this._prot_visitProperties(node, true);
 
-    for (const [k, v] of Object.entries(initialVisit)) {
+    for (const [k, v] of initialVisit) {
       if (!inProps && (k === 'length')) {
         inProps = true;
         continue;

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -203,9 +203,7 @@ export class HumanVisitor extends BaseValueVisitor {
     let   first   = true;
     let   inProps = !isArray;
 
-    const initialVisit = isArray
-      ? this._prot_visitArrayProperties(node)
-      : this._prot_visitObjectProperties(node);
+    const initialVisit = this._prot_visitProperties(node); // TODO: Use entries.
 
     for (const [k, v] of Object.entries(initialVisit)) {
       if (!inProps && (k === 'length')) {

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -1,0 +1,260 @@
+// Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import * as util from 'node:util';
+
+import { Sexp } from '@this/decon';
+import { Chalk } from '@this/text';
+import { BaseDefRef, BaseValueVisitor, VisitDef } from '@this/valvis';
+
+import { LogPayload } from '#x/LogPayload';
+
+
+/**
+ * Always-on `Chalk` instance.
+ *
+ * @type {Chalk}
+ */
+const chalk = Chalk.ON;
+
+/**
+ * Visitor class which stringifies instances of {@link LogPayload} and all its
+ * components. This produces an array whose elements are either strings or
+ * arrays (of strings or arrays of...), with the array nesting representing
+ * the hierarchical structure of instance.
+ */
+export class HumanVisitor extends BaseValueVisitor {
+  /**
+   * Should the output be colorized?
+   *
+   * @type {boolean}
+   */
+  #colorize;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {*} value The value to visit.
+   * @param {boolean} colorize Colorize the output?
+   */
+  constructor(value, colorize) {
+    super(value);
+    this.#colorize = colorize;
+  }
+
+  /** @override */
+  _impl_visitArray(node) {
+    return this.#visitAggregate(node, '[', ']', '[]');
+  }
+
+  /** @override */
+  _impl_visitBigInt(node_unused) {
+    throw this.#shouldntHappen();
+  }
+
+  /** @override */
+  _impl_visitBoolean(node) {
+    return `${node}`;
+  }
+
+  /** @override */
+  _impl_visitClass(node_unused) {
+    throw this.#shouldntHappen();
+  }
+
+  /** @override */
+  _impl_visitError(node_unused) {
+    throw this.#shouldntHappen();
+  }
+
+  /** @override */
+  _impl_visitFunction(node_unused) {
+    throw this.#shouldntHappen();
+  }
+
+  /** @override */
+  _impl_visitInstance(node) {
+    if (node instanceof LogPayload) {
+      const color          = HumanVisitor.#COLOR_PAYLOAD;
+      const { type, args } = node;
+      if (args.length === 0) {
+        // Avoid extra work in the easy zero-args case.
+        const text = `${type}()`;
+        return [this.#maybeColorize(text, color)];
+      } else {
+        const open  = this.#maybeColorize(`${type}(`, color);
+        const close = this.#maybeColorize(')', color);
+        return this.#visitAggregate(args, open, close, null);
+      }
+    } else if (node instanceof BaseDefRef) {
+      const color  = HumanVisitor.#COLOR_DEF_REF;
+      const result = [this.#maybeColorize(`#${node.index}`, color)];
+      if (node instanceof VisitDef) {
+        result.push(
+          this.#maybeColorize(' = ', color),
+          this._prot_visit(node.value).value);
+      }
+      return result;
+    } else if (node instanceof Sexp) {
+      const color                 = HumanVisitor.#COLOR_SEXP;
+      const { functorName, args } = node;
+      if (args.length === 0) {
+        // Avoid extra work in the easy zero-args case.
+        const text = `@${functorName}()`;
+        return [this.#maybeColorize(text, color)];
+      } else {
+        const open  = this.#maybeColorize(`@${functorName}(`, color);
+        const close = this.#maybeColorize(')', color);
+        return this.#visitAggregate(args, open, close, null);
+      }
+    } else {
+      throw this.#shouldntHappen();
+    }
+  }
+
+  /** @override */
+  _impl_visitNull() {
+    return 'null';
+  }
+
+  /** @override */
+  _impl_visitNumber(node) {
+    return this.#maybeColorize(`${node}`, chalk.yellow);
+  }
+
+  /** @override */
+  _impl_visitPlainObject(node) {
+    return this.#visitAggregate(node, '{ ', ' }', '{}');
+  }
+
+  /** @override */
+  _impl_visitProxy(node_unused, isFunction_unused) {
+    throw this.#shouldntHappen();
+  }
+
+  /** @override */
+  _impl_visitString(node) {
+    // `inspect()` to get good quoting, etc.
+    return this.#maybeColorize(util.inspect(node), chalk.green);
+  }
+
+  /** @override */
+  _impl_visitSymbol(node_unused) {
+    throw this.#shouldntHappen();
+  }
+
+  /** @override */
+  _impl_visitUndefined() {
+    throw this.#shouldntHappen();
+  }
+
+  /**
+   * Colorizes the given text, but only if this instance has been told to
+   * colorize.
+   *
+   * @param {string} text The text in question.
+   * @param {Function} func The colorizer function.
+   * @returns {string} The colorized-or-not result.
+   */
+  #maybeColorize(text, func) {
+    return this.#colorize ? func(text) : text;
+  }
+
+  /**
+   * Renders an object key, quoting and colorizing as appropriate.
+   *
+   * @param {*} key The key.
+   * @returns {string} The rendered form.
+   */
+  #renderKey(key) {
+    if ((typeof key === 'string') && /^[$_a-zA-Z][$_a-zA-Z0-9]*$/.test(key)) {
+      // It doesn't have to be quoted.
+      return key;
+    } else {
+      return this._impl_visitString(key);
+    }
+  }
+
+  /**
+   * Constructs a "shouldn't happen" error. This is used in the implementation
+   * of all the `_impl_visit*()` methods corresponding to types that aren't
+   * supposed to show up in a payload.
+   *
+   * @returns {Error} The error.
+   */
+  #shouldntHappen() {
+    return new Error('Shouldn\'t happen.');
+  }
+
+  /**
+   * Helper for various `_impl_visit*()` methods, which visits an aggregate
+   * object of some sort.
+   *
+   * @param {*} node The aggregate to visit.
+   * @param {string} open The "open" string.
+   * @param {string} close The "close" string.
+   * @param {string} ifEmpty The string to use to represent an empty
+   *   instance.
+   * @returns {Array<string>} The stringified aggregate, as an array.
+   */
+  #visitAggregate(node, open, close, ifEmpty) {
+    const isArray = Array.isArray(node);
+    const result  = [open];
+    let   first   = true;
+    let   inProps = !isArray;
+
+    const initialVisit = isArray
+      ? this._prot_visitArrayProperties(node)
+      : this._prot_visitObjectProperties(node);
+
+    for (const [k, v] of Object.entries(initialVisit)) {
+      if (!inProps && (k === 'length')) {
+        inProps = true;
+        continue;
+      } else if (first) {
+        first = false;
+      } else {
+        result.push(', ');
+      }
+
+      if (inProps) {
+        result.push(this.#renderKey(k), ': ');
+      }
+
+      result.push(v);
+    }
+
+    if (result.length === 1) {
+      return [ifEmpty];
+    } else {
+      result.push(close);
+      return result;
+    }
+  }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * Colorizer function to use for defs and refs.
+   *
+   * @type {Function}
+   */
+  static #COLOR_DEF_REF = chalk.magenta.bold;
+
+  /**
+   * Colorizer function to use for top-level payload type and cladding.
+   *
+   * @type {Function}
+   */
+  static #COLOR_PAYLOAD = chalk.bold;
+
+  /**
+   * Colorizer function to use for {@link Sexp} type and cladding.
+   *
+   * @type {Function}
+   */
+  static #COLOR_SEXP = chalk.ansi256(130).bold; // Dark orange, more or less.
+}

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -257,4 +257,33 @@ export class HumanVisitor extends BaseValueVisitor {
    * @type {Function}
    */
   static #COLOR_SEXP = chalk.ansi256(130).bold; // Dark orange, more or less.
+
+  /**
+   * Colorizer function to use for `payload.when`.
+   *
+   * @type {Function}
+   */
+  static #COLOR_WHEN = chalk.bold.blue;
+
+  /**
+   * Implementation of {@link LogPayload#toHuman}.
+   *
+   * @param {LogPayload} payload The instance to render.
+   * @param {boolean} [colorize] Colorize the result?
+   * @returns {string} The rendered "human form" string.
+   */
+  static payloadToHuman(payload, colorize = false) {
+    const { tag, when } = payload;
+    const whenString    = when.toString({ decimals: 4 });
+
+    const parts = [
+      colorize ? this.#COLOR_WHEN(whenString) : whenString,
+      ' ',
+      tag.toHuman(colorize),
+      ' ',
+      new HumanVisitor(payload, colorize).visitSync()
+    ];
+
+    return parts.flat(Number.POSITIVE_INFINITY).join('');
+  }
 }

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -608,7 +608,9 @@ export class BaseValueVisitor {
    * * If the original `node` is a sparse array, the result will have the same
    *   "holes."
    * * If `returnEntries` is passed as `true` and `node` is an array, it _will_
-   *   have a result entry for `length`.
+   *   have a result entry for `length`. Furthermore, the `length` will be in
+   *   the result between indexed properties and named properties, just as with
+   *   `Object.getOwnPropertyNames()`.
    *
    * @param {object} node The node whose contents are to be visited.
    * @param {boolean} [returnEntries] Return an array of two-element entry

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -593,8 +593,8 @@ export class BaseValueVisitor {
     const entry = this.#visitNode(node);
 
     return entry.isFinished()
-      ? new VisitResult(entry.extractSync())
-      : entry.promise;
+      ? entry.extractSync(true)
+      : entry.extractAsync(true);
   }
 
   /**

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -111,9 +111,6 @@ export class BaseValueVisitor {
 
     if (this.#allRefs instanceof Map) {
       return (allRefs.size > 0);
-    } else if (!this.#visitRoot().isFinished()) {
-      // The visit is still in progress.
-      return null;
     }
 
     // This is the first post-visit call to this method, so we can (and do) now

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -314,7 +314,7 @@ export class BaseValueVisitor {
    * Visits an array, that is, an object for which `Array.isArray()` returns
    * `true`. The base implementation returns the given `node` as-is. Subclasses
    * that wish to visit the contents can do so by calling
-   * {@link #_prot_visitArrayProperties}.
+   * {@link #_prot_visitProperties}.
    *
    * @param {Array} node The node to visit.
    * @returns {*} Arbitrary result of visiting.
@@ -427,8 +427,7 @@ export class BaseValueVisitor {
    * Visits a plain object value, that is, a non-`null` value of type `object`,
    * which has a `prototype` of either `null` or the class `Object`. The base
    * implementation returns the given `node` as-is. Subclasses that wish to
-   * visit the contents can do so by calling
-   * {@link #_prot_visitObjectProperties}.
+   * visit the contents can do so by calling {@link #_prot_visitProperties}.
    *
    * @param {object} node The node to visit.
    * @returns {*} Arbitrary result of visiting.
@@ -596,40 +595,6 @@ export class BaseValueVisitor {
     return entry.isFinished()
       ? new VisitResult(entry.extractSync())
       : entry.promise;
-  }
-
-  /**
-   * Visits the indexed values and any other "own" property values of an array,
-   * _excluding_ `length`. Returns an array consisting of all the visited
-   * values, with indices / property names corresponding to the original. If the
-   * original `node` is a sparse array, the result will have the same "holes."
-   *
-   * **Note:** If the given `node` has synthetic properties, this method will
-   * call those properties' getters.
-   *
-   * @param {Array} node The node whose contents are to be visited.
-   * @returns {Array|Promise} An array of visited results, or a promise for same
-   *   in the case where any of the visitor methods act asynchronously.
-   */
-  _prot_visitArrayProperties(node) {
-    return this._prot_visitProperties(node);
-  }
-
-  /**
-   * Visits the "own" property values of an object (typically a plain object).
-   * Returns a new plain object consisting of all the visited values, with
-   * property names corresponding to the original.
-   *
-   * **Note:** If the given `node` has synthetic properties, this method will
-   * call those properties' getters.
-   *
-   * @param {object} node The node whose contents are to be visited.
-   * @returns {object|Promise} A `null`-prototype object with the visited
-   *   results, or a promise for same in the case where any of the visitor
-   *   methods act asynchronously.
-   */
-  _prot_visitObjectProperties(node) {
-    return this._prot_visitProperties(node);
   }
 
   /**

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -976,6 +976,45 @@ ${'_prot_nameFromValue'}  | ${'expectedName'}
   });
 });
 
+describe('_prot_visit()', () => {
+  test('works synchronously when possible', () => {
+    class VisitCheckVisitor extends BaseValueVisitor {
+      _impl_visitNumber(node) {
+        return `${node}!`;
+      }
+
+      _impl_visitString(node) {
+        const got = this._prot_visit(9999);
+        expect(got).toBeInstanceOf(VisitResult);
+        expect(got.value).toBe('9999!');
+        return 'yep';
+      }
+    }
+
+    const got = new VisitCheckVisitor('boop').visitSync();
+    expect(got).toBe('yep');
+  });
+
+  test('works asynchronously when necessary', async () => {
+    class VisitCheckVisitor extends BaseValueVisitor {
+      async _impl_visitNumber(node) {
+        return `${node}!`;
+      }
+
+      async _impl_visitString(node) {
+        const got = this._prot_visit(98765);
+        expect(got).toBeInstanceOf(Promise);
+        expect(await got).toBeInstanceOf(VisitResult);
+        expect((await got).value).toBe('98765!');
+        return 'yep';
+      }
+    }
+
+    const got = new VisitCheckVisitor('boop').visit();
+    expect(await got).toBe('yep');
+  });
+});
+
 describe('_prot_visitProperties()', () => {
   class VisitPropertiesCheckVisitor extends BaseValueVisitor {
     #beAsync;

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -72,11 +72,11 @@ class RecursiveVisitor extends BaseValueVisitor {
   }
 
   _impl_visitArray(node) {
-    return this._prot_visitArrayProperties(node);
+    return this._prot_visitProperties(node);
   }
 
   _impl_visitPlainObject(node) {
-    return this._prot_visitObjectProperties(node);
+    return this._prot_visitProperties(node);
   }
 }
 
@@ -108,12 +108,12 @@ class RefMakingVisitor extends BaseValueVisitor {
   }
 
   _impl_visitArray(node) {
-    return this._prot_visitArrayProperties(node);
+    return this._prot_visitProperties(node);
   }
 
   async _impl_visitPlainObject(node) {
     await setImmediate();
-    return this._prot_visitObjectProperties(node);
+    return this._prot_visitProperties(node);
   }
 }
 
@@ -384,7 +384,7 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
       class ExtraAsyncVisitor extends RecursiveVisitor {
         async _impl_visitArray(node) {
           await setImmediate();
-          return this._prot_visitArrayProperties(node);
+          return this._prot_visitProperties(node);
         }
       }
 
@@ -493,7 +493,7 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
       }
 
       _impl_visitArray(node) {
-        return this._prot_visitArrayProperties(node);
+        return this._prot_visitProperties(node);
       }
     }
 
@@ -523,7 +523,7 @@ ${'visitWrap'} | ${true}  | ${true}  | ${true}
       }
 
       _impl_visitArray(node) {
-        return this._prot_visitArrayProperties(node);
+        return this._prot_visitProperties(node);
       }
     }
 
@@ -692,7 +692,7 @@ ${'_impl_visitUndefined'}   | ${false} | ${true}   | ${undefined}
       const expected  = ['this', 'is', 'it'];
       const vv        = new BaseValueVisitor(rootValue);
       vv[methodName]  = () => expected;
-      vv[rootImpl]    = () => vv._prot_visitArrayProperties([value]);
+      vv[rootImpl]    = () => vv._prot_visitProperties([value]);
 
       const got = vv.visitSync();
       expect(got).toBeInstanceOf(Array);
@@ -746,7 +746,7 @@ describe('_impl_visitInstance()', () => {
     gotNodes = [];
 
     _impl_visitArray(node) {
-      return this._prot_visitArrayProperties(node);
+      return this._prot_visitProperties(node);
     }
 
     _impl_visitInstance(node) {
@@ -787,7 +787,7 @@ describe('_impl_revisit()', () => {
     }
 
     _impl_visitArray(node) {
-      return this._prot_visitArrayProperties(node);
+      return this._prot_visitProperties(node);
     }
 
     _impl_revisit(node, result, isCycleHead, ref) {

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -1080,13 +1080,7 @@ describe('_prot_visitProperties()', () => {
     }
 
     function checkEntries(got) {
-      const gotTweak = Object.fromEntries(got);
-
-      if (Array.isArray(value)) {
-        gotTweak.length = null;
-      }
-
-      checkProps(gotTweak);
+      checkProps(Object.fromEntries(got));
     }
 
     test('operates synchronously when possible', () => {

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -983,7 +983,7 @@ describe('_prot_visit()', () => {
         return `${node}!`;
       }
 
-      _impl_visitString(node) {
+      _impl_visitString(node_unused) {
         const got = this._prot_visit(9999);
         expect(got).toBeInstanceOf(VisitResult);
         expect(got.value).toBe('9999!');
@@ -1001,7 +1001,7 @@ describe('_prot_visit()', () => {
         return `${node}!`;
       }
 
-      async _impl_visitString(node) {
+      async _impl_visitString(node_unused) {
         const got = this._prot_visit(98765);
         expect(got).toBeInstanceOf(Promise);
         expect(await got).toBeInstanceOf(VisitResult);

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -49,38 +49,6 @@ const PROMISE_EXAMPLES = [
 ];
 
 /**
- * Visitor subclass, with some synchronous and some asynchronous behavior, which
- * recursively visits plain objects and arrays.
- */
-class RecursiveVisitor extends BaseValueVisitor {
-  _impl_visitBigInt(node_unused) {
-    throw new Error('Nope!');
-  }
-
-  async _impl_visitBoolean(node) {
-    await setImmediate();
-    return `${node}`;
-  }
-
-  _impl_visitNumber(node) {
-    return `${node}`;
-  }
-
-  async _impl_visitSymbol(node_unused) {
-    await setImmediate();
-    throw new Error('NO');
-  }
-
-  _impl_visitArray(node) {
-    return this._prot_visitProperties(node);
-  }
-
-  _impl_visitPlainObject(node) {
-    return this._prot_visitProperties(node);
-  }
-}
-
-/**
  * Visitor subclass, which is set up to be proxy aware.
  */
 class ProxyAwareVisitor extends BaseValueVisitor {
@@ -256,6 +224,38 @@ ${'visitSync'} | ${false} | ${false} | ${true}
 ${'visitWrap'} | ${true}  | ${true}  | ${true}
 `('$methodName()', ({ methodName, isAsync, wraps, canReturnPromises }) => {
   const CIRCULAR_MSG = 'Visit is deadlocked due to circular reference.';
+
+  /**
+   * Visitor subclass, with some synchronous and some asynchronous behavior,
+   * which recursively visits plain objects and arrays.
+   */
+  class RecursiveVisitor extends BaseValueVisitor {
+    _impl_visitBigInt(node_unused) {
+      throw new Error('Nope!');
+    }
+
+    async _impl_visitBoolean(node) {
+      await setImmediate();
+      return `${node}`;
+    }
+
+    _impl_visitNumber(node) {
+      return `${node}`;
+    }
+
+    async _impl_visitSymbol(node_unused) {
+      await setImmediate();
+      throw new Error('NO');
+    }
+
+    _impl_visitArray(node) {
+      return this._prot_visitProperties(node);
+    }
+
+    _impl_visitPlainObject(node) {
+      return this._prot_visitProperties(node);
+    }
+  }
 
   async function doTest(value, options = {}) {
     const {


### PR DESCRIPTION
This PR is a cleanup pass for the recent work on value visiting and log rendering. Highlights:

* Combined the property-visiting methods in `BaseValueVisitor` into a single method, `_prot_visitProperties()`.
* Expanded `_prot_visitProperties()` so it can return an entries array when desired.
* Split out `HumanVisitor` from `LogPayload`.