### PR TITLE
`configClass`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
-* None.
+* `compy`:
+  * `BaseComponent`: Renamed `CONFIG_CLASS` to `configClass`.
 
 Other notable changes:
 * None.

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -441,7 +441,7 @@ export class BaseComponent {
    *
    * @type {Map<function(new:BaseComponent), function(new:BaseConfig)>}
    */
-  static #configClass = new Map();
+  static #configClassMap = new Map();
 
   /**
    * @returns {function(new:BaseConfig, object)} The expected configuration
@@ -449,7 +449,7 @@ export class BaseComponent {
    * should override {@link #_impl_configClass}.
    */
   static get CONFIG_CLASS() {
-    const already = BaseComponent.#configClass.get(this);
+    const already = BaseComponent.#configClassMap.get(this);
 
     if (already) {
       return already;
@@ -468,7 +468,7 @@ export class BaseComponent {
       result = superCls.CONFIG_CLASS;
     }
 
-    BaseComponent.#configClass.set(this, result);
+    BaseComponent.#configClassMap.set(this, result);
     return result;
   }
 

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -56,7 +56,7 @@ export class BaseComponent {
    *
    * **Note:** When passing `rawConfig` as a plain object, this constructor
    * will attempt to construct the concrete class's defined
-   * {@link #CONFIG_CLASS}, and then set that as the final {@link #config}. When
+   * {@link #configClass}, and then set that as the final {@link #config}. When
    * doing so, the constructor is passed the given `rawConfig` augmented with
    * the additional binding of `class` to the concrete class being constructed
    * (that is, the concrete subclass of this class whose constructor call landed
@@ -64,7 +64,7 @@ export class BaseComponent {
    *
    * @param {?object} [rawConfig] "Raw" (not guaranteed to be parsed and
    *   correct) configuration for this instance. It must either be an instance
-   *   of the concrete class's {@link #CONFIG_CLASS}, or a plain object which is
+   *   of the concrete class's {@link #configClass}, or a plain object which is
    *   acceptable to the constructor of that class, or `null` (equivalent to
    *   `{}`, that is, an empty object) to have no configuration properties.
    *   Default `null`.
@@ -74,7 +74,7 @@ export class BaseComponent {
    */
   constructor(rawConfig = null, rootContext = null) {
     const targetClass = new.target;
-    this.#config = targetClass.CONFIG_CLASS.eval(rawConfig, { targetClass });
+    this.#config = targetClass.configClass.eval(rawConfig, { targetClass });
 
     const name = this.#config?.name;
     if (name) {
@@ -92,7 +92,7 @@ export class BaseComponent {
   /**
    * @returns {?BaseConfig} Configuration object for this instance, or `null` if
    * it has no associated configuration. If non-`null`, this is an instance of
-   * {@link #CONFIG_CLASS}.
+   * {@link #configClass}.
    */
   get config() {
     return this.#config;
@@ -436,7 +436,7 @@ export class BaseComponent {
   //
 
   /**
-   * Map from each subclass to its return value for {@link #CONFIG_CLASS},
+   * Map from each subclass to its return value for {@link #configClass},
    * lazily filled in.
    *
    * @type {Map<function(new:BaseComponent), function(new:BaseConfig)>}
@@ -448,7 +448,7 @@ export class BaseComponent {
    * class. for this class. Subclasses should not override this; instead they
    * should override {@link #_impl_configClass}.
    */
-  static get CONFIG_CLASS() {
+  static get configClass() {
     const already = BaseComponent.#configClassMap.get(this);
 
     if (already) {
@@ -465,7 +465,7 @@ export class BaseComponent {
       MustBe.subclassOf(result, BaseConfig);
     } else {
       const superCls = Reflect.getPrototypeOf(this);
-      result = superCls.CONFIG_CLASS;
+      result = superCls.configClass;
     }
 
     BaseComponent.#configClassMap.set(this, result);
@@ -482,7 +482,7 @@ export class BaseComponent {
    * The result array elements are derived as follows:
    *
    * * Instances of this class become result elements directly.
-   * * Plain objects and instances of this class's {@link #CONFIG_CLASS} are
+   * * Plain objects and instances of this class's {@link #configClass} are
    *   used to construct instances of this class, which then become result
    *   elements.
    * * All other values are rejected, causing an `Error` to be `throw`n.
@@ -506,7 +506,7 @@ export class BaseComponent {
         return item;
       } else if (item instanceof BaseComponent) {
         throw new Error('Item is not an instance of this class (or a subclass).');
-      } else if ((item instanceof this.CONFIG_CLASS) || AskIf.plainObject(item)) {
+      } else if ((item instanceof this.configClass) || AskIf.plainObject(item)) {
         const { class: cls } = item;
         if (AskIf.constructorFunction(cls)) {
           if (AskIf.subclassOf(cls, this)) {
@@ -528,7 +528,7 @@ export class BaseComponent {
   /**
    * Gets the expected configuration class for this class. This (base) class
    * calls this method exactly once to get the value to return from {@link
-   * #CONFIG_CLASS}.
+   * #configClass}.
    *
    * The default value is a configuration class which adds `name` as an optional
    * configuration property, on top of (optional) `class` as defined by

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -436,8 +436,8 @@ export class BaseComponent {
   //
 
   /**
-   * Map from each subclass to its return value for {@link #configClass},
-   * lazily filled in.
+   * Map from each subclass to its return value for {@link #configClass}, lazily
+   * filled in.
    *
    * @type {Map<function(new:BaseComponent), function(new:BaseConfig)>}
    */
@@ -482,9 +482,8 @@ export class BaseComponent {
    * The result array elements are derived as follows:
    *
    * * Instances of this class become result elements directly.
-   * * Plain objects and instances of this class's {@link #configClass} are
-   *   used to construct instances of this class, which then become result
-   *   elements.
+   * * Plain objects and instances of this class's {@link #configClass} are used
+   *   to construct instances of this class, which then become result elements.
    * * All other values are rejected, causing an `Error` to be `throw`n.
    *
    * @param {*} items Single instance or configuration, or array thereof.
@@ -527,8 +526,8 @@ export class BaseComponent {
 
   /**
    * Gets the expected configuration class for this class. This (base) class
-   * calls this method exactly once to get the value to return from {@link
-   * #configClass}.
+   * calls this method exactly once to get the value to return from
+   * {@link #configClass}.
    *
    * The default value is a configuration class which adds `name` as an optional
    * configuration property, on top of (optional) `class` as defined by

--- a/src/compy/export/BaseRootComponent.js
+++ b/src/compy/export/BaseRootComponent.js
@@ -31,7 +31,7 @@ export class BaseRootComponent extends BaseComponent {
     // We need to recapitulate the config parsing our superclass would have done
     // so that we can pass the parsed config to the `RootControlContext`
     // constructor.
-    const config = new.target.CONFIG_CLASS.eval(rawConfig, {
+    const config = new.target.configClass.eval(rawConfig, {
       targetClass: new.target
     });
 
@@ -47,7 +47,7 @@ export class BaseRootComponent extends BaseComponent {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/loggy-intf/private/HumanVisitor.js
+++ b/src/loggy-intf/private/HumanVisitor.js
@@ -137,8 +137,8 @@ export class HumanVisitor extends BaseValueVisitor {
   }
 
   /**
-   * Styles the given text, but only if this instance has been told to be
-   * styled _and_ the given style function is passed as non-`null`.
+   * Styles the given text, but only if this instance has been told to be styled
+   * _and_ the given style function is passed as non-`null`.
    *
    * @param {string} text The text in question.
    * @param {?Function} func The style/colorizer function, or `null` if no style

--- a/src/net-util/export/EndpointAddress.js
+++ b/src/net-util/export/EndpointAddress.js
@@ -6,8 +6,8 @@ import { MustBe } from '@this/typey';
 
 
 /**
- * The address of a network endpoint, consisting of an IP address and port.
- * This can be used for either the local or origin (remote) side of a network
+ * The address of a network endpoint, consisting of an IP address and port. This
+ * can be used for either the local or origin (remote) side of a network
  * connection. This class only accepts numerical IP addresses, not hostnames.
  * Instances of this class are immutable.
  *

--- a/src/net-util/export/InterfaceAddress.js
+++ b/src/net-util/export/InterfaceAddress.js
@@ -77,9 +77,9 @@ export class InterfaceAddress extends IntfDeconstructable {
    *
    * @param {string|object} fullAddress The full address, in one of the forms
    *   mentioned above.
-   * @param {?object} nodeServerOptions Extra options to use when constructing
-   *   a Node {@link Server} object or calling `listen()` on one; or `null` not
-   *   to have extra options beyond the defaults.
+   * @param {?object} nodeServerOptions Extra options to use when constructing a
+   *   Node {@link Server} object or calling `listen()` on one; or `null` not to
+   *   have extra options beyond the defaults.
    */
   constructor(fullAddress, nodeServerOptions = null) {
     super();
@@ -224,9 +224,9 @@ export class InterfaceAddress extends IntfDeconstructable {
   }
 
   /**
-   * Indicates whether or not this instance represents the same interface as
-   * the given object. This only returns `true` if `other` is also an instance
-   * of this class.
+   * Indicates whether or not this instance represents the same interface as the
+   * given object. This only returns `true` if `other` is also an instance of
+   * this class.
    *
    * @param {*} other Object to compare to.
    * @returns {boolean} `true` if `this` and `other` represent the same

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -179,9 +179,9 @@ export class BaseValueVisitor {
   /**
    * Similar to {@link #visitWrap}, except (a) it will fail if the visit did not
    * finish synchronously; and (b) the result is not wrapped. Specifically with
-   * respect to (b), if a promise is returned, it is only ever
-   * because an `_impl_visit*()` method returned a promise result per se (and
-   * not because a visitor acted asynchronously).
+   * respect to (b), if a promise is returned, it is only ever because an
+   * `_impl_visit*()` method returned a promise result per se (and not because a
+   * visitor acted asynchronously).
    *
    * @returns {*} Whatever result was returned from the `_impl_*()` method which
    *   processed the original `value`.

--- a/src/valvis/export/VisitDef.js
+++ b/src/valvis/export/VisitDef.js
@@ -8,8 +8,8 @@ import { VisitRef } from '#x/VisitRef';
 
 
 /**
- * Representation of a result of a (sub-)visit which appears more than
- * once in an overall visit result.
+ * Representation of a result of a (sub-)visit which appears more than once in
+ * an overall visit result.
  */
 export class VisitDef extends BaseDefRef {
   /**
@@ -21,7 +21,7 @@ export class VisitDef extends BaseDefRef {
 
   /**
    * The error resulting from the visit, or `null` if there was none _or_ it is
-   * not yet  known.
+   * not yet known.
    *
    * @type {?Error}
    */

--- a/src/webapp-builtins/export/AccessLogToFile.js
+++ b/src/webapp-builtins/export/AccessLogToFile.js
@@ -197,7 +197,7 @@ export class AccessLogToFile extends BaseFileService {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/ConnectionRateLimiter.js
+++ b/src/webapp-builtins/export/ConnectionRateLimiter.js
@@ -70,7 +70,7 @@ export class ConnectionRateLimiter extends BaseService {
   static _impl_configClass() {
     return TemplRateLimitConfig(
       'ConnectionRateLimiterConfig',
-      BaseService.CONFIG_CLASS,
+      BaseService.configClass,
       {
         countType: ConnectionCount,
         rateType:  ConnectionRate

--- a/src/webapp-builtins/export/DataRateLimiter.js
+++ b/src/webapp-builtins/export/DataRateLimiter.js
@@ -63,7 +63,7 @@ export class DataRateLimiter extends BaseService {
   static _impl_configClass() {
     const baseClass = TemplRateLimitConfig(
       'DataRateJustLimiterConfig',
-      BaseService.CONFIG_CLASS,
+      BaseService.configClass,
       {
         allowMaxQueueGrant: true,
         countType:          ByteCount,

--- a/src/webapp-builtins/export/EventFan.js
+++ b/src/webapp-builtins/export/EventFan.js
@@ -95,7 +95,7 @@ export class EventFan extends BaseService {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -103,7 +103,7 @@ export class HostRouter extends BaseApplication {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       /**
        * Map which goes from a host prefix to the name of an application which
        * should handle that prefix. Each host must be a valid

--- a/src/webapp-builtins/export/MemoryMonitor.js
+++ b/src/webapp-builtins/export/MemoryMonitor.js
@@ -136,7 +136,7 @@ export class MemoryMonitor extends TemplThreadComponent('MemoryThread', BaseServ
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -92,7 +92,7 @@ export class PathRouter extends BaseApplication {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/ProcessIdFile.js
+++ b/src/webapp-builtins/export/ProcessIdFile.js
@@ -190,7 +190,7 @@ export class ProcessIdFile extends TemplThreadComponent('FileThread', BaseFileSe
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/ProcessInfoFile.js
+++ b/src/webapp-builtins/export/ProcessInfoFile.js
@@ -290,7 +290,7 @@ export class ProcessInfoFile extends TemplThreadComponent('FileThread', BaseFile
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/Redirector.js
+++ b/src/webapp-builtins/export/Redirector.js
@@ -68,7 +68,7 @@ export class Redirector extends BaseApplication {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/RequestDelay.js
+++ b/src/webapp-builtins/export/RequestDelay.js
@@ -51,7 +51,7 @@ export class RequestDelay extends BaseApplication {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/RequestFilter.js
+++ b/src/webapp-builtins/export/RequestFilter.js
@@ -98,7 +98,7 @@ export class RequestFilter extends BaseApplication {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/RequestRateLimiter.js
+++ b/src/webapp-builtins/export/RequestRateLimiter.js
@@ -59,7 +59,7 @@ export class RequestRateLimiter extends BaseApplication {
   static _impl_configClass() {
     return TemplRateLimitConfig(
       'RequestRateLimiterConfig',
-      BaseApplication.CONFIG_CLASS,
+      BaseApplication.configClass,
       {
         countType: RequestCount,
         rateType:  RequestRate

--- a/src/webapp-builtins/export/SerialRouter.js
+++ b/src/webapp-builtins/export/SerialRouter.js
@@ -70,7 +70,7 @@ export class SerialRouter extends BaseApplication {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -108,7 +108,7 @@ export class SimpleResponse extends BaseApplication {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -309,7 +309,7 @@ export class StaticFiles extends BaseApplication {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/SuffixRouter.js
+++ b/src/webapp-builtins/export/SuffixRouter.js
@@ -90,7 +90,7 @@ export class SuffixRouter extends BaseApplication {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-builtins/export/SyslogToFile.js
+++ b/src/webapp-builtins/export/SyslogToFile.js
@@ -116,7 +116,7 @@ export class SyslogToFile extends BaseFileService {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-core/export/BaseDispatched.js
+++ b/src/webapp-core/export/BaseDispatched.js
@@ -67,7 +67,7 @@ export class BaseDispatched extends BaseComponent {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -170,7 +170,7 @@ export class NetworkEndpoint extends BaseDispatched {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-core/export/NetworkHost.js
+++ b/src/webapp-core/export/NetworkHost.js
@@ -115,7 +115,7 @@ export class NetworkHost extends BaseComponent {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**
@@ -211,7 +211,7 @@ export class NetworkHost extends BaseComponent {
    * Makes the parameters for a newly-generated self-signed certificate and
    * corresponding key.
    *
-   * @param {NetworkHost.CONFIG_CLASS} config Parsed configuration item.
+   * @param {NetworkHost.configClass} config Parsed configuration item.
    * @returns {{certificate: string, privateKey: string}} The parameters.
    */
   static async #makeSelfSignedParameters(config) {

--- a/src/webapp-core/export/WebappRoot.js
+++ b/src/webapp-core/export/WebappRoot.js
@@ -183,7 +183,7 @@ export class WebappRoot extends BaseRootComponent {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       // @defaultConstructor
 
       /**

--- a/src/webapp-util/export/BaseFileService.js
+++ b/src/webapp-util/export/BaseFileService.js
@@ -54,7 +54,7 @@ export class BaseFileService extends BaseService {
 
   /** @override */
   static _impl_configClass() {
-    return class Config extends super.prototype.constructor.CONFIG_CLASS {
+    return class Config extends super.prototype.constructor.configClass {
       /**
        * Path parts, or `null` if not yet calculated.
        *

--- a/src/webapp-util/export/Rotator.js
+++ b/src/webapp-util/export/Rotator.js
@@ -18,7 +18,7 @@ export class Rotator extends BaseFilePreserver {
   /**
    * Configuration to use.
    *
-   * @type {BaseFileService.CONFIG_CLASS}
+   * @type {BaseFileService.configClass}
    */
   #config;
 
@@ -33,13 +33,13 @@ export class Rotator extends BaseFilePreserver {
   /**
    * Constructs an instance.
    *
-   * @param {BaseFileService.CONFIG_CLASS} config Configuration to use.
+   * @param {BaseFileService.configClass} config Configuration to use.
    * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
   constructor(config, logger) {
     super(config, logger);
 
-    this.#config      = MustBe.instanceOf(config, BaseFileService.CONFIG_CLASS);
+    this.#config      = MustBe.instanceOf(config, BaseFileService.configClass);
     this.#checkPeriod = config.rotate.checkPeriod;
   }
 

--- a/src/webapp-util/export/Saver.js
+++ b/src/webapp-util/export/Saver.js
@@ -14,7 +14,7 @@ export class Saver extends BaseFilePreserver {
   /**
    * Constructs an instance.
    *
-   * @param {BaseFileService.CONFIG_CLASS} config Configuration to use.
+   * @param {BaseFileService.configClass} config Configuration to use.
    * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
   constructor(config, logger) {

--- a/src/webapp-util/private/BaseFilePreserver.js
+++ b/src/webapp-util/private/BaseFilePreserver.js
@@ -23,7 +23,7 @@ export class BaseFilePreserver {
   /**
    * Configuration to use.
    *
-   * @type {BaseFileService.CONFIG_CLASS}
+   * @type {BaseFileService.configClass}
    */
   #config;
 
@@ -65,11 +65,11 @@ export class BaseFilePreserver {
   /**
    * Constructs an instance.
    *
-   * @param {BaseFileService.CONFIG_CLASS} config Configuration to use.
+   * @param {BaseFileService.configClass} config Configuration to use.
    * @param {?IntfLogger} logger Logger to use, or `null` to not do any logging.
    */
   constructor(config, logger) {
-    this.#config = MustBe.instanceOf(config, BaseFileService.CONFIG_CLASS);
+    this.#config = MustBe.instanceOf(config, BaseFileService.configClass);
     this.#logger = logger?.saver ?? null;
   }
 


### PR DESCRIPTION
This PR renames `CONFIG_CLASS` to `configClass` in `BaseComponent`. Even though it's pretty much a constant, it feels more ergonomic in context to use good ol' lowerCamelCase for it.