### PR TITLE
`StaticFiles` and `StaticFileResponder` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Breaking changes:
 * None.
 
 Other notable changes:
+* `webapp-builtins`:
+  * `StaticFileResponder`: Added `indexFile` configuration option.
 * `webapp-util`:
   * New class `StaticFileResponder`, extracted from
     `webapp-builtins.StaticFiles`.

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -459,13 +459,17 @@ reasonable demand:
 An application which serves static files from a local directory. This
 application accepts the following configuration bindings:
 
-* `etag` &mdash; ETag-generating options. If present and not `null`, the
-  response comes with an `ETag` header. See
-  [ETag Configuration](#etag-configuration-etag) for details.
 * `cacheControl` &mdash; `cache-control` header definition. If present and not
   `null`, every cacheable response comes with the specified header. See
   [Cache control configuration](#cache-control-configuration-cacheControl) for
   details.
+* `etag` &mdash; ETag-generating options. If present and not `null`, the
+  response comes with an `ETag` header. See
+  [ETag Configuration](#etag-configuration-etag) for details.
+* `indexFile` &mdash; Name or list of names to search for in response to a
+  directory request, or `null` (or empty array) to respond to directory requests
+  as not-found. When there is more than one name, the first one in listed order
+  to be found is the one that is used. Default is `index.html`.
 * `notFoundPath` &mdash; Optional filesystem path to the file to serve when a
   file/path is not found. The indicated file will get sent back along with a
   `404` ("Not Found") status code.
@@ -478,6 +482,7 @@ const applications = [
   {
     name:          'mySite',
     class:         StaticFiles,
+    indexFile:     ['index.html', 'index.txt'],
     siteDirectory: '/path/to/site',
     notFoundPath:  '/path/to/404.html'
   }
@@ -505,9 +510,6 @@ reasonable demand:
 * Directory responses:
   * "Naked" directory paths (i.e. ones that do not end with a slash) are
     redirected to the same path with a final slash appended.
-  * Directory paths are responded to with the contents of a file called
-    `index.html` in that directory, if it exists. The index file name is not
-    configurable.
 * These "odd" URL paths all cause not-found responses:
   * Ones with a `..` that would "back out" of the site directory.
   * Ones with an _encoded_ slash in them, that is to say literally `%2F`. (It is

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -227,6 +227,7 @@ const applications = [
     class:          StaticFiles,
     siteDirectory:  filePath('../site'),
     notFoundPath:   filePath('../site-extra/not-found.html'),
+    indexFile:      ['index.html', 'index.txt'],
     cacheControl:   { public: true, maxAge: '5 min' },
     etag:           { dataOnly: true, hashLength: 20 }
   },
@@ -337,6 +338,7 @@ const config = {
     '/application/*': false,
     '/application/mySeries/*': true,
     '/application/mySite/*': true,
+    // '/application/myStaticFun/*': true,
     '/application/myRedirector/*': true
   }
 };

--- a/etc/example-setup/site/avec-index-txt/index.txt
+++ b/etc/example-setup/site/avec-index-txt/index.txt
@@ -1,0 +1,1 @@
+I am an index.txt file!

--- a/etc/example-setup/site/index.html
+++ b/etc/example-setup/site/index.html
@@ -8,6 +8,7 @@
   <h1>Hello!</h1>
   <ul>
     <li><a href="avec-index">avec-index/</a></li>
+    <li><a href="avec-index">avec-index-txt/</a></li>
     <li>florp/
       <ul>
         <li><a href="florp/boop.html">boop.html</a></li>

--- a/etc/example-setup/site/sans-index/nope.txt
+++ b/etc/example-setup/site/sans-index/nope.txt
@@ -1,0 +1,1 @@
+This directory does not have an index file.

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -4,7 +4,7 @@
 import fs from 'node:fs/promises';
 
 import { Paths, Statter } from '@this/fs-util';
-import { DispatchInfo, FullResponse, HttpUtil, MimeTypes, StatusResponse }
+import { FullResponse, HttpUtil, MimeTypes, StatusResponse }
   from '@this/net-util';
 import { BaseApplication } from '@this/webapp-core';
 import { StaticFileResponder } from '@this/webapp-util';
@@ -72,41 +72,28 @@ export class StaticFiles extends BaseApplication {
     const { cacheControl, etag, notFoundPath, siteDirectory } = this.config;
 
     this.#cacheControl   = cacheControl;
-    this.#foundResponder = new StaticFileResponder({ cacheControl, etag });
     this.#notFoundPath   = notFoundPath;
     this.#siteDirectory  = siteDirectory;
+    this.#foundResponder = new StaticFileResponder({
+      baseDirectory: siteDirectory,
+      cacheControl,
+      etag,
+      indexFile: 'index.html'
+    });
   }
 
   /** @override */
   async _impl_handleRequest(request, dispatch) {
-    if (!request.isGetOrHead()) {
+    const response =
+      await this.#foundResponder.handleRequest(request, dispatch);
+
+    if (response) {
+      return response;
+    } if (!request.isGetOrHead()) {
       return StatusResponse.FORBIDDEN;
-    }
-
-    const resolved = await this.#resolvePath(dispatch);
-
-    if (!resolved) {
+    } else {
       return this.#notFound();
     }
-
-    const { path, stats, redirect } = resolved;
-
-    if (redirect) {
-      const response = FullResponse.makeRedirect(redirect, 308);
-
-      if (this.#cacheControl) {
-        response.cacheControl = this.#cacheControl;
-      }
-
-      return await response;
-    } else if (path) {
-      return this.#foundResponder.makeResponse(request, path, stats);
-    } else {
-      /* c8 ignore start */
-      // Shouldn't happen. If we get here, it's a bug in this class.
-      throw new Error('Shouldn\'t happen.');
-    }
-    /* c8 ignore stop */
   }
 
   /** @override */
@@ -184,71 +171,6 @@ export class StaticFiles extends BaseApplication {
     return response;
   }
 
-  /**
-   * Figures out the absolute path to serve for the given request path.
-   *
-   * @param {DispatchInfo} dispatch Dispatch info containing the path to serve.
-   * @returns {{path: string, stats: fs.Stats}|{redirect: string}|null} The
-   *   absolute path and stat info of the file to serve, the (absolute or
-   *   relative) URL to redirect to, or `null` if given invalid input or the
-   *   indicated path is not found.
-   */
-  async #resolvePath(dispatch) {
-    const decoded = StaticFileResponder.decodePath(dispatch.extra.path);
-
-    if (!decoded) {
-      return null;
-    }
-
-    const { path, isDirectory } = decoded;
-
-    // The conditional guarantees that the `fullPath` does not end with a slash,
-    // which makes the code below a bit simpler (because we care about only
-    // producing canonicalized paths that have no double slashes).
-    const fullPath = (path === '')
-      ? this.#siteDirectory
-      : `${this.#siteDirectory}/${path}`;
-    this.logger?.fullPath(fullPath);
-
-    try {
-      const stats = await Statter.statOrNull(fullPath);
-      if (stats === null) {
-        this.logger?.notFound(fullPath);
-        return null;
-      } else if (stats.isDirectory()) {
-        if (!isDirectory) {
-          // Redirect from non-ending-slash directory path. As a special case,
-          // `path === ''` happens when the mount point was requested directly,
-          // without a final slash. So we need to look at the base to figure out
-          // what to redirect to.
-          const source = (path === '') ? dispatch.base.path : dispatch.extra.path;
-          return { redirect: `${source[source.length - 1]}/` };
-        } else {
-          // It's a proper directory reference. Look for the index file.
-          const indexPath = `${fullPath}/index.html`;
-          const indexStats = await Statter.statOrNull(indexPath, true);
-          if (indexStats === null) {
-            this.logger?.indexNotFound(indexPath);
-            return null;
-          } else if (indexStats.isDirectory()) {
-            // Weird case, to be clear!
-            this.logger?.indexIsDirectory(indexPath);
-            return null;
-          }
-          return { path: indexPath, stats: indexStats };
-        }
-      } else if (isDirectory) {
-        // Non-directory file requested as if it is a directory (that is, with a
-        // final slash). Not accepted per class contract.
-        return null;
-      }
-      return { path: fullPath, stats };
-    } catch (e) {
-      this.logger?.statError(fullPath, e);
-      return null;
-    }
-  }
-
 
   //
   // Static members
@@ -304,7 +226,7 @@ export class StaticFiles extends BaseApplication {
        * @returns {string} Accepted configuration value.
        */
       _config_siteDirectory(value) {
-        return Paths.checkAbsolutePath(value);
+        return StaticFileResponder.checkBaseDirectory(value);
       }
     };
   }

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -16,11 +16,11 @@ import { StaticFileResponder } from '@this/webapp-util';
  */
 export class StaticFiles extends BaseApplication {
   /**
-   * Handler for "found file" cases.
+   * "Responder" that does most of the actual work of this class.
    *
    * @type {StaticFileResponder}
    */
-  #foundResponder;
+  #responder;
 
   /**
    * Path to the file to serve for a not-found result, or `null` if not-found
@@ -71,10 +71,10 @@ export class StaticFiles extends BaseApplication {
 
     const { cacheControl, etag, notFoundPath, siteDirectory } = this.config;
 
-    this.#cacheControl   = cacheControl;
-    this.#notFoundPath   = notFoundPath;
-    this.#siteDirectory  = siteDirectory;
-    this.#foundResponder = new StaticFileResponder({
+    this.#cacheControl  = cacheControl;
+    this.#notFoundPath  = notFoundPath;
+    this.#siteDirectory = siteDirectory;
+    this.#responder     = new StaticFileResponder({
       baseDirectory: siteDirectory,
       cacheControl,
       etag,
@@ -85,7 +85,7 @@ export class StaticFiles extends BaseApplication {
   /** @override */
   async _impl_handleRequest(request, dispatch) {
     const response =
-      await this.#foundResponder.handleRequest(request, dispatch);
+      await this.#responder.handleRequest(request, dispatch);
 
     if (response) {
       return response;

--- a/src/webapp-builtins/tests/StaticFiles.test.js
+++ b/src/webapp-builtins/tests/StaticFiles.test.js
@@ -130,7 +130,7 @@ describe('constructor', () => {
 
   test('rejects an invalid typed `indexFile`', () => {
     expect(() => new StaticFiles({
-      indexFile:     { eep: 'oop'},
+      indexFile:     { eep: 'oop' },
       siteDirectory: '/florp/fleep'
     })).toThrow();
   });

--- a/src/webapp-builtins/tests/StaticFiles.test.js
+++ b/src/webapp-builtins/tests/StaticFiles.test.js
@@ -40,6 +40,7 @@ describe('constructor', () => {
     expect(() => new StaticFiles({
       cacheControl:  { maxAge: '5 min' },
       etag:          true,
+      indexFile:     ['blorp.html', 'bleep.txt'],
       notFoundPath:  '/blip/blop/bloop.html',
       siteDirectory: '/florp/fleep'
     })).not.toThrow();
@@ -83,6 +84,53 @@ describe('constructor', () => {
   test('rejects an invalid `etag` option', () => {
     expect(() => new StaticFiles({
       etag:          ['ummm'],
+      siteDirectory: '/florp/fleep'
+    })).toThrow();
+  });
+
+  test('accepts `indexFile: null`', () => {
+    expect(() => new StaticFiles({
+      indexFile:     null,
+      siteDirectory: '/florp/fleep'
+    })).not.toThrow();
+  });
+
+  test('accepts `indexFile: []`', () => {
+    expect(() => new StaticFiles({
+      indexFile:     null,
+      siteDirectory: '/florp/fleep'
+    })).not.toThrow();
+  });
+
+  test('accepts `indexFile` with a single string', () => {
+    expect(() => new StaticFiles({
+      indexFile:     'bonk.html',
+      siteDirectory: '/florp/fleep'
+    })).not.toThrow();
+  });
+
+  test('accepts `indexFile` with an array of strings', () => {
+    expect(() => new StaticFiles({
+      indexFile:     ['bonk.html', 'blorp', 'zamboni.txt'],
+      siteDirectory: '/florp/fleep'
+    })).not.toThrow();
+  });
+
+  test('rejects `indexFile` with a string containing a slash', () => {
+    expect(() => new StaticFiles({
+      indexFile:     ['x.txt', 'zip/zap.txt'],
+      siteDirectory: '/florp/fleep'
+    })).toThrow();
+
+    expect(() => new StaticFiles({
+      indexFile:     'beep/boop.html',
+      siteDirectory: '/florp/fleep'
+    })).toThrow();
+  });
+
+  test('rejects an invalid typed `indexFile`', () => {
+    expect(() => new StaticFiles({
+      indexFile:     { eep: 'oop'},
       siteDirectory: '/florp/fleep'
     })).toThrow();
   });

--- a/src/webapp-builtins/tests/StaticFiles.test.js
+++ b/src/webapp-builtins/tests/StaticFiles.test.js
@@ -97,7 +97,7 @@ describe('constructor', () => {
 
   test('accepts `indexFile: []`', () => {
     expect(() => new StaticFiles({
-      indexFile:     null,
+      indexFile:     [],
       siteDirectory: '/florp/fleep'
     })).not.toThrow();
   });

--- a/src/webapp-builtins/tests/StaticFiles.test.js
+++ b/src/webapp-builtins/tests/StaticFiles.test.js
@@ -287,13 +287,23 @@ describe('_impl_handleRequest()', () => {
     expect(result.headers.get('location')).toBe(expectedLoc);
   });
 
-  test('includes a `cache-control` header in responses if so configured', async () => {
+  test('includes a `cache-control` header in file responses if so configured', async () => {
     const sf      = await makeInstance({ cacheControl: 'florp=123' });
     const request = RequestUtil.makeGet('/some-file.txt');
     const result  = await sf.handleRequest(request, new DispatchInfo(PathKey.EMPTY, request.pathname));
 
     expect(result).toBeInstanceOf(FullResponse);
     expect(result.status).toBe(200);
+    expect(result.cacheControl).toBe('florp=123');
+  });
+
+  test('includes a `cache-control` header in redirect responses if so configured', async () => {
+    const sf      = await makeInstance({ cacheControl: 'florp=123' });
+    const request = RequestUtil.makeGet('/subdir2');
+    const result  = await sf.handleRequest(request, new DispatchInfo(PathKey.EMPTY, request.pathname));
+
+    expect(result).toBeInstanceOf(FullResponse);
+    expect(result.status).toBe(308);
     expect(result.cacheControl).toBe('florp=123');
   });
 

--- a/src/webapp-util/export/StaticFileResponder.js
+++ b/src/webapp-util/export/StaticFileResponder.js
@@ -375,7 +375,7 @@ export class StaticFileResponder {
       throw new Error('Invalid `indexFile` option (bad type).');
     }
 
-    if (!AskIf.arrayOfString(value, /(?!.*[/])/)) {
+    if (!AskIf.arrayOfString(value, /^(?!.*[/])/)) {
       throw new Error('Invalid `indexFile` option (bad contents).');
     }
 

--- a/src/webapp-util/export/StaticFileResponder.js
+++ b/src/webapp-util/export/StaticFileResponder.js
@@ -119,9 +119,7 @@ export class StaticFileResponder {
 
     const resolved = await this.resolvePath(dispatch);
 
-    return resolved
-      ? await this.makeResponse(request, resolved)
-      : null;
+    return this.makeResponse(request, resolved)
   }
 
   /**

--- a/src/webapp-util/export/StaticFileResponder.js
+++ b/src/webapp-util/export/StaticFileResponder.js
@@ -119,7 +119,7 @@ export class StaticFileResponder {
 
     const resolved = await this.resolvePath(dispatch);
 
-    return this.makeResponse(request, resolved)
+    return this.makeResponse(request, resolved);
   }
 
   /**

--- a/src/webapp-util/export/StaticFileResponder.js
+++ b/src/webapp-util/export/StaticFileResponder.js
@@ -3,12 +3,29 @@
 
 import fs from 'node:fs/promises';
 
-import { Statter } from '@this/fs-util';
-import { EtagGenerator, FullResponse, HttpUtil, IncomingRequest, MimeTypes }
+import { PathKey } from '@this/collections';
+import { Paths, Statter } from '@this/fs-util';
+import { IntfLogger } from '@this/loggy-intf';
+import { DispatchInfo, EtagGenerator, FullResponse, HttpUtil, IncomingRequest,
+  MimeTypes }
   from '@this/net-util';
 import { BaseConfig } from '@this/structy';
 import { AskIf } from '@this/typey';
 
+
+/**
+ * Return type from {@link #resolvePath}.
+ *
+ * @typedef {
+ *     { path: string, stats: fs.Stats }
+ *   | { redirect: string }
+ *   | null
+ * } TypeResolved
+ */
+
+// TODO: Remove this workaround when this `eslint-plugin-jsdoc` bug is fixed:
+// <https://github.com/gajus/eslint-plugin-jsdoc/issues/1347>
+const workaroundBug_unused = fs;
 
 /**
  * Class which makes static content responses in a standardized form. This is
@@ -18,24 +35,47 @@ import { AskIf } from '@this/typey';
  */
 export class StaticFileResponder {
   /**
+   * Absolute path of the base directory to find files in.
+   *
+   * @type {string}
+   */
+  #baseDirectory;
+
+  /**
    * `cache-control` header to automatically include, or `null` not to do that.
    *
    * @type {?string}
    */
-  #cacheControl = null;
+  #cacheControl;
 
   /**
    * Etag generator to use, or `null` if not using one.
    *
    * @type {?EtagGenerator}
    */
-  #etagGenerator = null;
+  #etagGenerator;
+
+  /**
+   * Index file(s) to look for, or `null` to treat directories as not-found.
+   *
+   * @type {?string[]}
+   */
+  #indexFile;
+
+  /**
+   * Logger to use, if any.
+   *
+   * @type {?IntfLogger}
+   */
+  #logger;
 
   /**
    * Constructs an instance.
    *
    * @param {?object} [config] Instance configuration, or `null` to use all
    *   defaults.
+   * @param {string} config.baseDirectory Absolute path of the base directory to
+   *   find files in. Required.
    * @param {?object|string} [config.cacheControl] `cache-control` header to
    *   automatically include, or `null` not to include it. Can be passed either
    *   as a literal string or an object to be passed to
@@ -43,38 +83,159 @@ export class StaticFileResponder {
    * @param {?object|true} [config.etag] Etag-generating options, `true` for
    *   standard options, or `null` not to include an `etag` header in responses.
    *   Default `null`.
+   * @param {?string|string[]} [config.indexFile] Possible index file names, or
+   *   `null` to treat directory requests as not-found. Default `null`.
    */
   constructor(config = null) {
-    const { cacheControl, etag } = new StaticFileResponder.#Config(config);
+    const { baseDirectory, cacheControl, etag, indexFile, logger } =
+      new StaticFileResponder.#Config(config);
 
+    this.#baseDirectory = baseDirectory;
     this.#cacheControl  = cacheControl;
     this.#etagGenerator = etag ? new EtagGenerator(etag) : null;
+    this.#indexFile     = indexFile;
+    this.#logger        = logger;
   }
 
   /**
-   * Makes a response for the given absolute path. If the path is not an
-   * existing file, this returns `null`.
+   * Performs full request handling, calling through to {@link #resolvePath},
+   * and &mdash; if the request could be handled &mdash; then on to
+   * {@link #makeResponse}.
+   *
+   * **Note:** This will only possibly return non-`null` on `GET` and `HEAD`
+   * requests.
    *
    * @param {IncomingRequest} request The original request.
-   * @param {string} absolutePath The path to provide a response for.
-   * @param {fs.Stats} [stats] The `stat()` result on the path, or `null` if not
-   *   known.
-   * @returns {?FullResponse} The response.
+   * @param {DispatchInfo} dispatch Dispatch info, indicating the partial path
+   *   to serve (in `extra`).
+   * @returns {?FullResponse} The response, or `null` if the request could not
+   *   be handled.
    */
-  async makeResponse(request, absolutePath, stats = null) {
-    if (!stats) {
-      stats = await Statter.statOrNull(absolutePath);
-      if (!stats) {
-        return null;
-      }
+  async handleRequest(request, dispatch) {
+    if (!request.isGetOrHead()) {
+      return null;
     }
 
-    const contentType = MimeTypes.typeFromPathExtension(absolutePath);
-    const rawResponse = new FullResponse();
+    const resolved = await this.resolvePath(dispatch);
+
+    return resolved
+      ? await this.makeResponse(request, resolved)
+      : null;
+  }
+
+  /**
+   * Makes a response, based on the given request along with a result from
+   * {@link #resolvePath}.
+   *
+   * @param {IncomingRequest} request The original request.
+   * @param {TypeResolved} resolved Return value from {@link #resolvePath}.
+   * @returns {?FullResponse} The response.
+   */
+  async makeResponse(request, resolved) {
+    if (!resolved) {
+      return null;
+    } else if (resolved.path) {
+      return this.#makeFileResponse(request, resolved);
+    } else if (resolved.redirect) {
+      return this.#makeRedirectResponse(resolved.redirect);
+    } else {
+      /* c8 ignore start */
+      // Shouldn't happen. If we get here, it's a bug in this class.
+      throw new Error('Shouldn\'t happen.');
+    }
+    /* c8 ignore stop */
+  }
+
+  /**
+   * Resolves the given dispatch `extra` path to a file, or indicates it should
+   * be redirected (if it refers to a directory but `extra` doesn't have the
+   * form of a directory request), or indicates that the path is not found.
+   *
+   * Special cases:
+   * * When asked to resolve a path in directory form (trailing slash),
+   *   if the path corresponds to a regular (non-directory) file, this method
+   *   will treat it as not-found.
+   * * Index files (searched for when responding to a directory request) will
+   *   only be found if they are in fact regular (non-directory) files.
+   *
+   * @param {DispatchInfo} dispatch Dispatch info containing the path to
+   *   resolve.
+   * @returns {TypeResolved} The absolute path and stat info of the file to
+   *   serve, the (relative) URL to redirect to, or `null` if given invalid
+   *   input or the indicated path is not found.
+   */
+  async resolvePath(dispatch) {
+    const decoded = StaticFileResponder.decodePath(dispatch.extra);
+
+    if (!decoded) {
+      return null;
+    }
+
+    const { path, isDirectory } = decoded;
+
+    // The conditional guarantees that the `fullPath` does not end with a slash,
+    // which makes the code below a bit simpler (because we care about only
+    // producing canonicalized paths that have no double slashes).
+    const fullPath = (path === '')
+      ? this.#baseDirectory
+      : `${this.#baseDirectory}/${path}`;
+    this.#logger?.fullPath(fullPath);
+
+    try {
+      const stats = await Statter.statOrNull(fullPath);
+      if (stats === null) {
+        this.#logger?.notFound(fullPath);
+        return null;
+      } else if (stats.isDirectory()) {
+        if (!isDirectory) {
+          // Redirect from non-ending-slash directory path. As a special case,
+          // `path === ''` happens when the mount point (base with regards to
+          // `dispatch`) was requested directly, without a final slash. So we
+          // need to look at the base to figure out what to redirect to.
+          const source = (path === '') ? dispatch.base.path : dispatch.extra.path;
+          return { redirect: `${source[source.length - 1]}/` };
+        } else {
+          // It's a proper directory reference. Look for the index file.
+          const indexPath  = `${fullPath}/index.html`;
+          const indexStats = await Statter.statOrNull(indexPath, true);
+          if (indexStats === null) {
+            this.#logger?.indexNotFound(indexPath);
+            return null;
+          } else if (indexStats.isDirectory()) {
+            // Weird case, to be clear!
+            this.#logger?.indexIsDirectory(indexPath);
+            return null;
+          }
+          return { path: indexPath, stats: indexStats };
+        }
+      } else if (isDirectory) {
+        // Non-directory file requested as if it is a directory (that is, with a
+        // final slash). Treated as not-found per method contract.
+        this.#logger?.fileIsDirectory(fullPath);
+        return null;
+      }
+      return { path: fullPath, stats };
+    } catch (e) {
+      this.#logger?.statError(fullPath, e);
+      return null;
+    }
+  }
+
+  /**
+   * Helper for {@link #makeResponse}, which makes a response to serve a file.
+   *
+   * @param {IncomingRequest} request The original request.
+   * @param {TypeResolved} resolved Result from {@link #resolvePath}.
+   * @returns {?FullResponse} The response.
+   */
+  async #makeFileResponse(request, resolved) {
+    const { path, stats } = resolved;
+    const contentType     = MimeTypes.typeFromPathExtension(path);
+    const rawResponse     = new FullResponse();
 
     rawResponse.status = 200;
     rawResponse.headers.set('content-type', contentType);
-    await rawResponse.setBodyFile(absolutePath, { stats });
+    await rawResponse.setBodyFile(path, { stats });
 
     if (this.#cacheControl) {
       rawResponse.cacheControl = this.#cacheControl;
@@ -82,12 +243,28 @@ export class StaticFileResponder {
 
     if (this.#etagGenerator) {
       rawResponse.headers.set('etag',
-        await this.#etagGenerator.etagFromFile(absolutePath));
+        await this.#etagGenerator.etagFromFile(path));
     }
 
     const { headers, method } = request;
     const response = rawResponse.adjustFor(
       method, headers, { conditional: true, range: true });
+
+    return response;
+  }
+
+  /**
+   * Helper for {@link #makeResponse}, which makes a redirect response.
+   *
+   * @param {string} redirect The path to redirect to.
+   * @returns {?FullResponse} The response.
+   */
+  #makeRedirectResponse(redirect) {
+    const response = FullResponse.makeRedirect(redirect, 308);
+
+    if (this.#cacheControl) {
+      response.cacheControl = this.#cacheControl;
+    }
 
     return response;
   }
@@ -98,13 +275,23 @@ export class StaticFileResponder {
   //
 
   /**
+   * Checks / accepts a `baseDirectory` option. This is the absolute path to the
+   * base directory for the files to serve.
+   *
+   * @param {string} value Proposed configuration value.
+   * @returns {string} Accepted configuration value.
+   */
+  static checkBaseDirectory(value) {
+    return Paths.checkAbsolutePath(value);
+  }
+
+  /**
    * Checks / accepts a `cacheControl` option. This is a `cache-control` header
    * to automatically include, or `null` not to include it. Can be passed either
    * as a literal string or an object to be passed to {@link
    * HttpUtil#cacheControlHeader}.
    *
-   * @param {?string|object} value Proposed configuration value. Default
-   *   `null`.
+   * @param {?string|object} value Proposed configuration value.
    * @returns {?string} Accepted configuration value.
    */
   static checkCacheControl(value) {
@@ -123,8 +310,7 @@ export class StaticFileResponder {
    * Checks / accepts etag-generating options, `true` for default options, or
    * `null` not to include an `etag` header in responses.
    *
-   * @param {?object|true} value Proposed configuration value. Default
-   *   `null`.
+   * @param {?object|true} value Proposed configuration value.
    * @returns {?object} Accepted configuration value.
    */
   static checkEtag(value) {
@@ -137,6 +323,37 @@ export class StaticFileResponder {
     } else {
       throw new Error('Invalid `etag` option.');
     }
+  }
+
+  /**
+   * Checks / accepts index file name options. This is a file name to look for,
+   * or a list of file names to look for in order, to use when responding to a
+   * request for a directory. If `null` or an empty array, plain directory
+   * requests get a not-found response. Names must not contain any slash (`/`)
+   * characters.
+   *
+   * @param {?string|string[]} value Proposed configuration value.
+   * @returns {?string[]} Accepted configuration value.
+   */
+  static checkIndexFile(value) {
+    if (value === null) {
+      return null;
+    } else if (typeof value === 'string') {
+      value = [value];
+    } else if (Array.isArray(value)) {
+      if (value.length === 0) {
+        return null;
+      }
+      value = [...value]; // Prevent caller from changing it out from under us.
+    } else {
+      throw new Error('Invalid `indexFile` option (bad type).');
+    }
+
+    if (!AskIf.arrayOfString(value, /(?!.*[/])/)) {
+      throw new Error('Invalid `indexFile` option (bad contents).');
+    }
+
+    return value;
   }
 
   /**
@@ -153,6 +370,7 @@ export class StaticFileResponder {
    * **Note:** This method does _not_ check to see if the resolved path actually
    * exists.
    *
+   * @param {PathKey} relativePath The relative path to decode.
    * @returns {?{ isDirectory: boolean, path: string }} The decoded path and
    *   is-a-directory flag, or `null` if it could not be decoded.
    */
@@ -160,7 +378,7 @@ export class StaticFileResponder {
     const parts       = [];
     let   isDirectory = false; // Is a directory? (Path ends with a slash?)
 
-    for (const p of relativePath) {
+    for (const p of relativePath.path) {
       if (isDirectory) {
         // We got an empty path component _not_ at the end of the path.
         return null;
@@ -202,6 +420,16 @@ export class StaticFileResponder {
     // @defaultConstructor
 
     /**
+     * Absolute path to the base directory for the files to serve.
+     *
+     * @param {string} value Proposed configuration value.
+     * @returns {string} Accepted configuration value.
+     */
+    _config_baseDirectory(value) {
+      return StaticFileResponder.checkBaseDirectory(value);
+    }
+
+    /**
      * `cache-control` header to automatically include, or `null` not to
      * include it. Can be passed either as a literal string or an object to be
      * passed to {@link HttpUtil#cacheControlHeader}.
@@ -224,6 +452,31 @@ export class StaticFileResponder {
      */
     _config_etag(value = null) {
       return StaticFileResponder.checkEtag(value);
+    }
+
+    /**
+     * A file name to look for, or a list of file names to look for in order, to
+     * use when responding to a request for a directory. If `null` or an empty
+     * array, plain directory requests get a not-found response. Names must not
+     * contain any slash (`/`) characters.
+     *
+     * @param {?string|string[]} [value] Proposed configuration value. Default
+     *   `null`.
+     * @returns {?string[]} Accepted configuration value.
+     */
+    _config_indexFile(value = null) {
+      return StaticFileResponder.checkIndexFile(value);
+    }
+
+    /**
+     * Logger to use, if any.
+     *
+     * @param {?IntfLogger} [value] Proposed configuration value. Default
+     *   `null`.
+     * @returns {?IntfLogger} Accepted configuration value.
+     */
+    _config_logger(value = null) {
+      return IntfLogger.expectInstanceOrNull(value);
     }
   };
 }

--- a/tests/03-http2/01-basic/expect.md
+++ b/tests/03-http2/01-basic/expect.md
@@ -17,6 +17,7 @@
   <h1>Hello!</h1>
   <ul>
     <li><a href="avec-index">avec-index/</a></li>
+    <li><a href="avec-index">avec-index-txt/</a></li>
     <li>florp/
       <ul>
         <li><a href="florp/boop.html">boop.html</a></li>

--- a/tests/03-http2/01-basic/run.mjs
+++ b/tests/03-http2/01-basic/run.mjs
@@ -16,7 +16,7 @@ await requestAndCheck(
     headers: {
       'accept-ranges':  'bytes',
       'cache-control':  'public, max-age=300',
-      'content-length': '677',
+      'content-length': '731',
       'content-type':   'text/html; charset=utf-8',
       'etag':           /^"[-+/0-9a-zA-Z]+"$/,
       'last-modified':  /^[,: a-zA-Z0-9]+ GMT$/

--- a/tests/04-https/01-basic/expect.md
+++ b/tests/04-https/01-basic/expect.md
@@ -17,6 +17,7 @@
   <h1>Hello!</h1>
   <ul>
     <li><a href="avec-index">avec-index/</a></li>
+    <li><a href="avec-index">avec-index-txt/</a></li>
     <li>florp/
       <ul>
         <li><a href="florp/boop.html">boop.html</a></li>

--- a/tests/04-https/01-basic/run.mjs
+++ b/tests/04-https/01-basic/run.mjs
@@ -16,7 +16,7 @@ await requestAndCheck(
     headers: {
       'accept-ranges':  'bytes',
       'cache-control':  'public, max-age=300',
-      'content-length': '677',
+      'content-length': '731',
       'content-type':   'text/html; charset=utf-8',
       'etag':           /^"[-+/0-9a-zA-Z]+"$/,
       'last-modified':  /^[,: a-zA-Z0-9]+ GMT$/


### PR DESCRIPTION
This PR is all about static file stuff:

* Extracted more functionality from `StaticFiles` into `StaticFileResponder`.
* New configuration option `indexFile` (on both classes) which lets you specify what file(s) are looked for when responding to directory requests.
* Slightly improved test coverage on these files.