### PR TITLE
Loosen the requirement on the argument to the `BaseStruct` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Breaking changes:
 Other notable changes:
 * `loggy-intf` / `loggy`:
   * Minor tweaks to "human" (non-JSON) log rendering.
+* `structy`:
+  * Started allowing any object (plain or not) to be used as the argument to the
+    `BaseStruct` constructor.
 * `webapp-builtins`:
   * Simplified naming scheme for preserved log files: Names now always include
     a `-<num>` suffix after the date.

--- a/src/structy/export/BaseStruct.js
+++ b/src/structy/export/BaseStruct.js
@@ -6,24 +6,27 @@ import { AskIf, MustBe } from '@this/typey';
 
 /**
  * Base class for type-checked "structures." Each concrete subclass is expected
- * to pass a plain object in its `super()` constructor call (or pass nothing or
+ * to pass an object in its `super()` constructor call (or pass nothing or
  * `null` for an all-default construction) which is suitable for parsing by this
- * (base) class. This class defines the mechanism by which a plain object gets
- * mapped into properties on the constructed instance, including running
- * validation on each property and a final overall validation.
+ * (base) class. This class defines the mechanism by which an object gets mapped
+ * into properties on the constructed instance, including running validation on
+ * each property and a final overall validation.
  *
  * Instances of this class are always frozen.
  */
 export class BaseStruct {
   /**
-   * Constructs an instance.
+   * Constructs an instance. The argument, if non-`null`, is taken to be a
+   * "plain-like" object, in that its own enumerable string-keyed properties are
+   * what matter. Instances of (concrete subclasses of) this class can be used
+   * as arguments.
    *
-   * @param {?object} [rawObject] Raw object to parse. This is expected to be
-   *   either a plain object, or `null` to have all default values. The latter
-   *   is equivalent to passing `{}` (an empty object).
+   * @param {?object} [rawObject] Raw object to parse, or `null` to have all
+   *   default values. Passing `null` is equivalent to passing `{}` (an empty
+   *   plain object).
    */
   constructor(rawObject = null) {
-    rawObject = (rawObject === null) ? {} : MustBe.plainObject(rawObject);
+    rawObject = (rawObject === null) ? {} : MustBe.object(rawObject);
 
     this.#fillInObject(rawObject);
     Object.freeze(this);

--- a/src/structy/tests/BaseStruct.test.js
+++ b/src/structy/tests/BaseStruct.test.js
@@ -216,6 +216,13 @@ describe('using a subclass with one defaultable property and one required proper
       expect(got.florp).toBe(789);
     });
 
+    test('accepts an instance of itself', () => {
+      const arg = new SomeStruct({ abc: 'yes', florp: 999 });
+      const got = new SomeStruct(arg);
+      expect(got.abc).toBe(arg.abc);
+      expect(got.florp).toBe(arg.florp);
+    })
+
     test('throws given an extra property in a non-plain object', () => {
       const arg = {
         get florp() { return 789; },

--- a/src/structy/tests/BaseStruct.test.js
+++ b/src/structy/tests/BaseStruct.test.js
@@ -78,7 +78,7 @@ describe('using the (base) class directly', () => {
       };
 
       expect(() => new BaseStruct(obj)).toThrow(/Extra property:/);
-    })
+    });
   });
 
   describe('_impl_propertyPrefix', () => {
@@ -199,21 +199,29 @@ describe('using a subclass with one defaultable property and one required proper
     ${[]}
     ${[null]}
     `('throws given `$args` (because there is a required property)', ({ args }) => {
-      expect(() => new SomeStruct(...args)).toThrow(/florp/);
+      expect(() => new SomeStruct(...args)).toThrow(/Missing.*florp/);
     });
 
-    test.each('accepts the required property via a plain object', () => {
+    test('accepts the required property via a plain object', () => {
       const arg = { florp: 987 };
       const got = new SomeStruct(arg);
       expect(got.florp).toBe(987);
     });
 
-    test.each('accepts the required property via a non-plain object', () => {
+    test('accepts the required property via a non-plain object', () => {
       const arg = {
         get florp() { return 789; }
       };
       const got = new SomeStruct(arg);
       expect(got.florp).toBe(789);
+    });
+
+    test('throws given an extra property in a non-plain object', () => {
+      const arg = {
+        get florp() { return 789; },
+        get fleep() { return 'eep'; }
+      };
+      expect(() => new SomeStruct(arg)).toThrow(/Extra.*fleep/);
     });
   });
 

--- a/src/structy/tests/BaseStruct.test.js
+++ b/src/structy/tests/BaseStruct.test.js
@@ -221,7 +221,7 @@ describe('using a subclass with one defaultable property and one required proper
       const got = new SomeStruct(arg);
       expect(got.abc).toBe(arg.abc);
       expect(got.florp).toBe(arg.florp);
-    })
+    });
 
     test('throws given an extra property in a non-plain object', () => {
       const arg = {


### PR DESCRIPTION
This PR changes `BaseStruct` to accept _any_ kind of object in its constructor, instead of being persnickety and demanding only plain objects.