### PR TITLE
`StaticFileResponder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ Breaking changes:
 * None.
 
 Other notable changes:
-* None.
+* `webapp-util`:
+  * New class `StaticFileResponder`, extracted from
+    `webapp-builtins.StaticFiles`.
 
 ### v0.8.6 -- 2025-01-06 -- stable release
 

--- a/src/net-util/export/FullResponse.js
+++ b/src/net-util/export/FullResponse.js
@@ -241,7 +241,9 @@ export class FullResponse extends BaseResponse {
       } else if (rangeInfo.error) {
         // Note: We _don't_ use the for-success `headers` here.
         const result = new FullResponse();
-        result.headers = new HttpHeaders(rangeInfo.headers); // TODO: Fix this when `rangeInfo` changes.
+        // TODO: Fix the following line when `rangeInfo` is switched to
+        // returning an actual `HttpHeaders` object.
+        result.headers = new HttpHeaders(rangeInfo.headers);
         result.status  = rangeInfo.status;
         result.setBodyMessage();
         return result;

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -304,15 +304,7 @@ export class StaticFiles extends BaseApplication {
        * @returns {?string} Accepted configuration value.
        */
       _config_cacheControl(value = null) {
-        if (value === null) {
-          return null;
-        } else if (typeof value === 'string') {
-          return value;
-        } else if (AskIf.plainObject(value)) {
-          return HttpUtil.cacheControlHeader(value);
-        } else {
-          throw new Error('Invalid `cacheControl` option.');
-        }
+        return StaticFileResponder.checkCacheControl(value);
       }
 
       /**
@@ -324,15 +316,7 @@ export class StaticFiles extends BaseApplication {
        * @returns {?object} Accepted configuration value.
        */
       _config_etag(value = null) {
-        if (value === null) {
-          return null;
-        } else if (value === true) {
-          return EtagGenerator.expandOptions({});
-        } else if (AskIf.plainObject(value)) {
-          return EtagGenerator.expandOptions(value);
-        } else {
-          throw new Error('Invalid `etag` option.');
-        }
+        return StaticFileResponder.checkEtag(value);
       }
 
       /**

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -4,10 +4,8 @@
 import fs from 'node:fs/promises';
 
 import { Paths, Statter } from '@this/fs-util';
-import { DispatchInfo, EtagGenerator, FullResponse, HttpUtil, MimeTypes,
-  StatusResponse }
+import { DispatchInfo, FullResponse, HttpUtil, MimeTypes, StatusResponse }
   from '@this/net-util';
-import { AskIf } from '@this/typey';
 import { BaseApplication } from '@this/webapp-core';
 import { StaticFileResponder } from '@this/webapp-util';
 

--- a/src/webapp-util/export/StaticFileResponder.js
+++ b/src/webapp-util/export/StaticFileResponder.js
@@ -1,0 +1,145 @@
+// Copyright 2022-2025 the Lactoserv Authors (Dan Bornstein et alia).
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs/promises';
+
+import { Statter } from '@this/fs-util';
+import { EtagGenerator, FullResponse, HttpUtil, IncomingRequest, MimeTypes }
+  from '@this/net-util';
+import { BaseConfig } from '@this/structy';
+import { AskIf } from '@this/typey';
+
+
+/**
+ * Class which makes static content responses in a standardized form. This is
+ * used by the built-in `StaticFiles` application, and it is provided separately
+ * here to help with use cases which want a fairly standard behavior but where
+ * not all of the behavior `StaticFiles` is required or appropriate.
+ */
+export class StaticFileResponder {
+  /**
+   * `cache-control` header to automatically include, or `null` not to do that.
+   *
+   * @type {?string}
+   */
+  #cacheControl = null;
+
+  /**
+   * Etag generator to use, or `null` if not using one.
+   *
+   * @type {?EtagGenerator}
+   */
+  #etagGenerator = null;
+
+  /**
+   * Constructs an instance.
+   *
+   * @param {?object} [config] Instance configuration, or `null` to use all
+   *   defaults.
+   * @param {?object|string} [config.cacheControl] `cache-control` header to
+   *   automatically include, or `null` not to include it. Can be passed either
+   *   as a literal string or an object to be passed to
+   *   {@link HttpUtil#cacheControlHeader}. Default `null`.
+   * @param {?object|true} [config.etag] Etag-generating options, `true` for
+   *   standard options, or `null` not to include an `etag` header in responses.
+   *   Default `null`.
+   */
+  constructor(config = null) {
+    const { cacheControl, etag } = new StaticFileResponder.#Config(config);
+
+    this.#cacheControl  = cacheControl;
+    this.#etagGenerator = etag ? new EtagGenerator(etag) : null;
+  }
+
+  /**
+   * Makes a response for the given absolute path. If the path is not an
+   * existing file, this returns `null`.
+   *
+   * @param {IncomingRequest} request The original request.
+   * @param {string} absolutePath The path to provide a response for.
+   * @param {fs.Stats} [stats] The `stat()` result on the path, or `null` if not
+   *   known.
+   * @returns {?FullResponse} The response.
+   */
+  async makeResponse(request, absolutePath, stats = null) {
+    if (!stats) {
+      stats = await Statter.statOrNull(absolutePath);
+      if (!stats) {
+        return null;
+      }
+    }
+
+    const contentType = MimeTypes.typeFromPathExtension(absolutePath);
+    const rawResponse = new FullResponse();
+
+    rawResponse.status = 200;
+    rawResponse.headers.set('content-type', contentType);
+    await rawResponse.setBodyFile(absolutePath, { stats });
+
+    if (this.#cacheControl) {
+      rawResponse.cacheControl = this.#cacheControl;
+    }
+
+    if (this.#etagGenerator) {
+      rawResponse.headers.set('etag',
+        await this.#etagGenerator.etagFromFile(absolutePath));
+    }
+
+    const { headers, method } = request;
+    const response = rawResponse.adjustFor(
+      method, headers, { conditional: true, range: true });
+
+    return response;
+  }
+
+
+  //
+  // Static members
+  //
+
+  /** @override */
+  static #Config = class Config extends BaseConfig {
+    // @defaultConstructor
+
+    /**
+     * `cache-control` header to automatically include, or `null` not to
+     * include it. Can be passed either as a literal string or an object to be
+     * passed to {@link HttpUtil#cacheControlHeader}.
+     *
+     * @param {?string|object} [value] Proposed configuration value. Default
+     *   `null`.
+     * @returns {?string} Accepted configuration value.
+     */
+    _config_cacheControl(value = null) {
+      if (value === null) {
+        return null;
+      } else if (typeof value === 'string') {
+        return value;
+      } else if (AskIf.plainObject(value)) {
+        return HttpUtil.cacheControlHeader(value);
+      } else {
+        throw new Error('Invalid `cacheControl` option.');
+      }
+    }
+
+    /**
+     * Etag-generating options, `true` for default options, or `null` not to
+     * include an `etag` header in responses.
+     *
+     * @param {?object|true} [value] Proposed configuration value. Default
+     *   `null`.
+     * @returns {?object} Accepted configuration value.
+     */
+    _config_etag(value = null) {
+      if (value === null) {
+        return null;
+      } else if (value === true) {
+        return EtagGenerator.expandOptions({});
+      } else if (AskIf.plainObject(value)) {
+        return EtagGenerator.expandOptions(value);
+      } else {
+        throw new Error('Invalid `etag` option.');
+      }
+    }
+  };
+}

--- a/src/webapp-util/export/StaticFileResponder.js
+++ b/src/webapp-util/export/StaticFileResponder.js
@@ -97,6 +97,48 @@ export class StaticFileResponder {
   // Static members
   //
 
+  /**
+   * Checks / accepts a `cacheControl` option. This is a `cache-control` header
+   * to automatically include, or `null` not to include it. Can be passed either
+   * as a literal string or an object to be passed to {@link
+   * HttpUtil#cacheControlHeader}.
+   *
+   * @param {?string|object} value Proposed configuration value. Default
+   *   `null`.
+   * @returns {?string} Accepted configuration value.
+   */
+  static checkCacheControl(value) {
+    if (value === null) {
+      return null;
+    } else if (typeof value === 'string') {
+      return value;
+    } else if (AskIf.plainObject(value)) {
+      return HttpUtil.cacheControlHeader(value);
+    } else {
+      throw new Error('Invalid `cacheControl` option.');
+    }
+  }
+
+  /**
+   * Checks / accepts etag-generating options, `true` for default options, or
+   * `null` not to include an `etag` header in responses.
+   *
+   * @param {?object|true} value Proposed configuration value. Default
+   *   `null`.
+   * @returns {?object} Accepted configuration value.
+   */
+  static checkEtag(value) {
+    if (value === null) {
+      return null;
+    } else if (value === true) {
+      return EtagGenerator.expandOptions({});
+    } else if (AskIf.plainObject(value)) {
+      return EtagGenerator.expandOptions(value);
+    } else {
+      throw new Error('Invalid `etag` option.');
+    }
+  }
+
   /** @override */
   static #Config = class Config extends BaseConfig {
     // @defaultConstructor
@@ -111,15 +153,7 @@ export class StaticFileResponder {
      * @returns {?string} Accepted configuration value.
      */
     _config_cacheControl(value = null) {
-      if (value === null) {
-        return null;
-      } else if (typeof value === 'string') {
-        return value;
-      } else if (AskIf.plainObject(value)) {
-        return HttpUtil.cacheControlHeader(value);
-      } else {
-        throw new Error('Invalid `cacheControl` option.');
-      }
+      return StaticFileResponder.checkCacheControl(value);
     }
 
     /**
@@ -131,15 +165,7 @@ export class StaticFileResponder {
      * @returns {?object} Accepted configuration value.
      */
     _config_etag(value = null) {
-      if (value === null) {
-        return null;
-      } else if (value === true) {
-        return EtagGenerator.expandOptions({});
-      } else if (AskIf.plainObject(value)) {
-        return EtagGenerator.expandOptions(value);
-      } else {
-        throw new Error('Invalid `etag` option.');
-      }
+      return StaticFileResponder.checkEtag(value);
     }
   };
 }

--- a/src/webapp-util/index.js
+++ b/src/webapp-util/index.js
@@ -8,4 +8,5 @@ export * from '#x/RequestCount';
 export * from '#x/RequestRate';
 export * from '#x/Rotator';
 export * from '#x/Saver';
+export * from '#x/StaticFileResponder';
 export * from '#x/TokenBucket';


### PR DESCRIPTION
This PR extracts the core work of `StaticFiles` into a new class, `StaticFileResponder`. While the former is a Lactoserv "application," the latter is just a class-that-does-the-thing and as such can be more easily used to implement functionality inside other classes.