### PR TITLE
Human logging of object keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,13 @@ Other notable changes:
 * general:
   * Allow node version 23.
 * `loggy-intf` / `loggy`:
-  * Made several improvements to "human" (non-JSON) log rendering, including
-    fixing it to be able to log values with reference cycles.
+  * Improved the data model used to encode logged items, including:
+    * Representing functions and classes as structured objects instead of just
+      strings.
+    * Making it possible to encode values with reference cycles.
+  * Improved "human" (non-JSON) log rendering, including:
+    * Correctly rendering shared references.
+    * Tweaking the styling for readability.
 * `structy`:
   * Started allowing any object (plain or not) to be used as the argument to the
     `BaseStruct` constructor.

--- a/src/host/export/ProductInfo.js
+++ b/src/host/export/ProductInfo.js
@@ -50,6 +50,7 @@ export class ProductInfo {
   static init() {
     this.#extractInfo();
     ThisModule.logger?.productInfo(this.#info);
+    ThisModule.logger?.HELLO_THERE({ abc: 'boop', 'cd-ef': 'floop', 97: 'zoop', [-123]: 'doop' });
   }
 
   /**

--- a/src/host/export/ProductInfo.js
+++ b/src/host/export/ProductInfo.js
@@ -50,7 +50,6 @@ export class ProductInfo {
   static init() {
     this.#extractInfo();
     ThisModule.logger?.productInfo(this.#info);
-    ThisModule.logger?.HELLO_THERE({ abc: 'boop', 'cd-ef': 'floop', 97: 'zoop', [-123]: 'doop' });
   }
 
   /**

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -178,11 +178,24 @@ export class HumanVisitor extends BaseValueVisitor {
    * @returns {TypeText} The rendered form.
    */
   #renderKey(key) {
-    if ((typeof key === 'string') && /^[$_a-zA-Z][$_a-zA-Z0-9]*$/.test(key)) {
-      // It doesn't have to be quoted.
-      return `${key}:`;
+    if (typeof key === 'string') {
+      if (/^([$_a-zA-Z][$_a-zA-Z0-9]*|[1-9][0-9]{0,15}|0)$/.test(key)) {
+        // It doesn't have to be quoted.
+        return `${key}:`;
+      } else if (/^-[1-9][0-9]{0,15}$/.test(key)) {
+        // It can be treated like a negative numeric literal.
+        return `[${key}]:`;
+      } else {
+        // It needs to be quoted.
+        return `${util.inspect(key)}:`;
+      }
     } else {
-      return new ComboText(this._impl_visitString(key), ':');
+      // A non-string, perhaps a symbol, however as of this writing this case
+      // isn't used.
+      return new ComboText(
+        '[', ComboText.NO_BREAK,
+        this._prot_visitSync(key),
+        ComboText.NO_BREAK, ']:');
     }
   }
 


### PR DESCRIPTION
This PR tweaks the human-form rendering of object keys, to expand the use of un-quoted forms when possible. It also drops styling (colorization) of quoted strings, which I think made them harder to read especially in contexts where the values are also literal strings.