### PR TITLE
Logging defs in sexps

### DIFF
--- a/src/loggy-intf/export/LoggedValueEncoder.js
+++ b/src/loggy-intf/export/LoggedValueEncoder.js
@@ -197,7 +197,19 @@ export class LoggedValueEncoder extends BaseValueVisitor {
 
     /** @override */
     _impl_visitInstance(node) {
-      return this.#makeDefIfAppropriate(node, node);
+      const topResult = this.#makeDefIfAppropriate(node, node);
+
+      if (topResult !== node) {
+        // The instance itself is a shared reference.
+        return topResult;
+      } else if (node instanceof Sexp) {
+        // We have to crack open the sexp to wrap any def sites that it has in
+        // it (directly or indirectly).
+        const funcArgs = this._prot_visitProperties([...node]);
+        return new Sexp(...funcArgs);
+      } else {
+        return node;
+      }
     }
 
     /** @override */

--- a/src/loggy-intf/tests/LoggedValueEncoder.test.js
+++ b/src/loggy-intf/tests/LoggedValueEncoder.test.js
@@ -155,4 +155,28 @@ describe('encode()', () => {
     expect(gotValue[1]).toBeInstanceOf(VisitRef);
     expect(gotValue[1].def).toBe(got);
   });
+
+  test('finds defs and refs inside instances', () => {
+    class TestClass {
+      #args;
+
+      constructor(...args) {
+        this.#args = args;
+      }
+
+      deconstruct() {
+        return new Sexp(this.constructor, ...this.#args);
+      }
+    }
+
+    const inner = new TestClass('boop');
+    const outer = new TestClass(inner, inner);
+    const got = LoggedValueEncoder.encode(outer);
+
+    const exInner = new Sexp('TestClass', 'boop');
+    const def     = new VisitDef(0, exInner);
+    const ref     = def.ref;
+    const exOuter = new Sexp('TestClass', def, ref);
+    expect(got).toStrictEqual(exOuter);
+  });
 });

--- a/src/loggy-intf/tests/LoggedValueEncoder.test.js
+++ b/src/loggy-intf/tests/LoggedValueEncoder.test.js
@@ -66,7 +66,7 @@ describe('encode()', () => {
 
   const someFunc = () => null;
 
-  // Stuff that isn't JSON-encodable should end up in the form of a sexp.
+  // Most stuff that isn't JSON-encodable should end up in the form of a sexp.
   test.each`
   value                  | expected
   ${undefined}           | ${sexp('Undefined')}}
@@ -83,6 +83,17 @@ describe('encode()', () => {
   `('($#) correctly encodes $value', ({ value, expected }) => {
     const got = LoggedValueEncoder.encode(value);
     expect(got).toStrictEqual(expected);
+  });
+
+  test('encodes a function as its name', () => {
+    const value = someFunc;
+    const name  = value.name;
+
+    const got1 = LoggedValueEncoder.encode(value);
+    expect(got1).toBe(name);
+
+    const got2 = LoggedValueEncoder.encode([value, value, value]);
+    expect(got2).toStrictEqual([name, name, name]);
   });
 
   test('does not def-ref a small-enough array', () => {


### PR DESCRIPTION
This PR fixes `LoggedValueEncoder` to find shared-ref definition sites that are inside `Sexp`s.