### PR TITLE
Log rendering tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ Breaking changes:
 
 Other notable changes:
 * `loggy-intf` / `loggy`:
-  * Improved "human" (non-JSON) rendering of arrays.
+  * Improved "human" (non-JSON) rendering of arrays, symbols, `undefined`, and
+    `null`.
 
 ### v0.8.2 -- 2024-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@ Breaking changes:
 
 Other notable changes:
 * `loggy-intf` / `loggy`:
-  * Improved "human" (non-JSON) rendering of arrays, symbols, `undefined`, and
-    `null`.
+  * Improved "human" (non-JSON) rendering of arrays, symbols, bigints,
+    `undefined`, and `null`.
 
 ### v0.8.2 -- 2024-10-25
 

--- a/src/loggy-intf/export/LoggedValueEncoder.js
+++ b/src/loggy-intf/export/LoggedValueEncoder.js
@@ -55,7 +55,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
   /** @override */
   _impl_visitBigInt(node) {
     // Bigints aren't JSON-encodable.
-    return { '@BigInt': `${node}` };
+    return new Sexp('BigInt', `${node}`);
   }
 
   /** @override */

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -110,7 +110,7 @@ export class HumanVisitor extends BaseValueVisitor {
 
   /** @override */
   _impl_visitNull() {
-    return 'null';
+    return this.#maybeStyle('null', HumanVisitor.#STYLE_NULL);
   }
 
   /** @override */
@@ -324,6 +324,13 @@ export class HumanVisitor extends BaseValueVisitor {
    * @type {Function}
    */
   static #STYLE_DEF_REF = chalk.magenta.bold;
+
+  /**
+   * Styling function to use for the value `null`.
+   *
+   * @type {Function}
+   */
+  static #STYLE_NULL = chalk.ansi256(240).bold;
 
   /**
    * Styling function to use for numbers.

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -96,6 +96,10 @@ export class HumanVisitor extends BaseValueVisitor {
     } else if (node instanceof Sexp) {
       const { functorName, args } = node;
       switch (functorName) {
+        case 'BigInt': {
+          const str = `${args[0]}n`;
+          return this.#maybeStyle(str, HumanVisitor.#STYLE_NUMBER);
+        }
         case 'Undefined': {
           return this.#maybeStyle('undefined', HumanVisitor.#STYLE_UNDEFINED);
         }
@@ -333,7 +337,7 @@ export class HumanVisitor extends BaseValueVisitor {
   static #STYLE_NULL = chalk.ansi256(240).bold;
 
   /**
-   * Styling function to use for numbers.
+   * Styling function to use for numbers (including bigints).
    *
    * @type {Function}
    */

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -100,6 +100,9 @@ export class HumanVisitor extends BaseValueVisitor {
           const str = `${args[0]}n`;
           return this.#maybeStyle(str, HumanVisitor.#STYLE_NUMBER);
         }
+        case 'Symbol': {
+          return this.#visitCall('Symbol', args);
+        }
         case 'Undefined': {
           return this.#maybeStyle('undefined', HumanVisitor.#STYLE_UNDEFINED);
         }

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -95,7 +95,14 @@ export class HumanVisitor extends BaseValueVisitor {
       return new ComboText(...result);
     } else if (node instanceof Sexp) {
       const { functorName, args } = node;
-      return this.#visitCall(`@${functorName}`, args, HumanVisitor.#STYLE_SEXP);
+      switch (functorName) {
+        case 'Undefined': {
+          return this.#maybeStyle('undefined', HumanVisitor.#STYLE_UNDEFINED);
+        }
+        default: {
+          return this.#visitCall(`@${functorName}`, args, HumanVisitor.#STYLE_SEXP);
+        }
+      }
     } else {
       throw this.#shouldntHappen();
     }
@@ -345,6 +352,13 @@ export class HumanVisitor extends BaseValueVisitor {
    * @type {Function}
    */
   static #STYLE_STRING = chalk.green;
+
+  /**
+   * Styling function to use for the value `undefined`.
+   *
+   * @type {Function}
+   */
+  static #STYLE_UNDEFINED = chalk.ansi256(240).bold;
 
   /**
    * Styling function to use for `payload.when`.

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -150,14 +150,15 @@ export class HumanVisitor extends BaseValueVisitor {
 
   /**
    * Styles the given text, but only if this instance has been told to be
-   * styled.
+   * styled _and_ the given style function is passed as non-`null`.
    *
    * @param {string} text The text in question.
-   * @param {Function} func The colorizer function.
+   * @param {?Function} func The style/colorizer function, or `null` if no style
+   *   should be applied.
    * @returns {string} The styled-or-not result.
    */
   #maybeStyle(text, func) {
-    return this.#styled
+    return (func && this.#styled)
       ? new StyledText(func(text), text.length)
       : text;
   }
@@ -278,11 +279,11 @@ export class HumanVisitor extends BaseValueVisitor {
    * @param {string} funcString The string form of the functor or functor-like
    *   thing.
    * @param {Array} args The arguments.
-   * @param {?Function} claddingStyle The styler for the "cladding" (name and
+   * @param {?Function} [claddingStyle] The styler for the "cladding" (name and
    *   parens), or `null` if none.
    * @returns {TypeText} The rendered form.
    */
-  #visitCall(funcString, args, claddingStyle) {
+  #visitCall(funcString, args, claddingStyle = null) {
     if (args.length === 0) {
       // Avoid extra work in the easy zero-args case.
       const text = `${funcString}()`;


### PR DESCRIPTION
This PR improves "human" log rendering for `undefined`, `null`, bigints, and symbols.