### PR TITLE
More "last licks" on visiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Breaking changes:
   * Renamed some methods in `BaseValueVisitor`, for clarity and consistency, and
     introduced a public method `visitWrap()`, which has the same "synchronous if
     possible but async if not" behavior that is used internally.
+  * Reworked `VisitDef` and `VisitRef` to not assume an associated visitor
+    instance.
 
 Other notable changes:
 * None.

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -99,14 +99,6 @@ export class BaseDefRef {
   }
 
   /**
-   * @returns {*} The original value (not the visit result) which this
-   * instance is a reference to.
-   */
-  get originalValue() {
-    return this.#entry?.originalValue ?? null;
-  }
-
-  /**
    * @returns {*} The result value of the visit.
    * @throws {Error} Thrown if the visit was unsuccessful or is still in
    *   progress.

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -181,17 +181,6 @@ export class BaseDefRef {
   }
 
   /**
-   * Is this instance associated with the given visitor?
-   *
-   * @param {BaseValueVisitor} visitor The visitor in question.
-   * @returns {boolean} `true` if this instance's associated visitor is in fact
-   *   `visitor`.
-   */
-  isAssociatedWith(visitor) {
-    return this.#entry?.isAssociatedWith(visitor) ?? false;
-  }
-
-  /**
    * Indicates whether or not the visit of the referenced value is finished and
    * has a result value or error.
    *

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -58,10 +58,10 @@ export class BaseDefRef {
    * private inner class of {@link BaseValueVisitor}, and as such, this
    * constructor isn't usable publicly.
    *
+   * @param {number} index The reference index number.
    * @param {?VisitEntry} entry The visit-in-progress entry representing the
    *   original visit, or `null` if there is no associated entry. (The latter
    *   case is mostly intended for testing scenarios.)
-   * @param {number} index The reference index number.
    */
   constructor(index, entry) {
     this.#index = index;

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -41,49 +41,12 @@ export class BaseDefRef {
   #index;
 
   /**
-   * The value being referred to, or `null` if not yet known.
-   *
-   * @type {*} value
-   */
-  #value;
-
-  /**
-   * The error resulting from the visit, or `null` if there was none _or_ it is
-   * not yet  known.
-   *
-   * @type {?Error}
-   */
-  #error;
-
-  /**
-   * Is the visit finished? Relatedly, are {@link #value} and {@link #error}
-   * known?
-   *
-   * @type {boolean}
-   */
-  #finished;
-
-  /**
-   * Constructs an instance. Note that the first parameter is an instance of a
-   * private inner class of {@link BaseValueVisitor}, and as such, this
-   * constructor isn't usable publicly.
+   * Constructs an instance.
    *
    * @param {number} index The reference index number.
-   * @param {*} [value] The already-known associated value. If not passed, the
-   *   value is treated as not yet known, which relatedly means that the
-   *   associated (sub-)visit is not yet finished.
    */
-  constructor(index, value = BaseDefRef.#SYM_notFinished) {
+  constructor(index) {
     this.#index = index;
-    this.#error = null;
-
-    if (value === BaseDefRef.#SYM_notFinished) {
-      this.#value    = null;
-      this.#finished = false;
-    } else {
-      this.#value    = value;
-      this.#finished = true;
-    }
   }
 
   /**
@@ -113,73 +76,24 @@ export class BaseDefRef {
   }
 
   /**
+   * @abstract
    * @returns {*} The result value of the visit.
    * @throws {Error} Thrown if the visit was unsuccessful or is still in
    *   progress.
    */
   get value() {
-    if (!this.#finished) {
-      throw new Error('Not yet finished.');
-    } else if (this.#error) {
-      throw this.#error;
-    } else {
-      return this.#value;
-    }
-  }
-
-  /**
-   * Indicates that this instance's visit has now finished unsuccessfully with
-   * the given error. It is only ever valid to call this on an unfinished
-   * instance.
-   *
-   * @param {Error} error The error.
-   */
-  finishWithError(error) {
-    if (this.#finished) {
-      throw new Error('Already finished.');
-    }
-
-    this.#finished = true;
-    this.#error    = error;
-  }
-
-  /**
-   * Indicates that this instance's visit has now finished successfully with the
-   * given result value. It is only ever valid to call this on an unfinished
-   * instance.
-   *
-   * @param {*} value The result value.
-   */
-  finishWithValue(value) {
-    if (this.#finished) {
-      throw new Error('Already finished.');
-    }
-
-    this.#finished = true;
-    this.#value    = value;
+    throw Methods.abstract();
   }
 
   /**
    * Indicates whether or not the visit of the referenced value is finished and
    * has a result value or error.
    *
+   * @abstract
    * @returns {boolean} `true` if the visit of the referenced value is finished,
    *   or `false` if it is still in-progress.
    */
   isFinished() {
-    return this.#finished;
+    throw Methods.abstract();
   }
-
-
-  //
-  // Static members
-  //
-
-  /**
-   * Special uninterned symbol used in the constructor in order to distinguish
-   * whether the `value` argument was passed.
-   *
-   * @type {symbol}
-   */
-  static #SYM_notFinished = Symbol('BaseDefRef.notFinished');
 }

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -1,6 +1,8 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
+import { Methods } from '@this/typey';
+
 /**
  * Forward declaration of this class, because `import`ing it would cause a
  * circular dependency while loading.
@@ -47,13 +49,6 @@ export class BaseDefRef {
   #index;
 
   /**
-   * The entry which is being referred to.
-   *
-   * @type {VisitEntry}
-   */
-  #entry;
-
-  /**
    * The value being referred to, or `null` if not yet known.
    *
    * @type {*} value
@@ -82,16 +77,15 @@ export class BaseDefRef {
    * constructor isn't usable publicly.
    *
    * @param {number} index The reference index number.
-   * @param {?VisitEntry} entry The visit-in-progress entry representing the
-   *   original visit, or `null` if there is no associated entry. (The latter
-   *   case is mostly intended for testing scenarios.)
+   * @param {?VisitEntry} entry_ignored The visit-in-progress entry representing
+   *   the original visit, or `null` if there is no associated entry. (The
+   *   latter case is mostly intended for testing scenarios.)
    * @param {*} [value] The already-known associated value. If not passed, the
    *   value is treated as not yet known, which relatedly means that the
    *   associated (sub-)visit is not yet finished.
    */
-  constructor(index, entry, value = BaseDefRef.#SYM_notFinished) {
+  constructor(index, entry_ignored, value = BaseDefRef.#SYM_notFinished) {
     this.#index = index;
-    this.#entry = entry;
     this.#error = null;
 
     if (value === BaseDefRef.#SYM_notFinished) {
@@ -104,25 +98,21 @@ export class BaseDefRef {
   }
 
   /**
+   * @abstract
    * @returns {?VisitDef} The def corresponding to this instance. This is `this`
    * if this instance is in fact a def.
-   *
-   * **Note:** This is only ever `null` when the instance was constructed with
-   * `entry === null`.
    */
   get def() {
-    return this.#entry?.def ?? null;
+    throw Methods.abstract();
   }
 
   /**
+   * @abstract
    * @returns {?VisitRef} The ref corresponding to this instance. This is `this`
    * if this instance is in fact a ref.
-   *
-   * **Note:** This is only ever `null` when the instance was constructed with
-   * `entry === null`.
    */
   get ref() {
-    return this.#entry?.ref ?? null;
+    throw Methods.abstract();
   }
 
   /**

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -40,18 +40,18 @@
  */
 export class BaseDefRef {
   /**
-   * The entry which is being referred to.
-   *
-   * @type {VisitEntry}
-   */
-  #entry;
-
-  /**
    * The reference index number.
    *
    * @type {number}
    */
   #index;
+
+  /**
+   * The entry which is being referred to.
+   *
+   * @type {VisitEntry}
+   */
+  #entry;
 
   /**
    * Constructs an instance. Note that the first parameter is an instance of a
@@ -63,9 +63,9 @@ export class BaseDefRef {
    *   case is mostly intended for testing scenarios.)
    * @param {number} index The reference index number.
    */
-  constructor(entry, index) {
-    this.#entry = entry;
+  constructor(index, entry) {
     this.#index = index;
+    this.#entry = entry;
   }
 
   /**

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -7,14 +7,6 @@ import { Methods } from '@this/typey';
  * Forward declaration of this class, because `import`ing it would cause a
  * circular dependency while loading.
  *
- * @typedef BaseValueVisitor
- * @type {object}
- */
-
-/**
- * Forward declaration of this class, because `import`ing it would cause a
- * circular dependency while loading.
- *
  * @typedef VisitDef
  * @type {object}
  */

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -20,14 +20,6 @@ import { Methods } from '@this/typey';
  */
 
 /**
- * Declaration of the class `BaseValueVisitor.#VisitEntry` for documentation
- * purposes. The class isn't exposed publicly.
- *
- * @typedef VisitEntry
- * @type {object}
- */
-
-/**
  * Forward declaration of this class, because `import`ing it would cause a
  * circular dependency while loading.
  *
@@ -77,14 +69,11 @@ export class BaseDefRef {
    * constructor isn't usable publicly.
    *
    * @param {number} index The reference index number.
-   * @param {?VisitEntry} entry_ignored The visit-in-progress entry representing
-   *   the original visit, or `null` if there is no associated entry. (The
-   *   latter case is mostly intended for testing scenarios.)
    * @param {*} [value] The already-known associated value. If not passed, the
    *   value is treated as not yet known, which relatedly means that the
    *   associated (sub-)visit is not yet finished.
    */
-  constructor(index, entry_ignored, value = BaseDefRef.#SYM_notFinished) {
+  constructor(index, value = BaseDefRef.#SYM_notFinished) {
     this.#index = index;
     this.#error = null;
 

--- a/src/valvis/export/BaseDefRef.js
+++ b/src/valvis/export/BaseDefRef.js
@@ -54,6 +54,29 @@ export class BaseDefRef {
   #entry;
 
   /**
+   * The value being referred to, or `null` if not yet known.
+   *
+   * @type {*} value
+   */
+  #value;
+
+  /**
+   * The error resulting from the visit, or `null` if there was none _or_ it is
+   * not yet  known.
+   *
+   * @type {?Error}
+   */
+  #error;
+
+  /**
+   * Is the visit finished? Relatedly, are {@link #value} and {@link #error}
+   * known?
+   *
+   * @type {boolean}
+   */
+  #finished;
+
+  /**
    * Constructs an instance. Note that the first parameter is an instance of a
    * private inner class of {@link BaseValueVisitor}, and as such, this
    * constructor isn't usable publicly.
@@ -62,10 +85,22 @@ export class BaseDefRef {
    * @param {?VisitEntry} entry The visit-in-progress entry representing the
    *   original visit, or `null` if there is no associated entry. (The latter
    *   case is mostly intended for testing scenarios.)
+   * @param {*} [value] The already-known associated value. If not passed, the
+   *   value is treated as not yet known, which relatedly means that the
+   *   associated (sub-)visit is not yet finished.
    */
-  constructor(index, entry) {
+  constructor(index, entry, value = BaseDefRef.#SYM_notFinished) {
     this.#index = index;
     this.#entry = entry;
+    this.#error = null;
+
+    if (value === BaseDefRef.#SYM_notFinished) {
+      this.#value    = null;
+      this.#finished = false;
+    } else {
+      this.#value    = value;
+      this.#finished = true;
+    }
   }
 
   /**
@@ -104,7 +139,45 @@ export class BaseDefRef {
    *   progress.
    */
   get value() {
-    return this.#entry?.extractSync() ?? null;
+    if (!this.#finished) {
+      throw new Error('Not yet finished.');
+    } else if (this.#error) {
+      throw this.#error;
+    } else {
+      return this.#value;
+    }
+  }
+
+  /**
+   * Indicates that this instance's visit has now finished unsuccessfully with
+   * the given error. It is only ever valid to call this on an unfinished
+   * instance.
+   *
+   * @param {Error} error The error.
+   */
+  finishWithError(error) {
+    if (this.#finished) {
+      throw new Error('Already finished.');
+    }
+
+    this.#finished = true;
+    this.#error    = error;
+  }
+
+  /**
+   * Indicates that this instance's visit has now finished successfully with the
+   * given result value. It is only ever valid to call this on an unfinished
+   * instance.
+   *
+   * @param {*} value The result value.
+   */
+  finishWithValue(value) {
+    if (this.#finished) {
+      throw new Error('Already finished.');
+    }
+
+    this.#finished = true;
+    this.#value    = value;
   }
 
   /**
@@ -126,6 +199,19 @@ export class BaseDefRef {
    *   or `false` if it is still in-progress.
    */
   isFinished() {
-    return this.#entry?.isFinished() ?? false;
+    return this.#finished;
   }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * Special uninterned symbol used in the constructor in order to distinguish
+   * whether the `value` argument was passed.
+   *
+   * @type {symbol}
+   */
+  static #SYM_notFinished = Symbol('BaseDefRef.notFinished');
 }

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -96,6 +96,29 @@ export class BaseValueVisitor {
   }
 
   /**
+   * Gets the visit result corresponding to a value that was encountered during
+   * the visit. This works for either the original {@link #rootValue} or any
+   * value it refers to and was visited.
+   *
+   * @param {*} value The value that was visited (either the main visit or a
+   *   sub-visit).
+   * @returns {*} The result of the visit.
+   * @throws {Error} Thrown if the visit is still in progress or has not yet
+   *   started, _or_ if `value` was never visited.
+   */
+  getVisitResult(value) {
+    this.#throwIfNotFinished();
+
+    const entry = this.#visitEntries.get(value);
+
+    if (!entry) {
+      throw new Error('Value was not visited.');
+    }
+
+    return entry.extractSync();
+  }
+
+  /**
    * Indicates whether or not the visit represented by this instance resulted in
    * the creation of any refs.
    *

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -1247,6 +1247,25 @@ export class BaseValueVisitor {
         return this;
       })();
     }
+    
+    /**
+     * Sets the visit result to be an error value. This indicates that the visit
+     * has in fact finished with `ok === false`.
+     *
+     * @param {Error} error The visit error.
+     */
+    #finishWithError(error) {
+      this.#ok    = false;
+      this.#error = error;
+
+      if (this.#def && !this.#def.isFinished()) {
+        this.#def.finishWithValue(error);
+      }
+
+      if (this.#ref && !this.#ref.isFinished()) {
+        this.#ref.finishWithError(error);
+      }
+    }
 
     /**
      * Sets the visit result to be a non-error value. This indicates that the
@@ -1267,25 +1286,6 @@ export class BaseValueVisitor {
 
       if (this.#ref && !this.#ref.isFinished()) {
         this.#ref.finishWithValue(this.#value);
-      }
-    }
-
-    /**
-     * Sets the visit result to be an error value. This indicates that the visit
-     * has in fact finished with `ok === false`.
-     *
-     * @param {Error} error The visit error.
-     */
-    #finishWithError(error) {
-      this.#ok    = false;
-      this.#error = error;
-
-      if (this.#def && !this.#def.isFinished()) {
-        this.#def.finishWithValue(error);
-      }
-
-      if (this.#ref && !this.#ref.isFinished()) {
-        this.#ref.finishWithError(error);
       }
     }
   };

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -771,7 +771,7 @@ export class BaseValueVisitor {
    */
   #isAssociatedDefOrRef(value) {
     return (value instanceof BaseDefRef)
-      && value.isAssociatedWith(this);
+      && (value[BaseValueVisitor.#SYM_associatedVisitor] === this);
   }
 
   /**
@@ -953,6 +953,14 @@ export class BaseValueVisitor {
   //
   // Static members
   //
+
+  /**
+   * Uninterned symbol used for "secret" property on defs and refs which stores
+   * the associated visitor instance.
+   *
+   * @type {symbol}
+   */
+  static #SYM_associatedVisitor = Symbol('BaseValueVisitor.associatedVisitor');
 
   /**
    * Entry in a {@link #visitEntries} map.
@@ -1169,6 +1177,11 @@ export class BaseValueVisitor {
 
       this.#def = new VisitDef(index, this, ...valueArg);
       this.#ref = new VisitRef(index, this, ...valueArg);
+
+      Object.defineProperty(this.#def, BaseValueVisitor.#SYM_associatedVisitor,
+        { value: this.#visitor });
+      Object.defineProperty(this.#ref, BaseValueVisitor.#SYM_associatedVisitor,
+        { value: this.#visitor });
     }
 
     /**
@@ -1247,7 +1260,7 @@ export class BaseValueVisitor {
         return this;
       })();
     }
-    
+
     /**
      * Sets the visit result to be an error value. This indicates that the visit
      * has in fact finished with `ok === false`.

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -1027,14 +1027,6 @@ export class BaseValueVisitor {
     }
 
     /**
-     * @returns {*} The original value (not the visit result) which this
-     * instance is a reference to.
-     */
-    get originalValue() {
-      return this.#node;
-    }
-
-    /**
      * @returns {Promise} A promise for `this`, which resolves once the visit
      * has been finished (whether or not successful).
      */

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -56,7 +56,7 @@ export class BaseValueVisitor {
    *
    * @type {Map<*, BaseValueVisitor#VisitEntry>}
    */
-  #visits = new Map();
+  #visitEntries = new Map();
 
   /**
    * During a visit, an array of all refs created during the visit, in order of
@@ -736,7 +736,7 @@ export class BaseValueVisitor {
    * started yet).
    */
   get #rootEntry() {
-    return this.#visits.get(this.#rootValue);
+    return this.#visitEntries.get(this.#rootValue);
   }
 
   /**
@@ -765,16 +765,16 @@ export class BaseValueVisitor {
   /**
    * Visitor for a "node" (referenced value, including possibly the root) of the
    * graph of values being visited. If there is already an entry in
-   * {@link #visits} for the node, it is returned. Otherwise, a new entry is
-   * created, and visiting is initiated (and possibly, but not necessarily,
+   * {@link #visitEntries} for the node, it is returned. Otherwise, a new entry
+   * is created, and visiting is initiated (and possibly, but not necessarily,
    * finished).
    *
    * @param {*} node The node being visited.
-   * @returns {BaseValueVisitor#VisitEntry} Entry from {@link #visits} which
-   *   represents the current state of the visit.
+   * @returns {BaseValueVisitor#VisitEntry} Entry from {@link #visitEntries}
+   *   which represents the current state of the visit.
    */
   #visitNode(node) {
-    const already = this.#visits.get(node);
+    const already = this.#visitEntries.get(node);
 
     if (already) {
       let ref = already.ref;
@@ -818,7 +818,7 @@ export class BaseValueVisitor {
     // We have not previously encountered `node` during this visit.
 
     const visitEntry = new BaseValueVisitor.#VisitEntry(this, node);
-    this.#visits.set(node, visitEntry);
+    this.#visitEntries.set(node, visitEntry);
 
     // This call synchronously calls back to `visitNode0()`.
     visitEntry.startVisit();
@@ -921,7 +921,7 @@ export class BaseValueVisitor {
   //
 
   /**
-   * Entry in a {@link #visits} map.
+   * Entry in a {@link #visitEntries} map.
    */
   static #VisitEntry = class VisitEntry {
     /**

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -1117,8 +1117,8 @@ export class BaseValueVisitor {
       }
       /* c8 ignore stop */
 
-      this.#def = new VisitDef(this, index);
-      this.#ref = new VisitRef(this, index);
+      this.#def = new VisitDef(index, this);
+      this.#ref = new VisitRef(index, this);
     }
 
     /**

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -99,13 +99,13 @@ export class BaseValueVisitor {
    * Indicates whether or not the visit represented by this instance resulted in
    * the creation of any refs.
    *
-   * @returns {?boolean} `true` if the visit caused refs to be created, `false`
-   *   if not, or `null` if the visit is still in-progress.
+   * @returns {boolean} `true` if the visit caused refs to be created, or
+   *  `false` if not.
+   * @throws {Error} Thrown if the visit is still in progress or has not yet
+   *   started.
    */
   hasRefs() {
-    if (!this.isFinished()) {
-      return null;
-    }
+    this.#throwIfNotFinished();
 
     const allRefs = this.#allRefs;
 
@@ -150,6 +150,8 @@ export class BaseValueVisitor {
    * @param {*} value The result value to look up.
    * @returns {?VisitRef} The corresponding ref, or `null` if there is no ref
    *   for `value`.
+   * @throws {Error} Thrown if the visit is still in progress or has not yet
+   *   started.
    */
   refFromResultValue(value) {
     // Note: The first call to `hasRefs()` after a visit finishes will cause
@@ -746,6 +748,18 @@ export class BaseValueVisitor {
    */
   #isProxy(value) {
     return this.#proxyAware && types.isProxy(value);
+  }
+
+  /**
+   * Throws an error indicating that the visit either hasn't started yet or
+   * hasn't finished yet, if either of those are the case. If the visit has
+   * finished, then this does nothing.
+   */
+  #throwIfNotFinished() {
+    if (!this.isFinished()) {
+      const verb = this.#rootEntry ? 'finished' : 'started';
+      throw new Error(`Visit has not yet ${verb}. (Call a \`visit*()\` method.)`);
+    }
   }
 
   /**

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -1164,7 +1164,7 @@ export class BaseValueVisitor {
 
       const valueArg = this.isFinished() ? [this.extractSync()] : [];
 
-      this.#def = new VisitDef(index, this, ...valueArg);
+      this.#def = new VisitDef(index, ...valueArg);
       this.#ref = this.#def.ref;
 
       Object.defineProperty(this.#def, BaseValueVisitor.#SYM_associatedVisitor,

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -45,14 +45,14 @@ export class BaseValueVisitor {
   #proxyAware;
 
   /**
-   * The root value being visited.
+   * The root value to be visited (or currently being visited).
    *
    * @type {*}
    */
   #rootValue;
 
   /**
-   * Map from visited values to their visit representatives.
+   * Map from each visited value to its visit-representing entry.
    *
    * @type {Map<*, BaseValueVisitor#VisitEntry>}
    */

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -1138,17 +1138,6 @@ export class BaseValueVisitor {
     }
 
     /**
-     * Is this instance associated with the given visitor?
-     *
-     * @param {BaseValueVisitor} visitor The visitor in question.
-     * @returns {boolean} `true` if this instance's associated visitor is in
-     *   fact `visitor`.
-     */
-    isAssociatedWith(visitor) {
-      return this.#visitor === visitor;
-    }
-
-    /**
      * Returns an indication of whether the visit has finished.
      *
      * @returns {boolean} `true` if the visit of the referenced value is

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -74,7 +74,7 @@ export class BaseValueVisitor {
    *
    * @type {Set<BaseValueVisitor#VisitEntry>}
    */
-  #visitSet = new Set();
+  #activeVisits = new Set();
 
   /**
    * Constructs an instance whose purpose in life is to visit the indicated
@@ -794,7 +794,7 @@ export class BaseValueVisitor {
 
         this._impl_revisit(node, result, isCycleHead, ref);
         return this.#visitNode(ref);
-      } else if (this.#visitSet.has(already)) {
+      } else if (this.#activeVisits.has(already)) {
         // We have encountered the head of a reference cycle that was _not_
         // handled by making a "ref" object for the back-reference.
 
@@ -1194,7 +1194,7 @@ export class BaseValueVisitor {
       // about circular references.
       this.#promise = (async () => {
         const visitor = this.#visitor;
-        visitor.#visitSet.add(this);
+        visitor.#activeVisits.add(this);
 
         try {
           let result = visitor.#visitNode0(this.#node);
@@ -1214,7 +1214,7 @@ export class BaseValueVisitor {
           this.#finishWithError(e);
         }
 
-        visitor.#visitSet.delete(this);
+        visitor.#activeVisits.delete(this);
 
         return this;
       })();

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -731,9 +731,9 @@ export class BaseValueVisitor {
   }
 
   /**
-   * @returns {?VisitEntry} The entry corresponding to {@link #rootValue}, or
-   * `null` if it hasn't yet been created (which means that the visit hasn't
-   * started yet).
+   * @returns {?BaseValueVisitor#VisitEntry} The entry corresponding to
+   * {@link #rootValue}, or `null` if it hasn't yet been created (which means
+   * that the visit hasn't started yet).
    */
   get #rootEntry() {
     return this.#visitEntries.get(this.#rootValue);

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -1154,8 +1154,10 @@ export class BaseValueVisitor {
       }
       /* c8 ignore stop */
 
-      this.#def = new VisitDef(index, this);
-      this.#ref = new VisitRef(index, this);
+      const valueArg = this.isFinished() ? [this.extractSync()] : [];
+
+      this.#def = new VisitDef(index, this, ...valueArg);
+      this.#ref = new VisitRef(index, this, ...valueArg);
     }
 
     /**
@@ -1247,6 +1249,14 @@ export class BaseValueVisitor {
       this.#value  = (value instanceof VisitResult)
         ? value.value
         : value;
+
+      if (this.#def && !this.#def.isFinished()) {
+        this.#def.finishWithValue(this.#value);
+      }
+
+      if (this.#ref && !this.#ref.isFinished()) {
+        this.#ref.finishWithValue(this.#value);
+      }
     }
 
     /**
@@ -1258,6 +1268,14 @@ export class BaseValueVisitor {
     #finishWithError(error) {
       this.#ok    = false;
       this.#error = error;
+
+      if (this.#def && !this.#def.isFinished()) {
+        this.#def.finishWithValue(error);
+      }
+
+      if (this.#ref && !this.#ref.isFinished()) {
+        this.#ref.finishWithError(error);
+      }
     }
   };
 }

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -1167,10 +1167,9 @@ export class BaseValueVisitor {
       this.#def = new VisitDef(index, ...valueArg);
       this.#ref = this.#def.ref;
 
-      Object.defineProperty(this.#def, BaseValueVisitor.#SYM_associatedVisitor,
-        { value: this.#visitor });
-      Object.defineProperty(this.#ref, BaseValueVisitor.#SYM_associatedVisitor,
-        { value: this.#visitor });
+      const propArgs = [BaseValueVisitor.#SYM_associatedVisitor, { value: this.#visitor }];
+      Object.defineProperty(this.#def, ...propArgs);
+      Object.defineProperty(this.#ref, ...propArgs);
     }
 
     /**
@@ -1263,10 +1262,6 @@ export class BaseValueVisitor {
       if (this.#def && !this.#def.isFinished()) {
         this.#def.finishWithValue(error);
       }
-
-      if (this.#ref && !this.#ref.isFinished()) {
-        this.#ref.finishWithError(error);
-      }
     }
 
     /**
@@ -1284,10 +1279,6 @@ export class BaseValueVisitor {
 
       if (this.#def && !this.#def.isFinished()) {
         this.#def.finishWithValue(this.#value);
-      }
-
-      if (this.#ref && !this.#ref.isFinished()) {
-        this.#ref.finishWithValue(this.#value);
       }
     }
   };

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -134,7 +134,7 @@ export class BaseValueVisitor {
    *   either in-progress or hasn't yet started.
    */
   isFinished() {
-    const entry = this.#visits.get(this.#rootValue);
+    const entry = this.#rootEntry;
 
     return entry
       ? entry.isFinished()
@@ -729,6 +729,15 @@ export class BaseValueVisitor {
   }
 
   /**
+   * @returns {?VisitEntry} The entry corresponding to {@link #rootValue}, or
+   * `null` if it hasn't yet been created (which means that the visit hasn't
+   * started yet).
+   */
+  get #rootEntry() {
+    return this.#visits.get(this.#rootValue);
+  }
+
+  /**
    * Is the given value a proxy which should be detected as such? This checks
    * proxyness, but only if the instance is configured to do so.
    *
@@ -884,13 +893,12 @@ export class BaseValueVisitor {
    * @returns {BaseValueVisitor#VisitEntry} Vititor entry for the root value.
    */
   #visitRoot() {
-    // Note: This isn't _just_ `return this.#visitNode(<root>)`, because that
-    // would end up invoking the def/ref mechanism, which would be incorrect to
-    // do in this case (because we're not trying to possibly-share a result
-    // within the visit, just trying to _get_ the result).
+    // Note: This isn't _just_ `return this.#visitNode(this.#rootValue)`,
+    // because that would end up invoking the def/ref mechanism, which would be
+    // incorrect to do in this case (because we're not trying to possibly-share
+    // a result within the visit, just trying to _get_ the result).
 
-    const node = this.#rootValue;
-    return this.#visits.get(node) ?? this.#visitNode(node);
+    return this.#rootEntry ?? this.#visitNode(this.#rootValue);
   }
 
 

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -1165,7 +1165,7 @@ export class BaseValueVisitor {
       const valueArg = this.isFinished() ? [this.extractSync()] : [];
 
       this.#def = new VisitDef(index, this, ...valueArg);
-      this.#ref = new VisitRef(index, this, ...valueArg);
+      this.#ref = this.#def.ref;
 
       Object.defineProperty(this.#def, BaseValueVisitor.#SYM_associatedVisitor,
         { value: this.#visitor });

--- a/src/valvis/export/VisitDef.js
+++ b/src/valvis/export/VisitDef.js
@@ -20,6 +20,29 @@ import { VisitRef } from '#x/VisitRef';
  */
 export class VisitDef extends BaseDefRef {
   /**
+   * The value being referred to, or `null` if not yet known.
+   *
+   * @type {*} value
+   */
+  #value;
+
+  /**
+   * The error resulting from the visit, or `null` if there was none _or_ it is
+   * not yet  known.
+   *
+   * @type {?Error}
+   */
+  #error;
+
+  /**
+   * Is the visit finished? Relatedly, are {@link #value} and {@link #error}
+   * known?
+   *
+   * @type {boolean}
+   */
+  #finished;
+
+  /**
    * This instance's corresponding ref.
    *
    * @type {VisitRef}
@@ -30,12 +53,23 @@ export class VisitDef extends BaseDefRef {
    * Constructs an instance.
    *
    * @param {number} index The reference index number.
-   * @param {...*} rest Other arguments for the superclass constructor.
+   * @param {*} [value] The already-known associated value. If not passed, the
+   *   value is treated as not yet known, which relatedly means that the
+   *   associated (sub-)visit is not yet finished.
    */
-  constructor(index, ...rest) {
-    super(index, ...rest);
+  constructor(index, value = VisitDef.#SYM_notFinished) {
+    super(index);
 
-    this.#ref = new VisitRef(this);
+    this.#ref   = new VisitRef(this);
+    this.#error = null;
+
+    if (value === VisitDef.#SYM_notFinished) {
+      this.#value    = null;
+      this.#finished = false;
+    } else {
+      this.#value    = value;
+      this.#finished = true;
+    }
   }
 
   /** @override */
@@ -44,8 +78,61 @@ export class VisitDef extends BaseDefRef {
   }
 
   /** @override */
+  get error() {
+    return this.#error;
+  }
+
+  /** @override */
   get ref() {
     return this.#ref;
+  }
+
+  /** @override */
+  get value() {
+    if (!this.#finished) {
+      throw new Error('Not yet finished.');
+    } else if (this.#error) {
+      throw this.#error;
+    } else {
+      return this.#value;
+    }
+  }
+
+  /**
+   * Indicates that this instance's visit has now finished unsuccessfully with
+   * the given error. It is only ever valid to call this on an unfinished
+   * instance.
+   *
+   * @param {Error} error The error.
+   */
+  finishWithError(error) {
+    if (this.#finished) {
+      throw new Error('Already finished.');
+    }
+
+    this.#finished = true;
+    this.#error    = error;
+  }
+
+  /**
+   * Indicates that this instance's visit has now finished successfully with the
+   * given result value. It is only ever valid to call this on an unfinished
+   * instance.
+   *
+   * @param {*} value The result value.
+   */
+  finishWithValue(value) {
+    if (this.#finished) {
+      throw new Error('Already finished.');
+    }
+
+    this.#finished = true;
+    this.#value    = value;
+  }
+
+  /** @override */
+  isFinished() {
+    return this.#finished;
   }
 
   /**
@@ -60,6 +147,20 @@ export class VisitDef extends BaseDefRef {
    * @returns {*} The replacement form to encode.
    */
   toJSON(key_unused) {
-    return { '@def': [this.index, this.value] };
+    const valueArg = this.#finished ? [this.value] : [];
+    return { '@def': [this.index, ...valueArg] };
   }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * Special uninterned symbol used in the constructor in order to distinguish
+   * whether the `value` argument was passed.
+   *
+   * @type {symbol}
+   */
+  static #SYM_notFinished = Symbol('BaseDefRef.notFinished');
 }

--- a/src/valvis/export/VisitDef.js
+++ b/src/valvis/export/VisitDef.js
@@ -6,17 +6,8 @@ import { VisitRef } from '#x/VisitRef';
 
 
 /**
- * Forward declaration of this class, because `import`ing it would cause a
- * circular dependency while loading.
- *
- * @typedef BaseValueVisitor
- * @type {object}
- */
-
-/**
- * Companion class of {@link BaseValueVisitor}, which represents the defining
- * occurrence of a result of a (sub-)visit which appears more than once in an
- * overall visit result.
+ * Representation of a result of a (sub-)visit which appears more than
+ * once in an overall visit result.
  */
 export class VisitDef extends BaseDefRef {
   /**
@@ -55,7 +46,9 @@ export class VisitDef extends BaseDefRef {
    * @param {number} index The reference index number.
    * @param {*} [value] The already-known associated value. If not passed, the
    *   value is treated as not yet known, which relatedly means that the
-   *   associated (sub-)visit is not yet finished.
+   *   associated (sub-)visit is not yet finished (generally due to this
+   *   instance being created to represent the result of a value that is part of
+   *   a reference cycle).
    */
   constructor(index, value = VisitDef.#SYM_notFinished) {
     super(index);

--- a/src/valvis/export/VisitDef.js
+++ b/src/valvis/export/VisitDef.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BaseDefRef } from '#x/BaseDefRef';
+import { VisitRef } from '#x/VisitRef';
 
 
 /**
@@ -18,11 +19,33 @@ import { BaseDefRef } from '#x/BaseDefRef';
  * overall visit result.
  */
 export class VisitDef extends BaseDefRef {
-  // @defaultConstructor
+  /**
+   * This instance's corresponding ref.
+   *
+   * @type {VisitRef}
+   */
+  #ref;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {number} index The reference index number.
+   * @param {...*} rest Other arguments for the superclass constructor.
+   */
+  constructor(index, ...rest) {
+    super(index, ...rest);
+
+    this.#ref = new VisitRef(this);
+  }
 
   /** @override */
   get def() {
     return this;
+  }
+
+  /** @override */
+  get ref() {
+    return this.#ref;
   }
 
   /**

--- a/src/valvis/export/VisitRef.js
+++ b/src/valvis/export/VisitRef.js
@@ -2,14 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BaseDefRef } from '#x/BaseDefRef';
-
-/**
- * Forward declaration of this class, because `import`ing it would cause a
- * circular dependency while loading.
- *
- * @typedef VisitDef
- * @type {object}
- */
+import { VisitDef } from '#x/VisitDef';
 
 
 /**

--- a/src/valvis/export/VisitRef.js
+++ b/src/valvis/export/VisitRef.js
@@ -13,22 +13,13 @@ import { BaseDefRef } from '#x/BaseDefRef';
 
 
 /**
- * Forward declaration of this class, because `import`ing it would cause a
- * circular dependency while loading.
- *
- * @typedef BaseValueVisitor
- * @type {object}
- */
-
-/**
- * Companion class of {@link BaseValueVisitor}, which represents the result of a
- * visit of a value that had been visited elsewhere during a visit.
+ * Representative of the result of a visit of a value that had been visited
+ * elsewhere during a visit.
  *
  * Along with just having a record of the shared nature of the structure,
  * instances of this class are also instrucmental in "breaking" circular
  * references during visits, making it possible to fully visit values that have
- * such circular references. See {@link BaseValueVisitor#_impl_shouldRef} for
- * more details.
+ * such circular references.
  */
 export class VisitRef extends BaseDefRef {
   /**

--- a/src/valvis/export/VisitRef.js
+++ b/src/valvis/export/VisitRef.js
@@ -3,6 +3,14 @@
 
 import { BaseDefRef } from '#x/BaseDefRef';
 
+/**
+ * Forward declaration of this class, because `import`ing it would cause a
+ * circular dependency while loading.
+ *
+ * @typedef VisitDef
+ * @type {object}
+ */
+
 
 /**
  * Forward declaration of this class, because `import`ing it would cause a
@@ -23,11 +31,43 @@ import { BaseDefRef } from '#x/BaseDefRef';
  * more details.
  */
 export class VisitRef extends BaseDefRef {
-  // @defaultConstructor
+  /**
+   * This instance's corresponding def.
+   *
+   * @type {VisitDef}
+   */
+  #def;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {VisitDef} def The corresponding def.
+   */
+  constructor(def) {
+    const valueArg = def.isFinished() ? [def.value] : [];
+    super(def.index, ...valueArg);
+
+    this.#def = def;
+  }
+
+  /** @override */
+  get def() {
+    return this.#def;
+  }
 
   /** @override */
   get ref() {
     return this;
+  }
+
+  /** @override */
+  get value() {
+    return this.#def.value;
+  }
+
+  /** @override */
+  isFinished() {
+    return this.#def.isFinished();
   }
 
   /**

--- a/src/valvis/export/VisitResult.js
+++ b/src/valvis/export/VisitResult.js
@@ -14,9 +14,10 @@
  * Companion class of {@link BaseValueVisitor}, which holds the result from a
  * visit.
  *
- * This class exists to avoid ambiguity when promises are used as results-per-se
- * from visiting, as opposed to being used because of the JavaScript execution
- * semantics involved in implementing a visitor method as `async`.
+ * This class exists to avoid ambiguity when promises are used as the
+ * result-per-se from a visit (or sub-visit), as opposed to being used because
+ * of the JavaScript execution semantics involved in implementing a visitor
+ * method as `async`.
  */
 export class VisitResult {
   /**

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -204,6 +204,34 @@ describe('hasRefs()', () => {
   });
 });
 
+describe('isFinished()', () => {
+  test('returns `false` before the visit starts', () => {
+    const vv = new BaseValueVisitor(null);
+
+    expect(vv.isFinished()).toBeFalse();
+  });
+
+  test('returns `false` when the visit is in progress', async () => {
+    class TestVisitor extends BaseValueVisitor {
+      async _impl_visitNumber(node) { return node; }
+    }
+
+    const vv  = new TestVisitor(9000);
+    const got = vv.visitAsyncWrap();
+
+    expect(vv.isFinished()).toBeFalse();
+
+    await got; // Clean up pending promise.
+  });
+
+  test('returns `true` when the visit is complete', () => {
+    const vv = new BaseValueVisitor(null);
+
+    vv.visitSync();
+    expect(vv.isFinished()).toBeTrue();
+  });
+});
+
 describe('refFromResultValue()', () => {
   test('finds a root result reference', () => {
     // Note: This test can only possibly work if the root value itself

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -222,8 +222,8 @@ describe('refFromResultValue()', () => {
 
     // The actual test.
     expect(vv.refFromResultValue(got)).toBe(gotRef);
-    expect(gotRef.originalValue).toBe(value);
     expect(gotRef.value).toBe(got);
+    expect(vv.getVisitResult(value)).toBe(got);
   });
 
   test('finds a sub-visit result reference', () => {
@@ -243,8 +243,8 @@ describe('refFromResultValue()', () => {
 
     // The actual test.
     expect(vv.refFromResultValue(gotInner)).toBe(gotRef);
-    expect(gotRef.originalValue).toBe(inner);
     expect(gotRef.value).toBe(gotInner);
+    expect(vv.getVisitResult(inner)).toBe(gotRef.value);
   });
 
   test('returns `null` given any argument if there were no refs created', () => {
@@ -711,8 +711,8 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}
           expect(visitor.refs).toBeArrayOfSize(1);
           const { ref, wasFinished } = visitor.refs[0];
           expect(ref).toBe(got[2]);
-          expect(ref.originalValue).toBe(shared);
           expect(ref.value).toBe(got[1][1]);
+          expect(visitor.getVisitResult(shared)).toBe(ref.value);
           expect(wasFinished).toBeTrue();
         }
       });
@@ -731,8 +731,8 @@ ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}
           expect(visitor.refs).toBeArrayOfSize(1);
           const { ref, wasFinished } = visitor.refs[0];
           expect(ref).toBe(got[2]);
-          expect(ref.originalValue).toBe(selfRef);
           expect(ref.value).toBe(got[1][1]);
+          expect(visitor.getVisitResult(selfRef)).toBe(ref.value);
           expect(ref).toBe(ref.value[2]);
           expect(wasFinished).toBeFalse();
         }

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -988,7 +988,7 @@ describe('_impl_visitInstance()', () => {
   }
 
   test('gets called on an instance of `VisitRef` that was not created by the visitor-in-progress', () => {
-    const ref = new VisitRef(new VisitDef(10, null));
+    const ref = new VisitRef(new VisitDef(10));
     const vv  = new VisitInstanceCheckVisitor([ref]);
 
     expect(vv.visitSync()).toStrictEqual(['yes-sir']);
@@ -996,7 +996,7 @@ describe('_impl_visitInstance()', () => {
   });
 
   test('gets called on an instance of `VisitDef` that was not created by the visitor-in-progress', () => {
-    const def = new VisitDef(4321, null);
+    const def = new VisitDef(4321);
     const vv  = new VisitInstanceCheckVisitor([def]);
 
     expect(vv.visitSync()).toStrictEqual(['yes-sir']);

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -988,7 +988,7 @@ describe('_impl_visitInstance()', () => {
   }
 
   test('gets called on an instance of `VisitRef` that was not created by the visitor-in-progress', () => {
-    const ref = new VisitRef(10, null);
+    const ref = new VisitRef(new VisitDef(10, null));
     const vv  = new VisitInstanceCheckVisitor([ref]);
 
     expect(vv.visitSync()).toStrictEqual(['yes-sir']);

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -897,7 +897,7 @@ describe('_impl_visitInstance()', () => {
   }
 
   test('gets called on an instance of `VisitRef` that was not created by the visitor-in-progress', () => {
-    const ref = new VisitRef(null, 10);
+    const ref = new VisitRef(10, null);
     const vv  = new VisitInstanceCheckVisitor([ref]);
 
     expect(vv.visitSync()).toStrictEqual(['yes-sir']);
@@ -905,7 +905,7 @@ describe('_impl_visitInstance()', () => {
   });
 
   test('gets called on an instance of `VisitDef` that was not created by the visitor-in-progress', () => {
-    const def = new VisitDef(null, 4321);
+    const def = new VisitDef(4321, null);
     const vv  = new VisitInstanceCheckVisitor([def]);
 
     expect(vv.visitSync()).toStrictEqual(['yes-sir']);

--- a/src/valvis/tests/VisitDef.test.js
+++ b/src/valvis/tests/VisitDef.test.js
@@ -5,8 +5,12 @@ import { VisitDef } from '@this/valvis';
 
 
 describe('constructor()', () => {
-  test('doesn\'t throw given `entry === null`', () => {
+  test('doesn\'t throw when not given a `value`', () => {
     expect(() => new VisitDef(0, null)).not.toThrow();
+  });
+
+  test('doesn\'t throw when given a `value`', () => {
+    expect(() => new VisitDef(0, null, 'floomp')).not.toThrow();
   });
 });
 
@@ -19,7 +23,7 @@ describe('.def', () => {
 
 describe('.toJSON()', () => {
   test('returns the expected replacement', () => {
-    const def = new VisitDef(2, null);
-    expect(def.toJSON()).toStrictEqual({ '@def': [2, null] });
+    const def = new VisitDef(2, null, 'bongo');
+    expect(def.toJSON()).toStrictEqual({ '@def': [2, 'bongo'] });
   });
 });

--- a/src/valvis/tests/VisitDef.test.js
+++ b/src/valvis/tests/VisitDef.test.js
@@ -6,20 +6,20 @@ import { VisitDef } from '@this/valvis';
 
 describe('constructor()', () => {
   test('doesn\'t throw given `entry === null`', () => {
-    expect(() => new VisitDef(null, 0)).not.toThrow();
+    expect(() => new VisitDef(0, null)).not.toThrow();
   });
 });
 
 describe('.def', () => {
   test('returns `this`', () => {
-    const def = new VisitDef(null, 1);
+    const def = new VisitDef(1, null);
     expect(def.def).toBe(def);
   });
 });
 
 describe('.toJSON()', () => {
   test('returns the expected replacement', () => {
-    const def = new VisitDef(null, 2);
+    const def = new VisitDef(2, null);
     expect(def.toJSON()).toStrictEqual({ '@def': [2, null] });
   });
 });

--- a/src/valvis/tests/VisitDef.test.js
+++ b/src/valvis/tests/VisitDef.test.js
@@ -1,29 +1,37 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { VisitDef } from '@this/valvis';
+import { VisitDef, VisitRef } from '@this/valvis';
 
 
 describe('constructor()', () => {
   test('doesn\'t throw when not given a `value`', () => {
-    expect(() => new VisitDef(0, null)).not.toThrow();
+    expect(() => new VisitDef(0)).not.toThrow();
   });
 
   test('doesn\'t throw when given a `value`', () => {
-    expect(() => new VisitDef(0, null, 'floomp')).not.toThrow();
+    expect(() => new VisitDef(0, 'floomp')).not.toThrow();
   });
 });
 
 describe('.def', () => {
   test('returns `this`', () => {
-    const def = new VisitDef(1, null);
+    const def = new VisitDef(1);
     expect(def.def).toBe(def);
+  });
+});
+
+describe('.ref', () => {
+  test('returns a ref with the same index', () => {
+    const def = new VisitDef(199);
+    expect(def.ref).toBeInstanceOf(VisitRef);
+    expect(def.ref.index).toBe(def.index);
   });
 });
 
 describe('.toJSON()', () => {
   test('returns the expected replacement', () => {
-    const def = new VisitDef(2, null, 'bongo');
+    const def = new VisitDef(2, 'bongo');
     expect(def.toJSON()).toStrictEqual({ '@def': [2, 'bongo'] });
   });
 });

--- a/src/valvis/tests/VisitRef.test.js
+++ b/src/valvis/tests/VisitRef.test.js
@@ -6,20 +6,20 @@ import { VisitRef } from '@this/valvis';
 
 describe('constructor()', () => {
   test('doesn\'t throw given `entry === null`', () => {
-    expect(() => new VisitRef(null, 0)).not.toThrow();
+    expect(() => new VisitRef(0, null)).not.toThrow();
   });
 });
 
 describe('.ref', () => {
   test('returns `this`', () => {
-    const ref = new VisitRef(null, 1);
+    const ref = new VisitRef(1, null);
     expect(ref.ref).toBe(ref);
   });
 });
 
 describe('.toJSON()', () => {
   test('returns the expected replacement', () => {
-    const ref = new VisitRef(null, 2);
+    const ref = new VisitRef(2, null);
     expect(ref.toJSON()).toStrictEqual({ '@ref': [2] });
   });
 });

--- a/src/valvis/tests/VisitRef.test.js
+++ b/src/valvis/tests/VisitRef.test.js
@@ -1,25 +1,33 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { VisitRef } from '@this/valvis';
+import { VisitDef, VisitRef } from '@this/valvis';
 
 
 describe('constructor()', () => {
-  test('doesn\'t throw given `entry === null`', () => {
-    expect(() => new VisitRef(0, null)).not.toThrow();
+  test('doesn\'t throw given a def', () => {
+    expect(() => new VisitRef(new VisitDef(0, null, 999))).not.toThrow();
+  });
+});
+
+describe('.def', () => {
+  test('returns the `def` passed in the constructor', () => {
+    const def = new VisitDef(22, null, 987);
+    const ref = new VisitRef(def);
+    expect(ref.def).toBe(def);
   });
 });
 
 describe('.ref', () => {
   test('returns `this`', () => {
-    const ref = new VisitRef(1, null);
+    const ref = new VisitRef(new VisitDef(1, null));
     expect(ref.ref).toBe(ref);
   });
 });
 
 describe('.toJSON()', () => {
   test('returns the expected replacement', () => {
-    const ref = new VisitRef(2, null);
+    const ref = new VisitRef(new VisitDef(2, null));
     expect(ref.toJSON()).toStrictEqual({ '@ref': [2] });
   });
 });


### PR DESCRIPTION
This PR fixes a now-former morass of references within a visitor and its associated def and ref objects, also making it possible now for the def and ref classes to be used without an associated `BaseValueVisitor` instance. The latter is useful when building data decoding functionality for things like databases and RPC mechanisms where the "associated visitor" is something that's not in the address space of the thing doing the decoding.
