### PR TITLE
Better human logging of classes and functions

### DIFF
--- a/src/loggy-intf/export/LoggedValueEncoder.js
+++ b/src/loggy-intf/export/LoggedValueEncoder.js
@@ -108,7 +108,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
       const constructor = Reflect.getPrototypeOf(node).constructor;
       const ELIDED      = LoggedValueEncoder.#SEXP_ELIDED;
       return constructor
-        ? new Sexp(this._prot_nameFromValue(constructor), ELIDED)
+        ? new Sexp(constructor, ELIDED)
         : new Sexp('Object', this._prot_labelFromValue(node), ELIDED);
     }
   }

--- a/src/loggy-intf/export/LoggedValueEncoder.js
+++ b/src/loggy-intf/export/LoggedValueEncoder.js
@@ -66,7 +66,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
 
   /** @override */
   _impl_visitClass(node) {
-    return this._prot_nameFromValue(node);
+    return this.#visitFunctionOrClass(node, true);
   }
 
   /** @override */
@@ -95,7 +95,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
 
   /** @override */
   _impl_visitFunction(node) {
-    return this._prot_nameFromValue(node);
+    return this.#visitFunctionOrClass(node, false);
   }
 
   /** @override */
@@ -108,7 +108,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
       const constructor = Reflect.getPrototypeOf(node).constructor;
       const ELIDED      = LoggedValueEncoder.#SEXP_ELIDED;
       return constructor
-        ? new Sexp(constructor, ELIDED)
+        ? new Sexp(this._prot_visitSync(constructor), ELIDED)
         : new Sexp('Object', this._prot_labelFromValue(node), ELIDED);
     }
   }
@@ -142,6 +142,22 @@ export class LoggedValueEncoder extends BaseValueVisitor {
   _impl_visitUndefined(node_unused) {
     // `undefined` isn't JSON-encodable.
     return new Sexp('Undefined');
+  }
+
+  /**
+   * Transforms a function or class into the corresponding {@link Sexp} form.
+   *
+   * @param {function()} node Function or class to convert.
+   * @param {boolean} isClass Is it considered a class (that is, only usable as
+   *   a constructor)?
+   * @returns {Sexp} The converted form.
+   */
+  #visitFunctionOrClass(node, isClass) {
+    const name      = node.name;
+    const anonymous = !(name && (name !== ''));
+    const nameArgs  = anonymous ? [] : [name];
+
+    return new Sexp(isClass ? 'Class' : 'Function', ...nameArgs);
   }
 
   //

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -94,27 +94,7 @@ export class HumanVisitor extends BaseValueVisitor {
       }
       return new ComboText(...result);
     } else if (node instanceof Sexp) {
-      const { functorName, args } = node;
-      switch (functorName) {
-        case 'BigInt': {
-          const str = `${args[0]}n`;
-          return this.#maybeStyle(str, HumanVisitor.#STYLE_NUMBER);
-        }
-        case 'Elided': {
-          return this.#maybeStyle('...', HumanVisitor.#STYLE_ELIDED);
-        }
-        case 'Symbol': {
-          const funcStr = args[1] ? 'Symbol.for' : 'Symbol';
-          const symArgs = (args[0] === null) ? [] : [args[0]];
-          return this.#visitCall(funcStr, symArgs);
-        }
-        case 'Undefined': {
-          return this.#maybeStyle('undefined', HumanVisitor.#STYLE_UNDEFINED);
-        }
-        default: {
-          return this.#visitCall(`@${functorName}`, args, HumanVisitor.#STYLE_SEXP);
-        }
-      }
+      return this.#renderSexp(node);
     } else {
       throw this.#shouldntHappen();
     }
@@ -183,6 +163,36 @@ export class HumanVisitor extends BaseValueVisitor {
       return `${key}:`;
     } else {
       return new ComboText(this._impl_visitString(key), ':');
+    }
+  }
+
+  /**
+   * Renders a {@link Sexp}.
+   *
+   * @param {Sexp} sexp The instance to render.
+   * @returns {TypeText} The rendered form.
+   */
+  #renderSexp(sexp) {
+    const { functorName, args } = node;
+    switch (functorName) {
+      case 'BigInt': {
+        const str = `${args[0]}n`;
+        return this.#maybeStyle(str, HumanVisitor.#STYLE_NUMBER);
+      }
+      case 'Elided': {
+        return this.#maybeStyle('...', HumanVisitor.#STYLE_ELIDED);
+      }
+      case 'Symbol': {
+        const funcStr = args[1] ? 'Symbol.for' : 'Symbol';
+        const symArgs = (args[0] === null) ? [] : [args[0]];
+        return this.#visitCall(funcStr, symArgs);
+      }
+      case 'Undefined': {
+        return this.#maybeStyle('undefined', HumanVisitor.#STYLE_UNDEFINED);
+      }
+      default: {
+        return this.#visitCall(`@${functorName}`, args, HumanVisitor.#STYLE_SEXP);
+      }
     }
   }
 

--- a/src/sexp/export/Sexp.js
+++ b/src/sexp/export/Sexp.js
@@ -97,7 +97,7 @@ export class Sexp {
     switch (typeof functor) {
       case 'function':
       case 'object': {
-        if ((functor === null) || (functor === '')) {
+        if (functor === null) {
           break;
         }
 
@@ -158,10 +158,15 @@ export class Sexp {
    * @returns {*} The replacement form to encode.
    */
   toJSON(key_unused) {
-    const name      = this.functorName;
-    const finalName = (name === '<anonymous>') ? '@' : `@${name}`;
+    const { functor } = this;
 
-    return { [finalName]: this.#args };
+    if (typeof functor === 'string') {
+      const name      = this.functorName;
+      const finalName = (name === '<anonymous>') ? '@' : `@${name}`;
+      return { [finalName]: this.#args };
+    } else {
+      return { '@Sexp': this.toArray() };
+    }
   }
 
   /**


### PR DESCRIPTION
This PR rounds out the recent round of logging improvements by getting function and class objects to get encoded as sexps and then rendered in ways that are more suggestive of their actual identities, as opposed to just getting rendered like literal strings.