### PR TITLE
New `*ElseNull()` method naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
-* general:
+* framework API (general):
   * Defined a new `*ElseNull()` method naming convention, to use instead of
     `*OrNull*()`, clarifying the contexts in which each is appropriate. As a
     result, renamed a bunch of methods throughout the system.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ versioning principles. Unstable releases do not.
 
 Breaking changes:
 * general:
-  * Defined a new `*ElseNull()` method name coding convention, to use instead of
+  * Defined a new `*ElseNull()` method naming convention, to use instead of
     `*OrNull*()`, clarifying the contexts in which each is appropriate. As a
     result, renamed a bunch of methods throughout the system.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -628,7 +628,7 @@ Other notable changes:
 
 ### v0.6.10 -- 2024-03-15
 
-It's Fast(ish) Follow Friday!
+It's Fast-ish Follow Friday!
 
 Breaking changes:
 * Request logging: Stopped quoting URLs, as there was no need. (They won't have
@@ -777,7 +777,7 @@ Other notable changes:
     request stuff, including for conditional ranges.
   * Extracted new class `HttpRange` from `net-protocol.Request`, for range
     request handling.
-  * New class `HttpResponse` to encapsulate data required to make an HTTP(ish)
+  * New class `HttpResponse` to encapsulate data required to make an HTTP-ish
     response and to handle much of the mechanics of actually producing a
     response. Notably, it does _not_ use Express-specific functionality.
 * Changed all the built-in applications to construct `HttpResponse` objects
@@ -850,7 +850,7 @@ Other notable changes:
 Breaking changes:
 * Renamed most `url`-named properties on `Request` to instead use the term
   `target`. This represents a divergence from Node, which confusingly uses the
-  property name `url` to refer to an HTTP(ish) request target, even though it
+  property name `url` to refer to an HTTP-ish request target, even though it
   isn't actually ever a URL per se except when the server is being called as a
   proxy (and not just a regular webserver).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
-* None.
+* general:
+  * Defined a new `*ElseNull()` method name coding convention, to use instead of
+    `*OrNull*()`, clarifying the contexts in which each is appropriate. As a
+    result, renamed a bunch of methods throughout the system.
 
 Other notable changes:
 * `net-util`:

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -91,32 +91,59 @@ use the following comment in place of an intentionally omitted constructor:
 
 ### Member naming (and details)
 
-* `_config_<name>` &mdash; Method defined by configuration classes which are
+#### Prefixes
+
+* `_config_<name>()` &mdash; Method defined by configuration classes which are
   (direct or indirect) subclasses of `structy.BaseConfig`. Each such method
   is responsible for validating and parsing/converting the correspondingly named
   property of a plain-object configuration.
 
-* `_impl_<name>` &mdash; Declared in base classes, _either_ as abstract and left
-  for subclasses to fill in (as specified by the base class), or with a
+* `_impl_<name>()` &mdash; Declared in base classes, _either_ as abstract and
+  left for subclasses to fill in (as specified by the base class), or with a
   reasonable default implementation. _Not_ supposed to be called except by the
   defining base class (not even subclasses). These are more or less `protected`
   and methods declared by a base class, often (but not always) also `abstract`.
 
-* `_prop_<name>` &mdash; Method defined by struct classes which are (direct or
+  With very few exceptions, members _not_ marked with `_impl_` should be treated
+  as effectively `final`, that is, not to be overridden.
+
+* `_prop_<name>()` &mdash; Method defined by struct classes which are (direct or
   indirect) subclasses of `structy.BaseStruct`. Each such method is
   responsible for validating and parsing/converting the correspondingly named
   property of a plain-object configuration.
 
-* `_prot_<name>` &mdash; Defined in base classes and _not_ to be overridden. To
-  be called by subclasses; _not_ supposed to be used outside of the class. These
-  are more or less `protected final` methods defined by a base class.
+* `_prot_<name>()` &mdash; Defined in base classes and _not_ to be overridden.
+  To be called by subclasses; _not_ supposed to be used outside of the class.
+  These are more or less `protected final` methods defined by a base class.
 
-* `_testing_<name>` &mdash; Methods whose sole purpose is to do instance
+* `_testing_<name>()` &mdash; Methods whose sole purpose is to do instance
   introspection (and generally, break encapsulation) in order to make unit
   testing a little less painful.
 
-With very few exceptions, members _not_ marked with `_impl_` should be treated
-as effectively `final`, that is, not to be overridden.
+#### "Morphemes"
+
+* `<thing>From<thing>()` &mdash; This is the general pattern for converting one
+  sort of thing to another. It is phrased in terms of "from" so that the thing
+  names are close to the named things. For example, in `foo = fooFromBar(bar)`,
+  the `bar` parameter is next to the `Bar` label, and the returned `foo` is next
+  to the `foo` label.
+
+* `*<thing>OrNull*()` &mdash; Indicates that a method either accepts or returns
+  (depending on context) a "nullable" type without considering `null` to be an
+  error. For example, `fooOrNullFromString()` would accept a `string` (not
+  `null`) and return either a `foo` or `null`. And `fooFromStringOrNull()`
+  would accept either a `string` or `null` and always return a `foo` (never
+  `null`).
+
+* `*ElseNull()` &mdash; Indicates that a method will return `null` if there is
+  an error, as opposed to throwing an `Error`. For example, contrast
+  `fooFromStringOrNull()` (see previous bullet), `fooOrNullFromString()` (same),
+  and `fooFromStringElseNull()`. The last one only considers a `string` to be
+  a valid argument (not `null`), and it will return `null` to indicate an error
+  (and not an "expected" return value). With type conversion methods, the
+  distinction is sometimes a bit arbitrary, but the pattern `*ElseNull()` can
+  also be used in non-conversion contexts, e.g. `findFooElseNull()`, where the
+  distinction is more meaningful.
 
 ### Ledger of arbitrary decisions
 

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -142,6 +142,9 @@ use the following comment in place of an intentionally omitted constructor:
   a valid argument (not `null`), and it will return `null` to indicate an error
   (and not an "expected" return value).
 
+  This pattern is often used along side methods with the same name but _without_
+  the `ElseNull` suffix which _do_ throw `Error`s.
+
   With type conversion methods, the distinction is sometimes a bit arbitrary,
   but the pattern `*ElseNull()` can also be used in non-conversion contexts.
   For example, in `findFooElseNull()`, the distinction is more meaningful. And
@@ -168,6 +171,10 @@ meant to record them, in order to keep track of them and maintain consistency.
   ```js
   // @emptyBlock
   ```
+
+* Methods that throw `Error`s when encountering trouble aren't specially marked.
+  However, methods that return `null` to indicate an error _are_ marked with the
+  suffix `ElseNull`. (See above.)
 
 * Terminology:
   * Use "HTTP1" or "HTTP1-ish" to refer to the HTTP1 family of protocols. (No

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -140,10 +140,13 @@ use the following comment in place of an intentionally omitted constructor:
   `fooFromStringOrNull()` (see previous bullet), `fooOrNullFromString()` (same),
   and `fooFromStringElseNull()`. The last one only considers a `string` to be
   a valid argument (not `null`), and it will return `null` to indicate an error
-  (and not an "expected" return value). With type conversion methods, the
-  distinction is sometimes a bit arbitrary, but the pattern `*ElseNull()` can
-  also be used in non-conversion contexts, e.g. `findFooElseNull()`, where the
-  distinction is more meaningful.
+  (and not an "expected" return value).
+
+  With type conversion methods, the distinction is sometimes a bit arbitrary,
+  but the pattern `*ElseNull()` can also be used in non-conversion contexts.
+  For example, in `findFooElseNull()`, the distinction is more meaningful. And
+  in `expectFooOrNull()` it is clear that the expectation is for a "nullable"
+  `foo` and not that the method is allowed to return `null` in case of error.
 
 ### Ledger of arbitrary decisions
 

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -136,11 +136,12 @@ use the following comment in place of an intentionally omitted constructor:
   `null`).
 
 * `*ElseNull()` &mdash; Indicates that a method will return `null` if there is
-  a reasonably-expected error, as opposed to throwing an `Error`. For example,
-  contrast `fooFromStringOrNull()` (see previous bullet),
-  `fooOrNullFromString()` (same), and `fooFromStringElseNull()`. The last one
-  only considers a `string` to be a valid argument (not `null`), and it will
-  return `null` to indicate an error (and not an "expected" return value).
+  a reasonably-expected error or error-like condition, as opposed to throwing an
+  `Error` in such cases. For example, contrast `fooFromStringOrNull()` (see
+  previous bullet), `fooOrNullFromString()` (same), and
+  `fooFromStringElseNull()`. The last one only considers a `string` to be a
+  valid argument (not `null`), and it will return `null` to indicate an error
+  (and not an "expected" return value).
 
   This pattern is often used along side methods with the same name but _without_
   the `ElseNull` suffix which _do_ throw `Error`s.

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -136,14 +136,18 @@ use the following comment in place of an intentionally omitted constructor:
   `null`).
 
 * `*ElseNull()` &mdash; Indicates that a method will return `null` if there is
-  an error, as opposed to throwing an `Error`. For example, contrast
-  `fooFromStringOrNull()` (see previous bullet), `fooOrNullFromString()` (same),
-  and `fooFromStringElseNull()`. The last one only considers a `string` to be
-  a valid argument (not `null`), and it will return `null` to indicate an error
-  (and not an "expected" return value).
+  a reasonably-expected error, as opposed to throwing an `Error`. For example,
+  contrast `fooFromStringOrNull()` (see previous bullet),
+  `fooOrNullFromString()` (same), and `fooFromStringElseNull()`. The last one
+  only considers a `string` to be a valid argument (not `null`), and it will
+  return `null` to indicate an error (and not an "expected" return value).
 
   This pattern is often used along side methods with the same name but _without_
   the `ElseNull` suffix which _do_ throw `Error`s.
+
+  Note that with this suffix, a method may draw a distinction between what is
+  an "expected" error (suitable for returning `null`) and an "unexpected" error
+  (which is cause for a `throw`).
 
   With type conversion methods, the distinction is sometimes a bit arbitrary,
   but the pattern `*ElseNull()` can also be used in non-conversion contexts.

--- a/src/compy/export/ControlContext.js
+++ b/src/compy/export/ControlContext.js
@@ -203,7 +203,7 @@ export class ControlContext {
    * @throws {Error} Thrown if a suitable instance was not found.
    */
   getComponent(path, ...classes) {
-    const result = this.#root.getComponentOrNull(path, ...classes);
+    const result = this.#root.getComponentElseNull(path, ...classes);
 
     if (result === null) {
       path = Names.parsePossiblyNullPath(path);
@@ -232,8 +232,8 @@ export class ControlContext {
    * @returns {?BaseComponent} Found instance, or `null` if there was none.
    * @throws {Error} Thrown if a suitable instance was not found.
    */
-  getComponentOrNull(path, ...classes) {
-    return this.#root.getComponentOrNull(path, ...classes);
+  getComponentElseNull(path, ...classes) {
+    return this.#root.getComponentElseNull(path, ...classes);
   }
 
   /**

--- a/src/compy/export/RootControlContext.js
+++ b/src/compy/export/RootControlContext.js
@@ -58,7 +58,7 @@ export class RootControlContext extends ControlContext {
   }
 
   /** @override */
-  getComponentOrNull(path, ...classes) {
+  getComponentElseNull(path, ...classes) {
     path = Names.parsePossiblyNullPath(path);
 
     if (!path) {

--- a/src/fs-util/export/Statter.js
+++ b/src/fs-util/export/Statter.js
@@ -18,7 +18,7 @@ export class Statter {
    * @returns {boolean} The answer.
    */
   static async directoryExists(path) {
-    const stats = await this.statOrNull(path);
+    const stats = await this.statElseNull(path);
 
     return stats ? stats.isDirectory() : false;
   }
@@ -31,7 +31,7 @@ export class Statter {
    * @returns {boolean} The answer.
    */
   static async fileExists(path) {
-    const stats = await this.statOrNull(path);
+    const stats = await this.statElseNull(path);
 
     return stats ? stats.isFile() : false;
   }
@@ -44,7 +44,7 @@ export class Statter {
    * @returns {boolean} The answer.
    */
   static async pathExists(path) {
-    const stats = await this.statOrNull(path);
+    const stats = await this.statElseNull(path);
 
     return (stats !== null);
   }
@@ -56,7 +56,7 @@ export class Statter {
    * @returns {boolean} The answer.
    */
   static async socketExists(path) {
-    const stats = await this.statOrNull(path);
+    const stats = await this.statElseNull(path);
 
     return stats ? stats.isSocket() : false;
   }
@@ -70,7 +70,7 @@ export class Statter {
    * @param {string} path Path to check.
    * @returns {?fs.Stats} The stats, if the path exists, or `null` if not.
    */
-  static async statOrNull(path) {
+  static async statElseNull(path) {
     MustBe.string(path);
 
     try {

--- a/src/fs-util/tests/Statter.test.js
+++ b/src/fs-util/tests/Statter.test.js
@@ -109,20 +109,20 @@ ${'socketExists'}    | ${false}     | ${false}      | ${true}
   });
 });
 
-describe('statOrNull()', () => {
+describe('statElseNull()', () => {
   test('returns `null` for a non-existent path', async () => {
-    const got = await Statter.statOrNull('/boop/beep/blorp');
+    const got = await Statter.statElseNull('/boop/beep/blorp');
     expect(got).toBeNull();
   });
 
   test('returns a file-result `Stats` for an existing file', async () => {
-    const got = await Statter.statOrNull(knownFile);
+    const got = await Statter.statElseNull(knownFile);
     expect(got).not.toBeNull();
     expect(got.isFile()).toBeTrue();
   });
 
   test('returns a directory-result `Stats` for an existing directory', async () => {
-    const got = await Statter.statOrNull(knownDir);
+    const got = await Statter.statElseNull(knownDir);
     expect(got).not.toBeNull();
     expect(got.isDirectory()).toBeTrue();
   });

--- a/src/net-protocol/private/AsyncServerSocket.js
+++ b/src/net-protocol/private/AsyncServerSocket.js
@@ -84,7 +84,7 @@ export class AsyncServerSocket {
    * address and current-listening info.
    */
   get infoForLog() {
-    const address = InterfaceAddress.fromNodeServerOrNull(this.#serverSocket);
+    const address = InterfaceAddress.fromNodeServerElseNull(this.#serverSocket);
 
     return {
       protocol:  this.#protocol,

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -118,12 +118,13 @@ export class Cookies extends IntfDeconstructable {
   }
 
   /**
-   * Gets a cookie value, if there is a so-named cookie.
+   * Like {@link #getValue}, except returning `null` if there no so-named
+   * cookie.
    *
    * @param {string} name Cookie name.
    * @returns {?string} Cookie value, or `null` if not found.
    */
-  getValueOrNull(name) {
+  getValueElseNull(name) {
     return this.getAttributesOrNull(name)?.value ?? null;
   }
 

--- a/src/net-util/export/Cookies.js
+++ b/src/net-util/export/Cookies.js
@@ -85,7 +85,7 @@ export class Cookies extends IntfDeconstructable {
    * @throws {Error} Thrown if `name` is not bound.
    */
   getAttributes(name) {
-    const result = this.getAttributesOrNull(name);
+    const result = this.getAttributesElseNull(name);
 
     if (result !== null) {
       return result;
@@ -95,14 +95,15 @@ export class Cookies extends IntfDeconstructable {
   }
 
   /**
-   * Gets a cookie value, if available.
+   * Like {@link #getAttributes}, except returning `null` if there no so-named
+   * cookie.
    *
    * @param {string} name Cookie name.
    * @returns {?object} Cookie attributes, as a frozen object, or `null` if
    *   there is no such cookie. In addition to the attributes from the original
    *   call to {@link #set}, this also includes `name` and `value` properties.
    */
-  getAttributesOrNull(name) {
+  getAttributesElseNull(name) {
     return this.#attributes.get(name) ?? null;
   }
 
@@ -125,7 +126,7 @@ export class Cookies extends IntfDeconstructable {
    * @returns {?string} Cookie value, or `null` if not found.
    */
   getValueElseNull(name) {
-    return this.getAttributesOrNull(name)?.value ?? null;
+    return this.getAttributesElseNull(name)?.value ?? null;
   }
 
   /**

--- a/src/net-util/export/EndpointAddress.js
+++ b/src/net-util/export/EndpointAddress.js
@@ -127,7 +127,7 @@ export class EndpointAddress extends IntfDeconstructable {
    *   address.
    */
   static canonicalizeAddress(value, allowAny = false) {
-    const result = this.canonicalizeAddressOrNull(value, allowAny);
+    const result = this.canonicalizeAddressElseNull(value, allowAny);
 
     if (result) {
       return result;
@@ -147,7 +147,7 @@ export class EndpointAddress extends IntfDeconstructable {
    *   could not be parsed.
    * @throws {Error} Thrown if `value` is not a string.
    */
-  static canonicalizeAddressOrNull(value, allowAny = false) {
+  static canonicalizeAddressElseNull(value, allowAny = false) {
     MustBe.string(value);
 
     return this.#canonicalizeAddressV4(value, allowAny)

--- a/src/net-util/export/EtagGenerator.js
+++ b/src/net-util/export/EtagGenerator.js
@@ -139,7 +139,7 @@ export class EtagGenerator {
   async etagFromFileData(absolutePath) {
     Paths.checkAbsolutePath(absolutePath);
 
-    const stats = await Statter.statOrNull(absolutePath);
+    const stats = await Statter.statElseNull(absolutePath);
     if (!stats) {
       return null;
     } else if (!stats.isFile()) {

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -240,7 +240,7 @@ export class HostInfo {
     const { hostname, port } = topParse;
 
     // Refined `hostname` check, along with IP address canonicalization.
-    const canonicalHostname = HostUtil.checkHostnameOrNull(hostname, false);
+    const canonicalHostname = HostUtil.checkHostnameElseNull(hostname, false);
 
     if (!canonicalHostname) {
       return null;

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -202,7 +202,7 @@ export class HostInfo {
    * @throws {Error} Thrown if there was parsing trouble.
    */
   static parseHostHeader(hostString, localPort = null) {
-    const result = this.parseHostHeaderOrNull(hostString, localPort);
+    const result = this.parseHostHeaderElseNull(hostString, localPort);
 
     if (!result) {
       throw this.#parsingError(hostString);
@@ -220,7 +220,7 @@ export class HostInfo {
    * @returns {?HostInfo} The parsed info, or `null` if `hostString` was
    *   syntactically invalid.
    */
-  static parseHostHeaderOrNull(hostString, localPort = null) {
+  static parseHostHeaderElseNull(hostString, localPort = null) {
     MustBe.string(hostString);
 
     if (localPort !== null) {
@@ -268,7 +268,7 @@ export class HostInfo {
    * @returns {HostInfo} The parsed info.
    */
   static safeParseHostHeader(hostString, localPort = null) {
-    return this.parseHostHeaderOrNull(hostString, localPort)
+    return this.parseHostHeaderElseNull(hostString, localPort)
       ?? this.localhostInstance(localPort);
   }
 

--- a/src/net-util/export/HostUtil.js
+++ b/src/net-util/export/HostUtil.js
@@ -49,7 +49,7 @@ export class HostUtil {
    */
   static checkHostname(name, allowWildcard = false) {
     // Handle IP address cases.
-    const canonicalIp = EndpointAddress.canonicalizeAddressOrNull(name, false);
+    const canonicalIp = EndpointAddress.canonicalizeAddressElseNull(name, false);
     if (canonicalIp) {
       return canonicalIp;
     }
@@ -75,7 +75,7 @@ export class HostUtil {
    */
   static checkHostnameOrNull(name, allowWildcard = false) {
     // Handle IP address cases.
-    const canonicalIp = EndpointAddress.canonicalizeAddressOrNull(name, false);
+    const canonicalIp = EndpointAddress.canonicalizeAddressElseNull(name, false);
     if (canonicalIp) {
       return canonicalIp;
     }
@@ -147,7 +147,7 @@ export class HostUtil {
     MustBe.string(name);
 
     // Handle IP address cases.
-    const canonicalIp = EndpointAddress.canonicalizeAddressOrNull(name, false);
+    const canonicalIp = EndpointAddress.canonicalizeAddressElseNull(name, false);
     if (canonicalIp) {
       return new PathKey([canonicalIp], false);
     }

--- a/src/net-util/export/HostUtil.js
+++ b/src/net-util/export/HostUtil.js
@@ -73,7 +73,7 @@ export class HostUtil {
    *   pattern, canonicalized if it is an IP address. Returns `null` to indicate
    *   a parsing error.
    */
-  static checkHostnameOrNull(name, allowWildcard = false) {
+  static checkHostnameElseNull(name, allowWildcard = false) {
     // Handle IP address cases.
     const canonicalIp = EndpointAddress.canonicalizeAddressElseNull(name, false);
     if (canonicalIp) {

--- a/src/net-util/export/HostUtil.js
+++ b/src/net-util/export/HostUtil.js
@@ -125,7 +125,7 @@ export class HostUtil {
    * @throws {Error} Thrown if `name` is invalid.
    */
   static parseHostname(name, allowWildcard = false) {
-    const result = this.parseHostnameOrNull(name, allowWildcard);
+    const result = this.parseHostnameElseNull(name, allowWildcard);
 
     if (result) {
       return result;
@@ -143,7 +143,7 @@ export class HostUtil {
    * @param {boolean} [allowWildcard] Is a wildcard form allowed for `name`?
    * @returns {?PathKey} Parsed key, or `null` if `name` is invalid.
    */
-  static parseHostnameOrNull(name, allowWildcard = false) {
+  static parseHostnameElseNull(name, allowWildcard = false) {
     MustBe.string(name);
 
     // Handle IP address cases.

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -191,7 +191,7 @@ export class IncomingRequest {
    */
   get cookies() {
     if (!this.#cookies) {
-      const cookieStr = this.getHeaderOrNull('cookie');
+      const cookieStr = this.getHeaderElseNull('cookie');
       const result    = cookieStr ? Cookies.parse(cookieStr) : null;
 
       this.#cookies = result ? Object.freeze(result) : Cookies.EMPTY;
@@ -414,14 +414,15 @@ export class IncomingRequest {
   }
 
   /**
-   * Gets a request header, by name.
+   * Gets a request header, by name, returning `null` if there was no such
+   * header.
    *
    * @param {string} name The header name.
    * @returns {?string|Array<string>} The corresponding value, or `null` if
    *   there was no such header. The only case where an array is returned is for
    *   the very special name `set-coookie`.
    */
-  getHeaderOrNull(name) {
+  getHeaderElseNull(name) {
     return (name === 'set-cookie')
       ? this.headers.getSetCookie()
       : this.headers.get(name);

--- a/src/net-util/export/IncomingRequest.js
+++ b/src/net-util/export/IncomingRequest.js
@@ -139,7 +139,7 @@ export class IncomingRequest {
    * @param {?IntfLogger} [config.logger] Logger to use as a base, or `null` to
    *   not do any logging. If passed as non-`null`, the actual logger instance
    *   will be one that includes an additional subtag representing a new
-   *   unique(ish) ID for the request.
+   *   unique-ish ID for the request.
    * @param {string} config.protocolName The protocol name. This is expected to
    *   be a lowercase name followed by a dash and a version, e.g. `http-1.1`.
    * @param {HttpHeaders} config.pseudoHeaders HTTP2-ish "pseudo-headers" that
@@ -532,7 +532,7 @@ export class IncomingRequest {
    * @param {?IntfLogger} [options.logger] Logger to use as a base, or `null`
    *   not to do any logging. If passed as non-`null`, the actual logger
    *   instance will be one that includes an additional subtag representing a
-   *   new unique(ish) ID for the request.
+   *   new unique-ish ID for the request.
    * @param {?number} [options.maxRequestBodyBytes] Maximum size allowed for a
    *   request body, in bytes, or `null` not to have a limit. Note that not
    *   having a limit is often ill-advised. If non-`null`, must be a

--- a/src/net-util/export/InterfaceAddress.js
+++ b/src/net-util/export/InterfaceAddress.js
@@ -364,7 +364,7 @@ export class InterfaceAddress extends IntfDeconstructable {
    * @returns {?InterfaceAddress} Instance of this class representing the
    *   server's interface, or `null` if `server` is not currently listening.
    */
-  static fromNodeServerOrNull(server) {
+  static fromNodeServerElseNull(server) {
     const nodeAddress = server?.address();
 
     if (!nodeAddress) {

--- a/src/net-util/export/InterfaceAddress.js
+++ b/src/net-util/export/InterfaceAddress.js
@@ -326,7 +326,7 @@ export class InterfaceAddress extends IntfDeconstructable {
    * @throws {Error} Thrown if `value` does not match.
    */
   static canonicalizeAddress(value) {
-    const canonicalIp = EndpointAddress.canonicalizeAddressOrNull(value, false);
+    const canonicalIp = EndpointAddress.canonicalizeAddressElseNull(value, false);
     if (canonicalIp) {
       return canonicalIp;
     }

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -171,11 +171,11 @@ describe('getValue()', () => {
   });
 });
 
-describe('getValueOrNull()', () => {
+describe('getValueElseNull()', () => {
   test('returns `null` if a cookie is not found', () => {
     const cookies = new Cookies();
 
-    expect(cookies.getValueOrNull('florp')).toBeNull();
+    expect(cookies.getValueElseNull('florp')).toBeNull();
   });
 
   test('finds a cookie that was set', () => {
@@ -185,7 +185,7 @@ describe('getValueOrNull()', () => {
 
     cookies.set(name, value);
 
-    expect(cookies.getValueOrNull(name)).toBe(value);
+    expect(cookies.getValueElseNull(name)).toBe(value);
   });
 });
 

--- a/src/net-util/tests/Cookies.test.js
+++ b/src/net-util/tests/Cookies.test.js
@@ -119,11 +119,11 @@ describe('getAttributes()', () => {
   });
 });
 
-describe('getAttributesOrNull()', () => {
+describe('getAttributesElseNull()', () => {
   test('returns `null` if a cookie is not found', () => {
     const cookies = new Cookies();
 
-    expect(cookies.getAttributesOrNull('florp')).toBeNull();
+    expect(cookies.getAttributesElseNull('florp')).toBeNull();
   });
 
   test('finds a cookie that was set', () => {
@@ -134,7 +134,7 @@ describe('getAttributesOrNull()', () => {
 
     cookies.set(name, value, att);
 
-    expect(cookies.getAttributesOrNull(name)).toEqual({
+    expect(cookies.getAttributesElseNull(name)).toEqual({
       name,
       value,
       ...att
@@ -149,7 +149,7 @@ describe('getAttributesOrNull()', () => {
 
     cookies.set(name, value, att);
 
-    expect(cookies.getAttributesOrNull(name)).toBeFrozen();
+    expect(cookies.getAttributesElseNull(name)).toBeFrozen();
   });
 });
 

--- a/src/net-util/tests/EndpointAddress.test.js
+++ b/src/net-util/tests/EndpointAddress.test.js
@@ -131,9 +131,9 @@ describe('toString()', () => {
 //
 
 describe.each`
-method                         | throws
-${'canonicalizeAddress'}       | ${true}
-${'canonicalizeAddressOrNull'} | ${false}
+method                           | throws
+${'canonicalizeAddress'}         | ${true}
+${'canonicalizeAddressElseNull'} | ${false}
 `('$method()', ({ method, throws }) => {
   // Failures from passing non-strings. These are always supposed to throw.
   test.each`

--- a/src/net-util/tests/HostInfo.test.js
+++ b/src/net-util/tests/HostInfo.test.js
@@ -219,10 +219,10 @@ describe('localhostInstance()', () => {
 });
 
 describe.each`
-methodName                 | onError
-${'parseHostHeader'}       | ${'throws'}
-${'parseHostHeaderOrNull'} | ${'null'}
-${'safeParseHostHeader'}   | ${'localhost'}
+methodName                   | onError
+${'parseHostHeader'}         | ${'throws'}
+${'parseHostHeaderElseNull'} | ${'null'}
+${'safeParseHostHeader'}     | ${'localhost'}
 `('$methodName', ({ methodName, onError }) => {
   // Type failure cases. These should throw even in the "safe" versions.
   test.each`

--- a/src/net-util/tests/HostUtil.test.js
+++ b/src/net-util/tests/HostUtil.test.js
@@ -84,7 +84,7 @@ ${'parseHostnameOrNull'} | ${false} | ${'path'}
   const checkAnswer = (hostname, got) => {
     expect(got).not.toBeNull();
 
-    const canonicalIp = EndpointAddress.canonicalizeAddressOrNull(hostname, false);
+    const canonicalIp = EndpointAddress.canonicalizeAddressElseNull(hostname, false);
 
     if (returns === 'string') {
       if (canonicalIp) {

--- a/src/net-util/tests/HostUtil.test.js
+++ b/src/net-util/tests/HostUtil.test.js
@@ -6,11 +6,11 @@ import { EndpointAddress, HostUtil } from '@this/net-util';
 
 
 describe.each`
-method                   | throws   | returns
-${'checkHostname'}       | ${true}  | ${'string'}
-${'checkHostnameOrNull'} | ${false} | ${'string'}
-${'parseHostname'}       | ${true}  | ${'path'}
-${'parseHostnameOrNull'} | ${false} | ${'path'}
+method                     | throws   | returns
+${'checkHostname'}         | ${true}  | ${'string'}
+${'checkHostnameOrNull'}   | ${false} | ${'string'}
+${'parseHostname'}         | ${true}  | ${'path'}
+${'parseHostnameElseNull'} | ${false} | ${'path'}
 `('$method()', ({ method, throws, returns }) => {
   const LONGEST_COMPONENT = 'x'.repeat(63);
   const LONGEST_NAME      = `${'florp.'.repeat(41)}vwxyz.com`;

--- a/src/net-util/tests/HostUtil.test.js
+++ b/src/net-util/tests/HostUtil.test.js
@@ -8,7 +8,7 @@ import { EndpointAddress, HostUtil } from '@this/net-util';
 describe.each`
 method                     | throws   | returns
 ${'checkHostname'}         | ${true}  | ${'string'}
-${'checkHostnameOrNull'}   | ${false} | ${'string'}
+${'checkHostnameElseNull'} | ${false} | ${'string'}
 ${'parseHostname'}         | ${true}  | ${'path'}
 ${'parseHostnameElseNull'} | ${false} | ${'path'}
 `('$method()', ({ method, throws, returns }) => {

--- a/src/net-util/tests/IncomingRequest.test.js
+++ b/src/net-util/tests/IncomingRequest.test.js
@@ -42,7 +42,7 @@ describe('cookies', () => {
       cookie: 'blorp=bleep'
     });
 
-    expect(req.cookies.getValueOrNull('blorp')).toBe('bleep');
+    expect(req.cookies.getValueElseNull('blorp')).toBe('bleep');
   });
 });
 

--- a/src/net-util/tests/IncomingRequest.test.js
+++ b/src/net-util/tests/IncomingRequest.test.js
@@ -46,13 +46,13 @@ describe('cookies', () => {
   });
 });
 
-describe('getHeaderOrNull', () => {
+describe('getHeaderElseNull', () => {
   test('finds an existing header', () => {
     const req = makeWithHeaders({
       beep: 'boop'
     });
 
-    expect(req.getHeaderOrNull('beep')).toBe('boop');
+    expect(req.getHeaderElseNull('beep')).toBe('boop');
   });
 
   test('returns `null` for a nonexistent header', () => {
@@ -60,7 +60,7 @@ describe('getHeaderOrNull', () => {
       beep: 'boop'
     });
 
-    expect(req.getHeaderOrNull('blomp')).toBeNull();
+    expect(req.getHeaderElseNull('blomp')).toBeNull();
   });
 
   test('returns the empty array for a nonexistent `set-cookie` header', () => {
@@ -68,6 +68,6 @@ describe('getHeaderOrNull', () => {
       beep: 'boop'
     });
 
-    expect(req.getHeaderOrNull('set-cookie')).toEqual([]);
+    expect(req.getHeaderElseNull('set-cookie')).toEqual([]);
   });
 });

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -59,7 +59,7 @@ export class SimpleResponse extends BaseApplication {
     const headers   = response.headers;
 
     if (filePath) {
-      const stats = await Statter.statOrNull(filePath);
+      const stats = await Statter.statElseNull(filePath);
       if (!stats || stats.isDirectory()) {
         throw new Error(`Not found or not a non-directory file: ${filePath}`);
       }

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -146,7 +146,7 @@ export class StaticFiles extends BaseApplication {
     }
 
     const existingResponse = this.#notFoundResponse;
-    const stats            = await Statter.statOrNull(notFoundPath);
+    const stats            = await Statter.statElseNull(notFoundPath);
     const isFile           = stats?.isFile();
 
     if (existingResponse) {

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -241,7 +241,7 @@ export class HostManager extends TemplAggregateComponent('HostAggregate', BaseCo
      *   suitable is found.
      */
     #findItem(name, allowWildcard) {
-      const key = HostUtil.parseHostnameOrNull(name, allowWildcard);
+      const key = HostUtil.parseHostnameElseNull(name, allowWildcard);
 
       if (key === null) {
         this.#logger?.invalidHostname(name);

--- a/src/webapp-util/export/Rotator.js
+++ b/src/webapp-util/export/Rotator.js
@@ -56,7 +56,7 @@ export class Rotator extends BaseFilePreserver {
     const atSize = this.#config.rotate.atSize.byte;
 
     try {
-      const stats = await Statter.statOrNull(this.#config.path);
+      const stats = await Statter.statElseNull(this.#config.path);
       if (stats && (stats.size >= atSize)) {
         this._prot_saveNow();
       }

--- a/src/webapp-util/export/StaticFileResponder.js
+++ b/src/webapp-util/export/StaticFileResponder.js
@@ -178,7 +178,7 @@ export class StaticFileResponder {
       : `${this.#baseDirectory}/${path}`;
 
     try {
-      const stats = await Statter.statOrNull(fullPath);
+      const stats = await Statter.statElseNull(fullPath);
       if (stats === null) {
         this.#logger?.fileNotFound(fullPath);
         return null;
@@ -230,7 +230,7 @@ export class StaticFileResponder {
       const indexPath = `${dirPath}/${name}`;
 
       try {
-        const indexStats = await Statter.statOrNull(indexPath, true);
+        const indexStats = await Statter.statElseNull(indexPath, true);
 
         if (indexStats?.isFile()) {
           this.#logger?.foundIndex(dirPath, name);

--- a/src/webapp-util/private/BaseFilePreserver.js
+++ b/src/webapp-util/private/BaseFilePreserver.js
@@ -262,7 +262,7 @@ export class BaseFilePreserver {
     let   stats;
 
     try {
-      stats = await Statter.statOrNull(origPath);
+      stats = await Statter.statElseNull(origPath);
       if (!stats || (stats.size === 0)) {
         return;
       }


### PR DESCRIPTION
This PR clarifies the meaning of the `*OrNull*()` method naming convention, and as a result, defines a new `*ElseNull()` naming convention. This ended up causing a decent handful of methods to get renamed.

More detail: `*OrNull` had been used to mean two different things in slightly different contexts, (a) as a suffix on a type name in a method to indicate that it is "nullable" (e.g. `expectInstanceOrNull()`), or (b) as a suffix on a method to indicate that it can be expected to return `null` in some "usual" cases (e.g. `parseHostnameOrNull()`). Much of the time it was possible to figure out from context which of the two was meant, but — as it turned out — not always, and it was the source of at least a couple of bugs. So now the two meanings are distinguished more explicitly.