### PR TITLE
Consistency pass over `BaseValueVisitor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ versioning principles. Unstable releases do not.
 
 Breaking changes:
 * `valvis`:
-  * Renamed some methods in `BaseValueVisitor`, for clarity and consistency.
+  * Renamed some methods in `BaseValueVisitor`, for clarity and consistency, and
+    introduced a public method `visitWrap()`, which has the same "synchronous if
+    possible but async if not" behavior that is used internally.
 
 Other notable changes:
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
-* None.
+* `valvis`:
+  * Renamed some methods in `BaseValueVisitor`, for clarity and consistency.
 
 Other notable changes:
 * None.

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -90,7 +90,7 @@ export class HumanVisitor extends BaseValueVisitor {
         result.push(
           this.#maybeStyle(' = ', style),
           ComboText.INDENT,
-          this._prot_visit(node.value).value);
+          this._prot_visitWrap(node.value).value);
       }
       return new ComboText(...result);
     } else if (node instanceof Sexp) {
@@ -281,7 +281,7 @@ export class HumanVisitor extends BaseValueVisitor {
     const parts = [open, ComboText.INDENT];
 
     for (let at = 0; at < args.length; at++) {
-      const arg    = this._prot_visit(args[at]).value;
+      const arg    = this._prot_visitWrap(args[at]).value;
       const isLast = (at === (args.length - 1));
       if (at !== 0) {
         parts.push(ComboText.SPACE);

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -173,6 +173,8 @@ export class BaseValueVisitor {
    * value from the first call, even if the first call is still in progress at
    * the time of the call.
    *
+   * TODO: REMOVE THIS METHOD!
+   *
    * @returns {*} Whatever result was returned from the `_impl_*()` method which
    * processed the original `value`.
    */
@@ -181,27 +183,54 @@ export class BaseValueVisitor {
   }
 
   /**
-   * Similar to {@link #visit}, except (a) it will fail if the visit did not
-   * finish synchronously; and (b) if a promise is returned, it is only ever
-   * because a visitor returned a promise per se (and not from a visitor acting
-   * asynchronously).
+   * Similar to {@link #visitWrap}, except (a) it will fail if the visit did not
+   * finish synchronously; and (b) the result is not wrapped. Specifically with
+   * respect to (b), if a promise is returned, it is only ever
+   * because an `_impl_visit*()` method returned a promise result per se (and
+   * not because a visitor acted asynchronously).
    *
    * @returns {*} Whatever result was returned from the `_impl_*()` method which
-   * processed the original `value`.
+   *   processed the original `value`.
+   * @throws {Error} Thrown if there was trouble with the visit which could be
+   *   determined synchronously, _or_ if the visit could not be completed
+   *   synchronously.
    */
   visitSync() {
     return this.#visitRoot().extractSync();
   }
 
   /**
-   * Like {@link #visit}, except that successful results are wrapped in an
-   * instance of {@link VisitResult}, which makes it possible for a caller to
-   * tell the difference between a promise which is returned because the visitor
-   * is acting asynchronously and a promise which is returned because it is an
-   * actual visitor result.
+   * Visits this instance's designated value by calling through to the various
+   * `_impl_*()` methods as necessary (and as defined by the concrete subclass),
+   * synchronously if possible or asynchronously if not. That is, if all of the
+   * `_impl_*()` methods act synchronously, then this method returns
+   * synchronously with a result; but if any of the called methods returns a
+   * promise, then this method in turn returns a promise. In all cases, an
+   * ultimately successful return value is an instance of {@link VisitResult},
+   * which wraps the actual result value and can be queried for it. (This
+   * wrapping is made necessary because otherwise a result which is a promise
+   * would be mistaken for an asynchronous visit.)
    *
-   * @returns {*} Whatever result was returned from the `_impl_*()` method which
-   * processed the original `value`.
+   * If this method is called more than once on any given instance, the visit
+   * procedure is only actually run once; subsequent calls reuse the return
+   * value from the first call, even if the first call is still in progress at
+   * the time of the call.
+   *
+   * @returns {VisitResult|Promise<VisitResult>} Whatever result was returned
+   *   from the `_impl_*()` method which processed the original `value`.
+   * @throws {Error} Thrown if there was trouble with the visit which could be
+   *   determined synchronously.
+   */
+  visitWrap() {
+    // TODO
+  }
+
+  /**
+   * Like {@link #visitWrap}, except that it always operates asynchronously.
+   *
+   * @returns {VisitResult} Whatever result was returned from the `_impl_*()`
+   *   method which processed the original `value`.
+   * @throws {Error} Thrown if there was trouble with the visit.
    */
   async visitAsyncWrap() {
     return this.#visitRoot().extractAsync(true);

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -160,29 +160,6 @@ export class BaseValueVisitor {
   }
 
   /**
-   * Visits this instance's designated value. This in turn calls through to the
-   * various `_impl_*()` methods, as appropriate. The return value is whatever
-   * was returned from the `_impl_*()` method that was called to do the main
-   * processing of the value, except that this method "collapses" the promises
-   * that result from asynchronous visitor behavior with the promises that are
-   * direct visitor results. See {@link #visitAsyncWrap} for a
-   * "promise-preserving" variant.
-   *
-   * If this method is called more than once on any given instance, the visit
-   * procedure is only actually run once; subsequent calls reuse the return
-   * value from the first call, even if the first call is still in progress at
-   * the time of the call.
-   *
-   * TODO: REMOVE THIS METHOD!
-   *
-   * @returns {*} Whatever result was returned from the `_impl_*()` method which
-   * processed the original `value`.
-   */
-  async visit() {
-    return this.#visitRoot().extractAsync(false);
-  }
-
-  /**
    * Similar to {@link #visitWrap}, except (a) it will fail if the visit did not
    * finish synchronously; and (b) the result is not wrapped. Specifically with
    * respect to (b), if a promise is returned, it is only ever

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -582,11 +582,16 @@ export class BaseValueVisitor {
    * in concrete subclasses, for example, to visit the various pieces of
    * instances, where a simple object property visit wouldn't suffice.
    *
+   * This method returns synchronously if possible, or asynchronously if not. As
+   * such, it always returns a result wrapped in a {@link VisitResult}, so that
+   * returned promises can always be distinguished from promises due to the
+   * asynchronous nature of a visit.
+   *
    * @param {*} node Value to visit.
    * @returns {VisitResult|Promise<VisitResult>} The visit result if
    * synchronously available, or a promise for the result if not.
    */
-  _prot_visit(node) {
+  _prot_visitWrap(node) {
     const entry = this.#visitNode(node);
 
     return entry.isFinished()

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -165,8 +165,8 @@ export class BaseValueVisitor {
    * was returned from the `_impl_*()` method that was called to do the main
    * processing of the value, except that this method "collapses" the promises
    * that result from asynchronous visitor behavior with the promises that are
-   * direct visitor results. See {@link #visitAsyncWrap} for a "promise-preserving"
-   * variant.
+   * direct visitor results. See {@link #visitAsyncWrap} for a
+   * "promise-preserving" variant.
    *
    * If this method is called more than once on any given instance, the visit
    * procedure is only actually run once; subsequent calls reuse the return

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -903,6 +903,11 @@ export class BaseValueVisitor {
    * @returns {BaseValueVisitor#VisitEntry} Vititor entry for the root value.
    */
   #visitRoot() {
+    // Note: This isn't _just_ `return this.#visitNode(<root>)`, because that
+    // would end up invoking the def/ref mechanism, which would be incorrect to
+    // do in this case (because we're not trying to possibly-share a result
+    // within the visit, just trying to _get_ the result).
+
     const node = this.#rootValue;
     return this.#visits.get(node) ?? this.#visitNode(node);
   }

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -222,7 +222,11 @@ export class BaseValueVisitor {
    *   determined synchronously.
    */
   visitWrap() {
-    // TODO
+    const entry = this.#visitRoot();
+
+    return entry.isFinished()
+      ? entry.extractSync(true)
+      : entry.extractAsync(true);
   }
 
   /**

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -33,7 +33,7 @@ import { VisitResult } from '#x/VisitResult';
  * must use the method `_prot_wrapResult()` on its return value. Such a wrapped
  * value will get treated literally through all the visitor plumbing. Then, in
  * order to receive a promise from a visit call, client code can either use
- * {@link #visitSync} or {@link #visitWrap} (but not normal asynchronous
+ * {@link #visitSync} or {@link #visitAsyncWrap} (but not normal asynchronous
  * {@link #visit}).
  */
 export class BaseValueVisitor {
@@ -165,7 +165,7 @@ export class BaseValueVisitor {
    * was returned from the `_impl_*()` method that was called to do the main
    * processing of the value, except that this method "collapses" the promises
    * that result from asynchronous visitor behavior with the promises that are
-   * direct visitor results. See {@link #visitWrap} for a "promise-preserving"
+   * direct visitor results. See {@link #visitAsyncWrap} for a "promise-preserving"
    * variant.
    *
    * If this method is called more than once on any given instance, the visit
@@ -203,7 +203,7 @@ export class BaseValueVisitor {
    * @returns {*} Whatever result was returned from the `_impl_*()` method which
    * processed the original `value`.
    */
-  async visitWrap() {
+  async visitAsyncWrap() {
     return this.#visitRoot().extractAsync(true);
   }
 
@@ -1026,7 +1026,7 @@ export class BaseValueVisitor {
      * `wrapResult` is passed as `false`, this will cause the client (external
      * caller) to ultimately receive the fulfilled (resolved/rejected) value of
      * that promise and not the result promise per se. This is the crux of the
-     * difference between {link #visit} and {@link #visitWrap} (see which).
+     * difference between {link #visit} and {@link #visitAsyncWrap} (see which).
      *
      * @param {boolean} [wrapResult] Should a successful result be wrapped?
      * @returns {*} The successful result of the visit, if it was indeed

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -285,21 +285,21 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}
   ${'rejected'} | ${REJECTED_PROMISE}
   `('when the direct result is a $label promise', ({ value }) => {
     test('returns the promise as-is when synchronously available', async () => {
-      class SyncPromiseReturnVisitor extends BaseValueVisitor {
+      class TestVisitor extends BaseValueVisitor {
         _impl_visitInstance(node) {
           return new VisitResult(node);
         }
       }
 
       await doTest(value, {
-        cls:      SyncPromiseReturnVisitor,
+        cls:      TestVisitor,
         runsSync: true
       });
     });
 
     if (isAsync) {
       test('returns the promise as-is when asynchronously available', async () => {
-        class AsyncPromiseReturnVisitor extends BaseValueVisitor {
+        class TestVisitor extends BaseValueVisitor {
           async _impl_visitInstance(node) {
             await setImmediate();
             return new VisitResult(node);
@@ -307,7 +307,7 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}
         }
 
         await doTest(value, {
-          cls:      AsyncPromiseReturnVisitor,
+          cls:      TestVisitor,
           runsSync: false
         });
       });

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -977,7 +977,7 @@ ${'_prot_nameFromValue'}  | ${'expectedName'}
   });
 });
 
-describe('_prot_visit()', () => {
+describe('_prot_visitWrap()', () => {
   test('works synchronously when possible', () => {
     class VisitCheckVisitor extends BaseValueVisitor {
       _impl_visitNumber(node) {
@@ -985,7 +985,7 @@ describe('_prot_visit()', () => {
       }
 
       _impl_visitString(node_unused) {
-        const got = this._prot_visit(9999);
+        const got = this._prot_visitWrap(9999);
         expect(got).toBeInstanceOf(VisitResult);
         expect(got.value).toBe('9999!');
         return 'yep';
@@ -1003,7 +1003,7 @@ describe('_prot_visit()', () => {
       }
 
       async _impl_visitString(node_unused) {
-        const got = this._prot_visit(98765);
+        const got = this._prot_visitWrap(98765);
         expect(got).toBeInstanceOf(Promise);
         expect(await got).toBeInstanceOf(VisitResult);
         expect((await got).value).toBe('98765!');

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -378,17 +378,18 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
     });
   });
 
-  return;
-  // --------------------------------------------------------------------
-  // TODO: TWEAK AND VALIDATE EVERYTHING BELOW THIS COMMENT
-  // --------------------------------------------------------------------
-
   test('handles non-circular synchronously-visited duplicate references correctly (one ref)', async () => {
+    class TestVisitor extends BaseValueVisitor {
+      _impl_visitArray(node) { return this._prot_visitProperties(node); }
+      _impl_visitNumber(node) { return `${node}`; }
+    }
+
     const inner = [1];
     const outer = [inner, inner];
 
     await doTest(outer, {
-      cls: RecursiveVisitor,
+      cls:      TestVisitor,
+      runsSync: true,
       check: (got) => {
         expect(got).toBeArrayOfSize(2);
         expect(got[0]).toBe(got[1]);
@@ -400,12 +401,18 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
   });
 
   test('handles non-circular synchronously-visited duplicate references correctly (two refs)', async () => {
+    class TestVisitor extends BaseValueVisitor {
+      _impl_visitArray(node) { return this._prot_visitProperties(node); }
+      _impl_visitNumber(node) { return `${node}`; }
+    }
+
     const inner  = [1];
     const middle = [inner, inner, inner, 2];
     const outer  = [middle, inner, middle, 3];
 
     await doTest(outer, {
-      cls: RecursiveVisitor,
+      cls:      TestVisitor,
+      runsSync: true,
       check: (got) => {
         expect(got).toBeArrayOfSize(4);
         expect(got[0]).toBe(got[2]);
@@ -420,6 +427,11 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
       }
     });
   });
+
+  return;
+  // --------------------------------------------------------------------
+  // TODO: TWEAK AND VALIDATE EVERYTHING BELOW THIS COMMENT
+  // --------------------------------------------------------------------
 
   if (isAsync) {
     test('returns the value which was returned asynchronously by an `_impl_visit*()` method', async () => {

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -20,7 +20,8 @@ const EXAMPLES = [
   { what: 'is up?' },
   new Set(['x', 'y', 'z']),
   (x, y) => { return x < y; },
-  class Flomp { /*empty*/ }
+  class Flomp { /*empty*/ },
+  Map
 ];
 
 const OBJECT_PROXY   = new Proxy({ a: 'florp' }, {});

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -434,6 +434,12 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
       }
     }
 
+    class SyncPromiseReturnVisitor extends BaseValueVisitor {
+      _impl_visitInstance(node) {
+        return new VisitResult(node);
+      }
+    }
+
     describe.each`
     label         | value
     ${'pending'}  | ${PENDING_PROMISE}
@@ -441,7 +447,10 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
     ${'rejected'} | ${REJECTED_PROMISE}
     `('when the direct result is a $label promise', ({ value }) => {
       test('returns the promise as-is when synchronously available', async () => {
-        await doTest(value, { runsAsync: false });
+        await doTest(value, {
+          cls:       SyncPromiseReturnVisitor,
+          runsAsync: false
+        });
       });
 
       if (isAsync) {

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -222,7 +222,7 @@ describe.each`
 methodName          | isAsync   | wraps    | canReturnPromises
 ${'visit'}          | ${true}   | ${false} | ${false}
 ${'visitSync'}      | ${false}  | ${false} | ${true} // TODO: Delete this method!
-${'visitWrap'}      | ${'both'} | ${true}  | ${false}
+${'visitWrap'}      | ${'both'} | ${true}  | ${true}
 ${'visitAsyncWrap'} | ${true}   | ${true}  | ${true}
 `('$methodName()', ({ methodName, isAsync, wraps, canReturnPromises }) => {
   const CIRCULAR_MSG = 'Visit is deadlocked due to circular reference.';

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -447,7 +447,7 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
 
     test('throws the right error if a will-fail visit did not finish synchronously', async () => {
       class TestVisitor extends BaseValueVisitor {
-        async _impl_visitNumber(node) { throw new Error('Bonk!'); }
+        async _impl_visitNumber(node_unused) { throw new Error('Bonk!'); }
       }
 
       await expect(doTest(65432,
@@ -508,7 +508,7 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
 
     test('throws the error which was thrown asynchronously by an `_impl_visit*()` method', async () => {
       class TestVisitor extends BaseValueVisitor {
-        async _impl_visitBoolean(node) { throw new Error('oof!'); }
+        async _impl_visitBoolean(node_unused) { throw new Error('oof!'); }
       }
 
       await expect(doTest(true, { cls: TestVisitor }))
@@ -540,6 +540,7 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
           await setImmediate();
           return this._prot_visitProperties(node);
         }
+
         async _impl_visitBoolean(node) {
           await setImmediate();
           return `${node}`;

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -337,6 +337,10 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
     });
   }
 
+  // --------------------------------------------------------------------
+  // TODO: TWEAK AND VALIDATE EVERYTHING BELOW THIS COMMENT
+  // --------------------------------------------------------------------
+
   test('throws the right error if given a value whose synchronous visit directly encountered a circular reference', async () => {
     const circ1 = [4];
     const circ2 = [5, 6, circ1];

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -1051,8 +1051,8 @@ describe('_prot_visitWrap()', () => {
       }
     }
 
-    const got = new VisitCheckVisitor('boop').visit();
-    expect(await got).toBe('yep');
+    const got = await new VisitCheckVisitor('boop').visitAsyncWrap();
+    expect((await got).value).toBe('yep');
   });
 });
 
@@ -1133,24 +1133,28 @@ describe('_prot_visitProperties()', () => {
       checkProps(got);
     });
 
-    test('operates asynchronously when not strictly necessary', async () => {
+    test('operates asynchronously when called as such but not strictly necessary', async () => {
       const vv   = new VisitPropertiesCheckVisitor(value);
-      const got  = vv.visit();
+      const got  = vv.visitAsyncWrap();
 
       expect(got).toBeInstanceOf(Promise);
-      expect(Object.getPrototypeOf(await got)).toBe(proto);
-      expect(await got).toEqual(expected);
-      checkProps(await got);
+
+      const result = (await got).value;
+      expect(Object.getPrototypeOf(result)).toBe(proto);
+      expect(result).toEqual(expected);
+      checkProps(result);
     });
 
     test('operates asynchronously when necessary', async () => {
       const vv  = new VisitPropertiesCheckVisitor(value, { async: true });
-      const got = vv.visit();
+      const got = vv.visitAsyncWrap();
 
       expect(got).toBeInstanceOf(Promise);
-      expect(Object.getPrototypeOf(await got)).toBe(proto);
-      expect(await got).toEqual(expected);
-      checkProps(await got);
+
+      const result = (await got).value;
+      expect(Object.getPrototypeOf(result)).toBe(proto);
+      expect(result).toEqual(expected);
+      checkProps(result);
     });
 
     test('produces entries (when asked)', () => {
@@ -1181,7 +1185,7 @@ describe('_prot_visitProperties()', () => {
 
     test('asynchronously propagates an error thrown asynchronously by one of the sub-calls', async () => {
       const vv  = new VisitPropertiesCheckVisitor(value, { async: true, errors: true });
-      const got = vv.visit();
+      const got = vv.visitAsyncWrap();
 
       expect(got).toBeInstanceOf(Promise);
       await expect(got).rejects.toThrow(/Ouch/);
@@ -1209,11 +1213,13 @@ describe('_prot_visitProperties()', () => {
       expected[sym] = '914%';
 
       const vv  = new VisitPropertiesCheckVisitor(value, { async: true });
-      const got = vv.visit();
+      const got = vv.visitAsyncWrap();
 
       expect(got).toBeInstanceOf(Promise);
-      expect(await got).toEqual(expected);
-      checkProps(await got);
+
+      const result = (await got).value;
+      expect(result).toEqual(expected);
+      checkProps(result);
     });
 
     if (Array.isArray(value)) {
@@ -1237,11 +1243,11 @@ describe('_prot_visitProperties()', () => {
         expected.bloop = '321%';
 
         const vv   = new VisitPropertiesCheckVisitor(value, { async: true });
-        const got  = vv.visit();
+        const got  = vv.visitAsyncWrap();
 
-        expect(got).toBeInstanceOf(Promise);
-        expect(await got).toEqual(expected);
-        checkProps(await got);
+        const result = (await got).value;
+        expect(result).toEqual(expected);
+        checkProps(result);
       });
     }
   });

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -428,6 +428,22 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
     });
   });
 
+  test('throws the error which was thrown synchronously by an `_impl_visit*()` method', async () => {
+    class TestVisitor extends BaseValueVisitor {
+      _impl_visitNumber(node) {
+        throw new Error('Nope!');
+      }
+    }
+
+    const value = 123;
+    await expect(
+      doTest(value, {
+        cls:      TestVisitor,
+        runsSync: true
+      })
+    ).rejects.toThrow('Nope!');
+  });
+
   return;
   // --------------------------------------------------------------------
   // TODO: TWEAK AND VALIDATE EVERYTHING BELOW THIS COMMENT
@@ -512,11 +528,6 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
       await expect(doTest(value, { cls: RecursiveVisitor })).rejects.toThrow(MSG);
     });
   }
-
-  test('throws the error which was thrown synchronously by an `_impl_visit*()` method', async () => {
-    const value = 123n;
-    await expect(doTest(value, { cls: RecursiveVisitor })).rejects.toThrow('Nope!');
-  });
 
   test('calls `_impl_newRef()` when a non-circular reference is detected', async () => {
     const shared = [9, 99, 999];

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -711,6 +711,7 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
 
 // Tests for plain `visit()` not easily covered by the common `visit*()` test
 // mechanism above.
+// TODO: Remove this method!
 describe('visit()', () => {
   test('plumbs through a resolved promise value', async () => {
     const vv  = new BaseValueVisitor(RESOLVED_PROMISE);
@@ -755,7 +756,6 @@ describe('_impl_shouldRef()', () => {
     expect(vv._impl_shouldRef([])).toBeFalse();
   });
 });
-
 
 describe('_impl_revisit()', () => {
   class RevisitCheckVisitor extends BaseValueVisitor {

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -266,14 +266,14 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
     }
 
     const {
-      cls       = BaseValueVisitor,
-      check     = (got, visitor_unused) => { expect(got).toBe(value); },
-      runsAsync = (isAsync && !isSync)
+      cls      = BaseValueVisitor,
+      check    = (got, visitor_unused) => { expect(got).toBe(value); },
+      runsSync = isSync && !isAsync
     } = options;
 
     const visitor = new cls(value);
 
-    if (isSync && !isAsync && runsAsync) {
+    if (isSync && !isAsync && !runsSync) {
       // This unit test should be under a title like, "throws an error
       // indicating the call could not complete synchronously."
       throw new Error('Test should not have been run!');
@@ -305,7 +305,12 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
 
     circ1.push(circ2);
 
-    await expect(doTest(value, { cls: RecursiveVisitor })).rejects.toThrow(CIRCULAR_MSG);
+    await expect(
+      doTest(value, {
+        cls:      RecursiveVisitor,
+        runsSync: true
+      })
+    ).rejects.toThrow(CIRCULAR_MSG);
   });
 
   test('handles non-circular synchronously-visited duplicate references correctly (one ref)', async () => {
@@ -448,16 +453,16 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
     `('when the direct result is a $label promise', ({ value }) => {
       test('returns the promise as-is when synchronously available', async () => {
         await doTest(value, {
-          cls:       SyncPromiseReturnVisitor,
-          runsAsync: false
+          cls:      SyncPromiseReturnVisitor,
+          runsSync: true
         });
       });
 
       if (isAsync) {
         test('returns the promise as-is when asynchronously available', async () => {
           await doTest(value, {
-            cls:       AsyncPromiseReturnVisitor,
-            runsAsync: true
+            cls:      AsyncPromiseReturnVisitor,
+            runsSync: false
           });
         });
       }

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -219,10 +219,10 @@ describe('refFromResultValue()', () => {
 
 // Tests for all three `visit*()` methods.
 describe.each`
-methodName     | isAsync  | wraps    | canReturnPromises
-${'visit'}     | ${true}  | ${false} | ${false}
-${'visitSync'} | ${false} | ${false} | ${true}
-${'visitWrap'} | ${true}  | ${true}  | ${true}
+methodName          | isAsync  | wraps    | canReturnPromises
+${'visit'}          | ${true}  | ${false} | ${false}
+${'visitSync'}      | ${false} | ${false} | ${true}
+${'visitAsyncWrap'} | ${true}  | ${true}  | ${true}
 `('$methodName()', ({ methodName, isAsync, wraps, canReturnPromises }) => {
   const CIRCULAR_MSG = 'Visit is deadlocked due to circular reference.';
 

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -295,7 +295,7 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
     }
   }
 
-  test.each(EXAMPLES)('returns the given value as-is: %o', async (value) => {
+  test.each([...EXAMPLES, ...PROXY_EXAMPLES])('returns the given value as-is: %o', async (value) => {
     await doTest(value);
   });
 

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -268,8 +268,7 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
     } = options;
 
     if (isSync && !isAsync && !runsSync) {
-      // This unit test should be under a title like, "throws an error
-      // indicating the call could not complete synchronously."
+      // This unit test shouldn't have been called for this method.
       throw new Error('Test should not have been run!');
     }
 

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -294,8 +294,27 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
     }
   }
 
-  test.each([...EXAMPLES, ...PROXY_EXAMPLES])('returns the given synchronously-available value as-is: %o', async (value) => {
+  test.each([...EXAMPLES])('returns the given synchronously-available value as-is: %o', async (value) => {
     await doTest(value, { runsSync: true });
+  });
+
+  describe('when `_impl_proxyAware() === false`', () => {
+    test.each(PROXY_EXAMPLES)('returns the given value as-is: %o', async (value) => {
+      await doTest(value, { runsSync: true });
+    });
+  });
+
+  describe('when `_impl_proxyAware() === true`', () => {
+    test.each(PROXY_EXAMPLES)('returns the value returned from `_impl_visitProxy()`: %o', async (value) => {
+      await doTest(value, {
+        cls:      ProxyAwareVisitor,
+        runsSync: true,
+        check: (got) => {
+          expect(got).toEqual({ proxy: value });
+          expect(got.proxy).toBe(value);
+        }
+      });
+    });
   });
 
   if (canReturnPromises) {
@@ -593,24 +612,6 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
         expect(ref).toBe(ref.value[2]);
         expect(wasFinished).toBeFalse();
       }
-    });
-  });
-
-  describe('when `_impl_proxyAware() === false`', () => {
-    test.each(PROXY_EXAMPLES)('returns the given value as-is: %o', async (value) => {
-      await doTest(value);
-    });
-  });
-
-  describe('when `_impl_proxyAware() === true`', () => {
-    test.each(PROXY_EXAMPLES)('returns the value returned from `_impl_visitProxy()`: %o', async (value) => {
-      await doTest(value, {
-        cls: ProxyAwareVisitor,
-        check: (got) => {
-          expect(got).toEqual({ proxy: value });
-          expect(got.proxy).toBe(value);
-        }
-      });
     });
   });
 

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -213,7 +213,7 @@ describe('refFromResultValue()', () => {
 });
 
 // Tests for all three `visit*()` methods.
-describe.only.each`
+describe.each`
 methodName          | isAsync  | isSync   | wraps    | canReturnPromises
 ${'visit'}          | ${true}  | ${false} | ${false} | ${false}
 ${'visitSync'}      | ${false} | ${true}  | ${false} | ${true} // TODO: Delete this method!

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -488,6 +488,15 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
         }
       });
     });
+
+    test('throws the error which was thrown asynchronously by an `_impl_visit*()` method', async () => {
+      class TestVisitor extends BaseValueVisitor {
+        async _impl_visitBoolean(node) { throw new Error('oof!'); }
+      }
+
+      await expect(doTest(true, { cls: TestVisitor }))
+        .rejects.toThrow('oof!');
+    });
   }
 
   return;
@@ -496,11 +505,6 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
   // --------------------------------------------------------------------
 
   if (isAsync) {
-    test('throws the error which was thrown asynchronously by an `_impl_visit*()` method', async () => {
-      const value = Symbol('eep');
-      await expect(doTest(value, { cls: RecursiveVisitor })).rejects.toThrow('NO');
-    });
-
     test('throws the right error if given a value whose asynchronous visit would directly contain a circular reference', async () => {
       const circ1 = [true, 4];
       const circ2 = [true, 5, 6, circ1];

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -516,19 +516,16 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
       await expect(doTest(value, { cls: TestVisitor }))
         .rejects.toThrow(CIRCULAR_MSG);
     });
-  }
 
-  return;
-  // --------------------------------------------------------------------
-  // TODO: TWEAK AND VALIDATE EVERYTHING BELOW THIS COMMENT
-  // --------------------------------------------------------------------
-
-  if (isAsync) {
     test('throws the right error if given a value whose asynchronous visit would directly contain a circular reference (even more async)', async () => {
-      class ExtraAsyncVisitor extends RecursiveVisitor {
+      class TestVisitor extends BaseValueVisitor {
         async _impl_visitArray(node) {
           await setImmediate();
           return this._prot_visitProperties(node);
+        }
+        async _impl_visitBoolean(node) {
+          await setImmediate();
+          return `${node}`;
         }
       }
 
@@ -538,9 +535,15 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
 
       circ1.push(circ2);
 
-      await expect(doTest(value, { cls: ExtraAsyncVisitor })).rejects.toThrow(CIRCULAR_MSG);
+      await expect(doTest(value, { cls: TestVisitor }))
+        .rejects.toThrow(CIRCULAR_MSG);
     });
   }
+
+  return;
+  // --------------------------------------------------------------------
+  // TODO: TWEAK AND VALIDATE EVERYTHING BELOW THIS COMMENT
+  // --------------------------------------------------------------------
 
   if (isSync) {
     const MSG = 'Visit did not finish synchronously.';

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -215,7 +215,7 @@ describe('refFromResultValue()', () => {
 // Tests for all three `visit*()` methods.
 describe.each`
 methodName          | isAsync  | isSync   | wraps    | canReturnPromises
-${'visit'}          | ${true}  | ${false} | ${false} | ${false}
+${'visitSync'}      | ${false} | ${true}  | ${false} | ${true}
 ${'visitWrap'}      | ${true}  | ${true}  | ${true}  | ${true}
 ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
 `('$methodName()', ({ methodName, isAsync, isSync, wraps, canReturnPromises }) => {

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -3,7 +3,7 @@
 
 import { setImmediate } from 'node:timers/promises';
 
-import { ManualPromise, PromiseState, PromiseUtil } from '@this/async';
+import { PromiseState, PromiseUtil } from '@this/async';
 import { BaseValueVisitor, VisitDef, VisitRef, VisitResult }
   from '@this/valvis';
 

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -337,12 +337,13 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
     });
   }
 
-  return;
-  // --------------------------------------------------------------------
-  // TODO: TWEAK AND VALIDATE EVERYTHING BELOW THIS COMMENT
-  // --------------------------------------------------------------------
-
   test('throws the right error if given a value whose synchronous visit directly encountered a circular reference', async () => {
+    class TestVisitor extends BaseValueVisitor {
+      _impl_visitArray(node) {
+        return this._prot_visitProperties(node);
+      }
+    }
+
     const circ1 = [4];
     const circ2 = [5, 6, circ1];
     const value = [1, [2, 3, circ1]];
@@ -351,11 +352,16 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}  | ${true}
 
     await expect(
       doTest(value, {
-        cls:      RecursiveVisitor,
+        cls:      TestVisitor,
         runsSync: true
       })
     ).rejects.toThrow(CIRCULAR_MSG);
   });
+
+  return;
+  // --------------------------------------------------------------------
+  // TODO: TWEAK AND VALIDATE EVERYTHING BELOW THIS COMMENT
+  // --------------------------------------------------------------------
 
   test('handles non-circular synchronously-visited duplicate references correctly (one ref)', async () => {
     const inner = [1];

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -219,10 +219,11 @@ describe('refFromResultValue()', () => {
 
 // Tests for all three `visit*()` methods.
 describe.each`
-methodName          | isAsync  | wraps    | canReturnPromises
-${'visit'}          | ${true}  | ${false} | ${false}
-${'visitSync'}      | ${false} | ${false} | ${true}
-${'visitAsyncWrap'} | ${true}  | ${true}  | ${true}
+methodName          | isAsync   | wraps    | canReturnPromises
+${'visit'}          | ${true}   | ${false} | ${false}
+${'visitSync'}      | ${false}  | ${false} | ${true} // TODO: Delete this method!
+${'visitWrap'}      | ${'both'} | ${true}  | ${false}
+${'visitAsyncWrap'} | ${true}   | ${true}  | ${true}
 `('$methodName()', ({ methodName, isAsync, wraps, canReturnPromises }) => {
   const CIRCULAR_MSG = 'Visit is deadlocked due to circular reference.';
 


### PR DESCRIPTION
This PR does a few things to make `BaseValueVisitor` a bit more self-consistent. Highlights:

* Dropped the public method `visit()`, which had bad semantics.
* Renamed `visitAsync()` -> `visitWrapAsync()`, which better represents its behavior.
* Renamed `_prot_visit()` -> `_protVisitWrap()`, which better represents its behavior.
* Added public method `visitWrap()`, which has the same behavior as `_prot_visitWrap()` but for the root value being visited.
