### PR TITLE
`IntfLogger.expectInstance()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ Breaking changes:
   * `BaseComponent`: Renamed `CONFIG_CLASS` to `configClass`.
 
 Other notable changes:
-* None.
+* `loggy-intf`:
+  * `LoggyIntf`: New static methods `expectInstance()` and
+    `expectInstanceOrNull()`, to avoid more ad-hoc checks.
 
 ### v0.8.5 -- 2024-12-06
 

--- a/src/loggy-intf/export/IntfLogger.js
+++ b/src/loggy-intf/export/IntfLogger.js
@@ -117,7 +117,7 @@ export class IntfLogger {
    * @throws {Error} Thrown if `logger` is not actually a logger or `null`.
    */
   static expectInstanceOrNull(logger) {
-    return (logger === null) ? logger : this.expectInstance(logger);
+    return (logger === null) ? null : this.expectInstance(logger);
   }
 
   /**

--- a/src/loggy-intf/export/IntfLogger.js
+++ b/src/loggy-intf/export/IntfLogger.js
@@ -1,7 +1,7 @@
 // Copyright 2022-2024 the Lactoserv Authors (Dan Bornstein et alia).
 // SPDX-License-Identifier: Apache-2.0
 
-import { Methods } from '@this/typey';
+import { AskIf, Methods } from '@this/typey';
 
 import { IntfLoggingEnvironment } from '#x/IntfLoggingEnvironment';
 import { LogPayload } from '#x/LogPayload';
@@ -77,6 +77,47 @@ export class IntfLogger {
    */
   get $newId() {
     return Methods.abstract();
+  }
+
+
+  //
+  // Static members
+  //
+
+  /**
+   * Returns the given value if it is an instance of this interface. Throws an
+   * error if not.
+   *
+   * **Note:** Because of JavaScript's loosey-goosey nature, this method is, as
+   * a practical matter, overly accepting of values as instances.
+   *
+   * @param {*} logger (Alleged) logger instance.
+   * @returns {IntfLogger} `logger` if it is a logger.
+   * @throws {Error} Thrown if `logger` is not actually a logger.
+   */
+  static expectInstance(logger) {
+    if (logger instanceof IntfLogger) {
+      return logger;
+    } else if (AskIf.callableFunction(logger) && logger.$env) {
+      return logger;
+    }
+
+    throw new Error(`Not a logger: ${logger}`);
+  }
+
+  /**
+   * Returns the given value if it is an instance of this interface or is
+   * `null`. Throws an error if not either.
+   *
+   * **Note:** Because of JavaScript's loosey-goosey nature, this method is, as
+   * a practical matter, overly accepting of values as instances.
+   *
+   * @param {*} logger (Alleged) logger instance.
+   * @returns {?IntfLogger} `logger` if it is a logger or `null`.
+   * @throws {Error} Thrown if `logger` is not actually a logger or `null`.
+   */
+  static expectInstanceOrNull(logger) {
+    return (logger === null) ? logger : this.expectInstance(logger);
   }
 
   /**

--- a/src/metacomp/export/LimitedLoader.js
+++ b/src/metacomp/export/LimitedLoader.js
@@ -71,7 +71,7 @@ export class LimitedLoader {
    */
   constructor(context = null, logger = null) {
     this.#context = context;
-    this.#logger  = logger;
+    this.#logger  = IntfLogger.expectInstanceOrNull(logger);
 
     if (context && !vm.isContext(context)) {
       vm.createContext(context);

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -181,7 +181,7 @@ export class ProtocolWrangler {
    *   logging.
    */
   async init(logger) {
-    this.#logger = logger;
+    this.#logger = IntfLogger.expectInstanceOrNull(logger);
 
     // Confusion alert!: This is not the same as the `requestLogger` (a "request
     // logger") per se) passed in as an option. This is the sub-logger of the

--- a/src/net-protocol/private/AsyncServerSocket.js
+++ b/src/net-protocol/private/AsyncServerSocket.js
@@ -76,7 +76,7 @@ export class AsyncServerSocket {
     // Note: `interface` is a reserved word.
     this.#interface = MustBe.instanceOf(iface, InterfaceAddress);
     this.#protocol  = MustBe.string(protocol);
-    this.#logger    = logger;
+    this.#logger    = IntfLogger.expectInstanceOrNull(logger);
   }
 
   /**

--- a/src/net-protocol/private/WranglerContext.js
+++ b/src/net-protocol/private/WranglerContext.js
@@ -267,8 +267,8 @@ export class WranglerContext {
     ctx.#socket   = socket;
 
     if (logger) {
-      ctx.#connectionLogger = logger;
-      ctx.#connectionId     = logger.$meta.lastContext;
+      ctx.#connectionLogger = IntfLogger.expectInstanceOrNull(logger);
+      ctx.#connectionId     = logger?.$meta.lastContext ?? null;
     }
 
     ctx.bind(socket);

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -57,7 +57,7 @@ export class DispatchInfo extends IntfDeconstructable {
 
     this.#base   = MustBe.instanceOf(base, PathKey);
     this.#extra  = MustBe.instanceOf(extra, PathKey);
-    this.#logger = (logger === null) ? null : MustBe.callableFunction(logger);
+    this.#logger = IntfLogger.expectInstanceOrNull(logger);
   }
 
   /** @override */

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -130,7 +130,7 @@ export class HostManager extends TemplAggregateComponent('HostAggregate', BaseCo
      * @param {?IntfLogger} logger Logger to use, if any.
      */
     constructor(logger) {
-      this.#logger = logger;
+      this.#logger = IntfLogger.expectInstanceOrNull(logger);
     }
 
     /**


### PR DESCRIPTION
This adds convenient logger type check methods `IntfLogger.expectInstance()` and `IntfLogger.expectInstanceOrNull()` to help avoid ad-hoc checking.