### PR TITLE
Standardize on `mustBe*()` method name prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ versioning principles. Unstable releases do not.
 Breaking changes:
 * framework API (general):
   * Defined a new `*ElseNull()` method naming convention, to use instead of
-    `*OrNull*()`, clarifying the contexts in which each is appropriate. As a
-    result, renamed a bunch of methods throughout the system.
+    `*OrNull*()`, clarifying the contexts in which each is appropriate.
+  * Reworked method naming convention for type/value-checking methods to be
+    `mustBe*()`, instead of using either `expect*()` or `check*()`.
+  * As a result of the above, renamed a bunch of methods throughout the system.
 
 Other notable changes:
 * `net-util`:

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -156,6 +156,10 @@ use the following comment in place of an intentionally omitted constructor:
   in `expectFooOrNull()` it is clear that the expectation is for a "nullable"
   `foo` and not that the method is allowed to return `null` in case of error.
 
+* `mustBe<thing>()` &mdash; Names a method which is checking that its argument
+  is of the given type (or type-ish thing), and which will `throw` if not. This
+  parallels the library class `typey.MustBe`.
+
 ### Ledger of arbitrary decisions
 
 Every enduring project of nontrivial size ends up having the results of myriad

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -157,8 +157,9 @@ use the following comment in place of an intentionally omitted constructor:
   `foo` and not that the method is allowed to return `null` in case of error.
 
 * `mustBe<thing>()` &mdash; Names a method which is checking that its argument
-  is of the given type (or type-ish thing), and which will `throw` if not. This
-  parallels the library class `typey.MustBe`.
+  is of the given type (or type-ish thing), returning the given value if it
+  matches the type, or `throw`ing if not. This parallels the library class
+  `typey.MustBe`.
 
 ### Ledger of arbitrary decisions
 

--- a/doc/coding-conventions.md
+++ b/doc/coding-conventions.md
@@ -153,7 +153,7 @@ use the following comment in place of an intentionally omitted constructor:
   With type conversion methods, the distinction is sometimes a bit arbitrary,
   but the pattern `*ElseNull()` can also be used in non-conversion contexts.
   For example, in `findFooElseNull()`, the distinction is more meaningful. And
-  in `expectFooOrNull()` it is clear that the expectation is for a "nullable"
+  in `mustBeFooOrNull()` it is clear that the expectation is for a "nullable"
   `foo` and not that the method is allowed to return `null` in case of error.
 
 * `mustBe<thing>()` &mdash; Names a method which is checking that its argument

--- a/src/compy/export/BaseComponent.js
+++ b/src/compy/export/BaseComponent.js
@@ -19,7 +19,7 @@ import { ThisModule } from '#p/ThisModule';
  *
  * **Note:** If a concrete subclass uses a configuration object with a `name`
  * property, then this class requires that that name honor the contract of
- * {@link Names#checkName}.
+ * {@link Names#mustBeName}.
  */
 export class BaseComponent {
   /**
@@ -78,7 +78,7 @@ export class BaseComponent {
 
     const name = this.#config?.name;
     if (name) {
-      Names.checkName(name);
+      Names.mustBeName(name);
     }
 
     if (rootContext !== null) {
@@ -544,7 +544,7 @@ export class BaseComponent {
        * The item's name, or `null` if it does not have a configured name. If
        * `null`, the corresponding component will get a synthesized name as soon
        * as it is attached to a hierarchy. If non-`null`, it must adhere to the
-       * syntax defined by {@link Names#checkName}. Names are used when finding
+       * syntax defined by {@link Names#mustBeName}. Names are used when finding
        * a component in its hierarchy, and when logging.
        *
        * @param {?string} [value] Proposed configuration value. Default `null`.
@@ -553,7 +553,7 @@ export class BaseComponent {
       _config_name(value = null) {
         return (value === null)
           ? null
-          : Names.checkName(value);
+          : Names.mustBeName(value);
       }
     };
   }

--- a/src/compy/export/BaseRootComponent.js
+++ b/src/compy/export/BaseRootComponent.js
@@ -80,7 +80,7 @@ export class BaseRootComponent extends BaseComponent {
        * @returns {string} Accepted configuration value.
        */
       _config_name(value = 'root') {
-        return Names.checkName(value);
+        return Names.mustBeName(value);
       }
 
       /**

--- a/src/compy/export/ControlContext.js
+++ b/src/compy/export/ControlContext.js
@@ -243,7 +243,7 @@ export class ControlContext {
    * @param {string} state State to wait for.
    */
   async whenState(state) {
-    ControlContext.#checkState(state);
+    ControlContext.#mustBeState(state);
 
     while (this.#state !== state) {
       await this.#stateChangeCondition.whenTrue();
@@ -280,7 +280,7 @@ export class ControlContext {
    * @param {string} state The new state.
    */
   [ThisModule.SYM_setState](state) {
-    ControlContext.#checkState(state);
+    ControlContext.#mustBeState(state);
 
     if (state !== this.#state) {
       this.#state = state;
@@ -343,7 +343,7 @@ export class ControlContext {
    * @param {string} state State value to check.
    * @throws {Error} Thrown if `state` is invalid.
    */
-  static #checkState(state) {
+  static #mustBeState(state) {
     MustBe.string(state);
 
     if (!this.#VALID_STATES.has(state)) {

--- a/src/compy/export/Names.js
+++ b/src/compy/export/Names.js
@@ -20,7 +20,7 @@ export class Names {
    *   pattern.
    * @throws {Error} Thrown if `value` does not match.
    */
-  static checkName(value) {
+  static mustBeName(value) {
     if (this.isName(value)) {
       return value;
     }

--- a/src/compy/tests/Names.test.js
+++ b/src/compy/tests/Names.test.js
@@ -7,7 +7,7 @@ import { Names } from '@this/compy';
 
 describe.each`
 methodName      | throws
-${'checkName'}  | ${true}
+${'mustBeName'}  | ${true}
 ${'isName'}     | ${false}
 `('$methodName()', ({ methodName, throws }) => {
   // Non-string errors. Always expected to throw.

--- a/src/fs-util/export/FileAppender.js
+++ b/src/fs-util/export/FileAppender.js
@@ -66,7 +66,7 @@ export class FileAppender {
    *   stuff to write, or `null` not to do any buffering.
    */
   constructor(filePath, maxBufferTime = null) {
-    this.#filePath = Paths.checkAbsolutePath(filePath);
+    this.#filePath = Paths.mustBeAbsolutePath(filePath);
     this.#maxBufferTime = maxBufferTime
       ? MustBe.instanceOf(maxBufferTime, Duration)
       : Duration.ZERO;

--- a/src/fs-util/export/Paths.js
+++ b/src/fs-util/export/Paths.js
@@ -18,7 +18,7 @@ export class Paths {
    * @returns {string} `value` if it is a string which matches the pattern.
    * @throws {Error} Thrown if `value` does not match.
    */
-  static checkAbsolutePath(value) {
+  static mustBeAbsolutePath(value) {
     const pattern = '^' +
       '(?!.*/[.]{1,2}/)' + // No dot or double-dot internal component.
       '(?!.*/[.]{1,2}$)' + // No dot or double-dot final component.
@@ -45,7 +45,7 @@ export class Paths {
    *   pattern.
    * @throws {Error} Thrown if `value` does not match.
    */
-  static checkFileName(value) {
+  static mustBeFileName(value) {
     const pattern = /^(?![.]{1,2}$)[^/]+$/;
 
     try {

--- a/src/fs-util/tests/Paths.test.js
+++ b/src/fs-util/tests/Paths.test.js
@@ -4,7 +4,7 @@
 import { Paths } from '@this/fs-util';
 
 
-describe('checkAbsolutePath()', () => {
+describe('mustBeAbsolutePath()', () => {
   // Errors: Wrong argument type.
   test.each`
   arg
@@ -16,7 +16,7 @@ describe('checkAbsolutePath()', () => {
   ${['/x/y']}
   ${new Map()}
   `('fails for $arg', ({ arg }) => {
-    expect(() => Paths.checkAbsolutePath(arg)).toThrow();
+    expect(() => Paths.mustBeAbsolutePath(arg)).toThrow();
   });
 
   // Errors: Invalid string syntax.
@@ -36,7 +36,7 @@ describe('checkAbsolutePath()', () => {
   ${'/a/../b'}
   ${'/a/b/'}
   `('fails for $arg', ({ arg }) => {
-    expect(() => Paths.checkAbsolutePath(arg)).toThrow();
+    expect(() => Paths.mustBeAbsolutePath(arg)).toThrow();
   });
 
   // Correct cases.
@@ -47,11 +47,11 @@ describe('checkAbsolutePath()', () => {
   ${'/abc'}
   ${'/abc/def'}
   `('succeeds for $arg', ({ arg }) => {
-    expect(Paths.checkAbsolutePath(arg)).toBe(arg);
+    expect(Paths.mustBeAbsolutePath(arg)).toBe(arg);
   });
 });
 
-describe('checkFileName()', () => {
+describe('mustBeFileName()', () => {
   // Errors: Wrong argument type.
   test.each`
   arg
@@ -63,7 +63,7 @@ describe('checkFileName()', () => {
   ${['/x/y']}
   ${new Map()}
   `('fails for $arg', ({ arg }) => {
-    expect(() => Paths.checkFileName(arg)).toThrow();
+    expect(() => Paths.mustBeFileName(arg)).toThrow();
   });
 
   // Errors: Invalid string syntax.
@@ -77,7 +77,7 @@ describe('checkFileName()', () => {
   ${'a/'}
   ${'a/b'}
   `('fails for $arg', ({ arg }) => {
-    expect(() => Paths.checkFileName(arg)).toThrow();
+    expect(() => Paths.mustBeFileName(arg)).toThrow();
   });
 
   // Correct cases.
@@ -92,6 +92,6 @@ describe('checkFileName()', () => {
   ${'a..'}
   ${'a..b'}
   `('succeeds for $arg', ({ arg }) => {
-    expect(Paths.checkFileName(arg)).toBe(arg);
+    expect(Paths.mustBeFileName(arg)).toBe(arg);
   });
 });

--- a/src/loggy-intf/export/IntfLogger.js
+++ b/src/loggy-intf/export/IntfLogger.js
@@ -95,7 +95,7 @@ export class IntfLogger {
    * @returns {IntfLogger} `logger` if it is a logger.
    * @throws {Error} Thrown if `logger` is not actually a logger.
    */
-  static expectInstance(logger) {
+  static mustBeInstance(logger) {
     if (logger instanceof IntfLogger) {
       return logger;
     } else if (AskIf.callableFunction(logger) && logger.$env) {
@@ -116,8 +116,8 @@ export class IntfLogger {
    * @returns {?IntfLogger} `logger` if it is a logger or `null`.
    * @throws {Error} Thrown if `logger` is not actually a logger or `null`.
    */
-  static expectInstanceOrNull(logger) {
-    return (logger === null) ? null : this.expectInstance(logger);
+  static mustBeInstanceOrNull(logger) {
+    return (logger === null) ? null : this.mustBeInstance(logger);
   }
 
   /**

--- a/src/loggy-intf/export/LogTag.js
+++ b/src/loggy-intf/export/LogTag.js
@@ -60,10 +60,10 @@ export class LogTag extends IntfDeconstructable {
   constructor(main, ...context) {
     super();
 
-    this.#main = LogTag.#checkMainString(main);
+    this.#main = LogTag.#mustBeMainString(main);
 
     for (const c of context) {
-      LogTag.#checkContextString(c);
+      LogTag.#mustBeContextString(c);
     }
 
     this.#context = Object.freeze(context);
@@ -215,7 +215,7 @@ export class LogTag extends IntfDeconstructable {
    * @returns {string} `value`, if it is valid.
    * @throws {Error} Thrown if `value` is invalid.
    */
-  static #checkContextString(value) {
+  static #mustBeContextString(value) {
     return MustBe.string(value, /^.{1,30}$/);
   }
 
@@ -226,7 +226,7 @@ export class LogTag extends IntfDeconstructable {
    * @returns {string} `value`, if it is valid.
    * @throws {Error} Thrown if `value` is invalid.
    */
-  static #checkMainString(value) {
+  static #mustBeMainString(value) {
     return MustBe.string(value, /^(?![-.])(?:[-._a-zA-Z0-9]{1,20}|\(top\))(?<![-.])$/);
   }
 }

--- a/src/metacomp/export/LimitedLoader.js
+++ b/src/metacomp/export/LimitedLoader.js
@@ -71,7 +71,7 @@ export class LimitedLoader {
    */
   constructor(context = null, logger = null) {
     this.#context = context;
-    this.#logger  = IntfLogger.expectInstanceOrNull(logger);
+    this.#logger  = IntfLogger.mustBeInstanceOrNull(logger);
 
     if (context && !vm.isContext(context)) {
       vm.createContext(context);

--- a/src/net-protocol/export/ProtocolWrangler.js
+++ b/src/net-protocol/export/ProtocolWrangler.js
@@ -181,7 +181,7 @@ export class ProtocolWrangler {
    *   logging.
    */
   async init(logger) {
-    this.#logger = IntfLogger.expectInstanceOrNull(logger);
+    this.#logger = IntfLogger.mustBeInstanceOrNull(logger);
 
     // Confusion alert!: This is not the same as the `requestLogger` (a "request
     // logger") per se) passed in as an option. This is the sub-logger of the

--- a/src/net-protocol/export/ProtocolWranglers.js
+++ b/src/net-protocol/export/ProtocolWranglers.js
@@ -53,7 +53,7 @@ export class ProtocolWranglers {
    * @throws {Error} Thrown if `name` is not a known protocol (or is not a
    *   string).
    */
-  static checkProtocol(name) {
+  static mustBeProtocol(name) {
     MustBe.string(name);
 
     if (!this.#WRANGLER_CLASSES.has(name)) {

--- a/src/net-protocol/private/AsyncServerSocket.js
+++ b/src/net-protocol/private/AsyncServerSocket.js
@@ -76,7 +76,7 @@ export class AsyncServerSocket {
     // Note: `interface` is a reserved word.
     this.#interface = MustBe.instanceOf(iface, InterfaceAddress);
     this.#protocol  = MustBe.string(protocol);
-    this.#logger    = IntfLogger.expectInstanceOrNull(logger);
+    this.#logger    = IntfLogger.mustBeInstanceOrNull(logger);
   }
 
   /**

--- a/src/net-protocol/private/WranglerContext.js
+++ b/src/net-protocol/private/WranglerContext.js
@@ -267,7 +267,7 @@ export class WranglerContext {
     ctx.#socket   = socket;
 
     if (logger) {
-      ctx.#connectionLogger = IntfLogger.expectInstanceOrNull(logger);
+      ctx.#connectionLogger = IntfLogger.mustBeInstanceOrNull(logger);
       ctx.#connectionId     = logger?.$meta.lastContext ?? null;
     }
 

--- a/src/net-util/export/CertUtil.js
+++ b/src/net-util/export/CertUtil.js
@@ -24,7 +24,7 @@ export class CertUtil {
    *   pattern.
    * @throws {Error} Thrown if `value` does not match.
    */
-  static checkCertificateChain(value) {
+  static mustBeCertificateChain(value) {
     const pattern = this.#makePemPattern('CERTIFICATE', true);
     return MustBe.string(value, pattern);
   }
@@ -38,7 +38,7 @@ export class CertUtil {
    *   pattern.
    * @throws {Error} Thrown if `value` does not match.
    */
-  static checkPrivateKey(value) {
+  static mustBePrivateKey(value) {
     const pattern = this.#makePemPattern('((RSA|EC) )?PRIVATE KEY');
     return MustBe.string(value, pattern);
   }

--- a/src/net-util/export/DispatchInfo.js
+++ b/src/net-util/export/DispatchInfo.js
@@ -57,7 +57,7 @@ export class DispatchInfo extends IntfDeconstructable {
 
     this.#base   = MustBe.instanceOf(base, PathKey);
     this.#extra  = MustBe.instanceOf(extra, PathKey);
-    this.#logger = IntfLogger.expectInstanceOrNull(logger);
+    this.#logger = IntfLogger.mustBeInstanceOrNull(logger);
   }
 
   /** @override */

--- a/src/net-util/export/EtagGenerator.js
+++ b/src/net-util/export/EtagGenerator.js
@@ -137,7 +137,7 @@ export class EtagGenerator {
    *   exist.
    */
   async etagFromFileData(absolutePath) {
-    Paths.checkAbsolutePath(absolutePath);
+    Paths.mustBeAbsolutePath(absolutePath);
 
     const stats = await Statter.statElseNull(absolutePath);
     if (!stats) {
@@ -205,7 +205,7 @@ export class EtagGenerator {
       throw new Error('Cannot use with data-only instance.');
     }
 
-    Paths.checkAbsolutePath(absolutePath);
+    Paths.mustBeAbsolutePath(absolutePath);
 
     // Converts a number to hex.
     const hex = (num) => {

--- a/src/net-util/export/FullResponse.js
+++ b/src/net-util/export/FullResponse.js
@@ -337,7 +337,7 @@ export class FullResponse extends BaseResponse {
    *   header based on the file's stats. Defaults to `true`.
    */
   async setBodyFile(absolutePath, options = null) {
-    Paths.checkAbsolutePath(absolutePath);
+    Paths.mustBeAbsolutePath(absolutePath);
     const {
       offset = null,
       length = null,

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -240,7 +240,7 @@ export class HostInfo {
     const { hostname, port } = topParse;
 
     // Refined `hostname` check, along with IP address canonicalization.
-    const canonicalHostname = HostUtil.checkHostnameElseNull(hostname, false);
+    const canonicalHostname = HostUtil.canonicalizeHostnameElseNull(hostname, false);
 
     if (!canonicalHostname) {
       return null;

--- a/src/net-util/export/HostUtil.js
+++ b/src/net-util/export/HostUtil.js
@@ -47,7 +47,7 @@ export class HostUtil {
    *   pattern, canonicalized if it is an IP address.
    * @throws {Error} Thrown if `value` does not match.
    */
-  static checkHostname(name, allowWildcard = false) {
+  static canonicalizeHostname(name, allowWildcard = false) {
     // Handle IP address cases.
     const canonicalIp = EndpointAddress.canonicalizeAddressElseNull(name, false);
     if (canonicalIp) {
@@ -64,8 +64,8 @@ export class HostUtil {
   }
 
   /**
-   * Like {@link #checkHostname}, except it returns `null` to indicate a parsing
-   * error.
+   * Like {@link #canonicalizeHostname}, except it returns `null` to indicate a
+   * parsing error.
    *
    * @param {string} name Hostname to parse.
    * @param {boolean} [allowWildcard] Is a wildcard form allowed for `name`?
@@ -73,7 +73,7 @@ export class HostUtil {
    *   pattern, canonicalized if it is an IP address. Returns `null` to indicate
    *   a parsing error.
    */
-  static checkHostnameElseNull(name, allowWildcard = false) {
+  static canonicalizeHostnameElseNull(name, allowWildcard = false) {
     // Handle IP address cases.
     const canonicalIp = EndpointAddress.canonicalizeAddressElseNull(name, false);
     if (canonicalIp) {

--- a/src/net-util/export/HttpUtil.js
+++ b/src/net-util/export/HttpUtil.js
@@ -138,7 +138,7 @@ export class HttpUtil {
    * @returns {number} `value` if it is indeed a valid status value.
    * @throws {Error} Thrown if `value` is not valid.
    */
-  static checkStatus(value) {
+  static mustBeStatus(value) {
     if (AskIf.number(value, { safeInteger: true, minInclusive: 100, maxInclusive: 599 })) {
       return value;
     }

--- a/src/net-util/export/InterfaceAddress.js
+++ b/src/net-util/export/InterfaceAddress.js
@@ -121,7 +121,7 @@ export class InterfaceAddress extends IntfDeconstructable {
       }
 
       if (portNumber) {
-        InterfaceAddress.#checkPortNumber(portNumber);
+        InterfaceAddress.#mustBePortNumber(portNumber);
       }
     }
 
@@ -401,7 +401,7 @@ export class InterfaceAddress extends IntfDeconstructable {
     MustBe.string(iface);
 
     const portStr = iface.match(/:(?<port>[0-9]{1,5})$/)?.groups.port ?? null;
-    const port    = portStr ? this.#checkPortNumber(portStr, true) : null;
+    const port    = portStr ? this.#mustBePortNumber(portStr, true) : null;
 
     const addressStr = portStr
       ? iface.match(/^(?<address>.*):[^:]+$/).groups.address
@@ -443,7 +443,7 @@ export class InterfaceAddress extends IntfDeconstructable {
    * @returns {number} `portNumber` if it is valid.
    * @throws {Error} Thrown if `portNumber` is invalid.
    */
-  static #checkPortNumber(portNumber, allowString = false) {
+  static #mustBePortNumber(portNumber, allowString = false) {
     if (allowString && (typeof portNumber === 'string')) {
       if (/^[0-9]{1,5}$/.test(portNumber)) {
         portNumber = parseInt(portNumber, 10);

--- a/src/net-util/export/MimeTypes.js
+++ b/src/net-util/export/MimeTypes.js
@@ -52,7 +52,7 @@ export class MimeTypes {
    * @returns {string} The MIME type.
    */
   static typeFromPathExtension(absolutePath, options = {}) {
-    Paths.checkAbsolutePath(absolutePath);
+    Paths.mustBeAbsolutePath(absolutePath);
     const { charSet = 'utf-8', isText = false } = MustBe.object(options);
 
     return this.#typeFromPathOrExtension(absolutePath, charSet, isText);

--- a/src/net-util/export/UriUtil.js
+++ b/src/net-util/export/UriUtil.js
@@ -28,7 +28,7 @@ export class UriUtil {
    * @returns {string} `value` if it is a string which matches the pattern.
    * @throws {Error} Thrown if `value` does not match.
    */
-  static checkBasicUri(value) {
+  static mustBeBasicUri(value) {
     // Basic constraints.
     const pattern =
       '^' +

--- a/src/net-util/tests/CertUtil.test.js
+++ b/src/net-util/tests/CertUtil.test.js
@@ -4,31 +4,31 @@
 import { CertUtil } from '@this/net-util';
 
 
-describe('checkCertificateChain()', () => {
+describe('mustBeCertificateChain()', () => {
   const SOME_CERT =
     '-----BEGIN CERTIFICATE-----\n' +
     'ABCDEFG+/abcdefg1234567890=\n' +
     '-----END CERTIFICATE-----\n';
 
   test('throws given a non-string', () => {
-    expect(() => CertUtil.checkCertificateChain(12345)).toThrow();
+    expect(() => CertUtil.mustBeCertificateChain(12345)).toThrow();
   });
 
   test('throws given a string that is clearly not a certificate chain', () => {
-    expect(() => CertUtil.checkCertificateChain('florp\nflop\n')).toThrow();
+    expect(() => CertUtil.mustBeCertificateChain('florp\nflop\n')).toThrow();
   });
 
   test('accepts a pretty minimal syntactically correct single-cert example', () => {
-    expect(() => CertUtil.checkCertificateChain(SOME_CERT)).not.toThrow();
+    expect(() => CertUtil.mustBeCertificateChain(SOME_CERT)).not.toThrow();
   });
 
   test('accepts a pretty minimal syntactically correct multi-cert example', () => {
-    expect(() => CertUtil.checkCertificateChain(SOME_CERT + SOME_CERT)).not.toThrow();
-    expect(() => CertUtil.checkCertificateChain(SOME_CERT + SOME_CERT + SOME_CERT)).not.toThrow();
+    expect(() => CertUtil.mustBeCertificateChain(SOME_CERT + SOME_CERT)).not.toThrow();
+    expect(() => CertUtil.mustBeCertificateChain(SOME_CERT + SOME_CERT + SOME_CERT)).not.toThrow();
   });
 });
 
-describe('checkPrivateKey()', () => {
+describe('mustBePrivateKey()', () => {
   const SOME_KEY =
     '-----BEGIN PRIVATE KEY-----\n' +
     'ABCDEFG+/abcdefg1234567890=\n' +
@@ -43,23 +43,23 @@ describe('checkPrivateKey()', () => {
     '-----END EC PRIVATE KEY-----\n';
 
   test('throws given a non-string', () => {
-    expect(() => CertUtil.checkPrivateKey(12345)).toThrow();
+    expect(() => CertUtil.mustBePrivateKey(12345)).toThrow();
   });
 
   test('throws given a string that is clearly not a private key', () => {
-    expect(() => CertUtil.checkPrivateKey('florp\nflop\n')).toThrow();
+    expect(() => CertUtil.mustBePrivateKey('florp\nflop\n')).toThrow();
   });
 
   test('accepts a pretty minimal syntactically correct regular key (PKCS#8)', () => {
-    expect(() => CertUtil.checkPrivateKey(SOME_KEY)).not.toThrow();
+    expect(() => CertUtil.mustBePrivateKey(SOME_KEY)).not.toThrow();
   });
 
   test('accepts a pretty minimal syntactically correct RSA key (PKCS#1)', () => {
-    expect(() => CertUtil.checkPrivateKey(SOME_RSA_KEY)).not.toThrow();
+    expect(() => CertUtil.mustBePrivateKey(SOME_RSA_KEY)).not.toThrow();
   });
 
   test('accepts a pretty minimal syntactically correct EC key (PKCS#1)', () => {
-    expect(() => CertUtil.checkPrivateKey(SOME_EC_KEY)).not.toThrow();
+    expect(() => CertUtil.mustBePrivateKey(SOME_EC_KEY)).not.toThrow();
   });
 });
 
@@ -77,7 +77,7 @@ describe('makeSelfSignedPair()', () => {
 
     expect(got).toContainAllKeys(['certificate', 'privateKey']);
 
-    expect(() => CertUtil.checkCertificateChain(got.certificate)).not.toThrow();
-    expect(() => CertUtil.checkPrivateKey(got.privateKey)).not.toThrow();
+    expect(() => CertUtil.mustBeCertificateChain(got.certificate)).not.toThrow();
+    expect(() => CertUtil.mustBePrivateKey(got.privateKey)).not.toThrow();
   });
 });

--- a/src/net-util/tests/HostUtil.test.js
+++ b/src/net-util/tests/HostUtil.test.js
@@ -6,11 +6,11 @@ import { EndpointAddress, HostUtil } from '@this/net-util';
 
 
 describe.each`
-method                     | throws   | returns
-${'checkHostname'}         | ${true}  | ${'string'}
-${'checkHostnameElseNull'} | ${false} | ${'string'}
-${'parseHostname'}         | ${true}  | ${'path'}
-${'parseHostnameElseNull'} | ${false} | ${'path'}
+method                            | throws   | returns
+${'canonicalizeHostname'}         | ${true}  | ${'string'}
+${'canonicalizeHostnameElseNull'} | ${false} | ${'string'}
+${'parseHostname'}                | ${true}  | ${'path'}
+${'parseHostnameElseNull'}        | ${false} | ${'path'}
 `('$method()', ({ method, throws, returns }) => {
   const LONGEST_COMPONENT = 'x'.repeat(63);
   const LONGEST_NAME      = `${'florp.'.repeat(41)}vwxyz.com`;

--- a/src/net-util/tests/HttpUtil.test.js
+++ b/src/net-util/tests/HttpUtil.test.js
@@ -28,7 +28,7 @@ describe('cacheControlHeader()', () => {
   });
 });
 
-describe('checkStatus()', () => {
+describe('mustBeStatus()', () => {
   // pass cases
   test.each`
   value
@@ -43,7 +43,7 @@ describe('checkStatus()', () => {
   ${501}
   ${599}
   `('passes value $value', ({ value }) => {
-    expect(HttpUtil.checkStatus(value)).toBe(value);
+    expect(HttpUtil.mustBeStatus(value)).toBe(value);
   });
 
   // fail cases
@@ -58,7 +58,7 @@ describe('checkStatus()', () => {
   ${'123'}
   ${[123]}
   `('throws given value $value', ({ value }) => {
-    expect(() => HttpUtil.checkStatus(value)).toThrow();
+    expect(() => HttpUtil.mustBeStatus(value)).toThrow();
   });
 });
 

--- a/src/net-util/tests/UriUtil.test.js
+++ b/src/net-util/tests/UriUtil.test.js
@@ -5,7 +5,7 @@ import { PathKey } from '@this/collections';
 import { UriUtil } from '@this/net-util';
 
 
-describe('checkBasicUri()', () => {
+describe('mustBeBasicUri()', () => {
   // Failure cases.
   test.each`
   label                               | path
@@ -28,7 +28,7 @@ describe('checkBasicUri()', () => {
   ${'username and password'}          | ${'https://user:pass@foo/bar/'}
   ${'invalid hostname'}               | ${'https://foo .bar/'}
   `('fails for $label', ({ path }) => {
-    expect(() => UriUtil.checkBasicUri(path)).toThrow();
+    expect(() => UriUtil.mustBeBasicUri(path)).toThrow();
   });
 
   // Success cases.
@@ -39,7 +39,7 @@ describe('checkBasicUri()', () => {
   ${'https://foo.bar/baz/'}
   ${'https://foo.bar/b%20az/'}
   `('succeeds for $path', ({ path }) => {
-    expect(UriUtil.checkBasicUri(path)).toBe(path);
+    expect(UriUtil.mustBeBasicUri(path)).toBe(path);
   });
 });
 

--- a/src/webapp-builtins/export/EventFan.js
+++ b/src/webapp-builtins/export/EventFan.js
@@ -100,7 +100,7 @@ export class EventFan extends BaseService {
 
       /**
        * Names of services to fan out to. Each name must be a valid component
-       * name, per {@link Names#checkName}.
+       * name, per {@link Names#mustBeName}.
        *
        * @param {string|Array<string>} value Proposed configuration value.
        * @returns {Array<string>} Accepted configuration value.
@@ -108,7 +108,7 @@ export class EventFan extends BaseService {
       _config_services(value) {
         return StringUtil.checkAndFreezeStrings(
           value,
-          (item) => Names.checkName(item));
+          (item) => Names.mustBeName(item));
       }
     };
   }

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -108,7 +108,7 @@ export class HostRouter extends BaseApplication {
        * Map which goes from a host prefix to the name of an application which
        * should handle that prefix. Each host must be a valid
        * possibly-wildcarded host name, per {@link HostUtil#parseHostname}. Each
-       * name must be a valid component name, per {@link Names#checkName}. On
+       * name must be a valid component name, per {@link Names#mustBeName}. On
        * input, the value must be a plain object.
        *
        * @param {object} value Proposed configuration value.
@@ -118,7 +118,7 @@ export class HostRouter extends BaseApplication {
         MustBe.plainObject(value);
 
         for (const [host, name] of Object.entries(value)) {
-          Names.checkName(name);
+          Names.mustBeName(name);
           HostUtil.canonicalizeHostname(host, true);
         }
 

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -119,7 +119,7 @@ export class HostRouter extends BaseApplication {
 
         for (const [host, name] of Object.entries(value)) {
           Names.checkName(name);
-          HostUtil.checkHostname(host, true);
+          HostUtil.canonicalizeHostname(host, true);
         }
 
         return value;

--- a/src/webapp-builtins/export/PathRouter.js
+++ b/src/webapp-builtins/export/PathRouter.js
@@ -99,7 +99,7 @@ export class PathRouter extends BaseApplication {
        * Map which goes from a path prefix to the name of the application to
        * handle that prefix. Each path prefix must be a valid
        * possibly-wildcarded _absolute_ path prefix. Each name must be a valid
-       * component name, per {@link Names#checkName}. On input, the value must
+       * component name, per {@link Names#mustBeName}. On input, the value must
        * be a plain object.
        *
        * @param {object} value Proposed configuration value.
@@ -112,7 +112,7 @@ export class PathRouter extends BaseApplication {
 
         for (const [path, name] of Object.entries(value)) {
           if (name !== null) {
-            Names.checkName(name);
+            Names.mustBeName(name);
           }
           const key = Config.#parsePath(path);
           result.add(key, name);

--- a/src/webapp-builtins/export/Redirector.js
+++ b/src/webapp-builtins/export/Redirector.js
@@ -88,7 +88,7 @@ export class Redirector extends BaseApplication {
        * @returns {string} Accepted configuration value.
        */
       _config_target(value) {
-        return UriUtil.checkBasicUri(value);
+        return UriUtil.mustBeBasicUri(value);
       }
 
       /**

--- a/src/webapp-builtins/export/RequestFilter.js
+++ b/src/webapp-builtins/export/RequestFilter.js
@@ -127,7 +127,7 @@ export class RequestFilter extends BaseApplication {
        * @returns {number} Accepted configuration value.
        */
       _config_filterResponseStatus(value = 404) {
-        return HttpUtil.checkStatus(value);
+        return HttpUtil.mustBeStatus(value);
       }
 
       /**

--- a/src/webapp-builtins/export/SerialRouter.js
+++ b/src/webapp-builtins/export/SerialRouter.js
@@ -75,7 +75,7 @@ export class SerialRouter extends BaseApplication {
 
       /**
        * List of the names of all the applications to route to, in order. Each
-       * name must be a valid component name, per {@link Names#checkName}.
+       * name must be a valid component name, per {@link Names#mustBeName}.
        *
        * @param {Array<string>} value Proposed configuration value.
        * @returns {Array<string>} Accepted configuration value.
@@ -83,7 +83,7 @@ export class SerialRouter extends BaseApplication {
       _config_applications(value) {
         return StringUtil.checkAndFreezeStrings(
           value,
-          (item) => Names.checkName(item));
+          (item) => Names.mustBeName(item));
       }
     };
   }

--- a/src/webapp-builtins/export/SimpleResponse.js
+++ b/src/webapp-builtins/export/SimpleResponse.js
@@ -193,7 +193,7 @@ export class SimpleResponse extends BaseApplication {
       _config_filePath(value = null) {
         return (value === null)
           ? null
-          : Paths.checkAbsolutePath(value);
+          : Paths.mustBeAbsolutePath(value);
       }
 
       /**

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -206,7 +206,7 @@ export class StaticFiles extends BaseApplication {
        * @returns {?string} Accepted configuration value.
        */
       _config_cacheControl(value = null) {
-        return StaticFileResponder.checkCacheControl(value);
+        return StaticFileResponder.mustBeCacheControl(value);
       }
 
       /**
@@ -218,7 +218,7 @@ export class StaticFiles extends BaseApplication {
        * @returns {?object} Accepted configuration value.
        */
       _config_etag(value = null) {
-        return StaticFileResponder.checkEtag(value);
+        return StaticFileResponder.mustBeEtag(value);
       }
 
       /**
@@ -232,7 +232,7 @@ export class StaticFiles extends BaseApplication {
        * @returns {?string[]} Accepted configuration value.
        */
       _config_indexFile(value = 'index.html') {
-        return StaticFileResponder.checkIndexFile(value);
+        return StaticFileResponder.mustBeIndexFile(value);
       }
 
       /**
@@ -255,7 +255,7 @@ export class StaticFiles extends BaseApplication {
        * @returns {string} Accepted configuration value.
        */
       _config_siteDirectory(value) {
-        return StaticFileResponder.checkBaseDirectory(value);
+        return StaticFileResponder.mustBeBaseDirectory(value);
       }
     };
   }

--- a/src/webapp-builtins/export/StaticFiles.js
+++ b/src/webapp-builtins/export/StaticFiles.js
@@ -245,7 +245,7 @@ export class StaticFiles extends BaseApplication {
       _config_notFoundPath(value = null) {
         return (value === null)
           ? null
-          : Paths.checkAbsolutePath(value);
+          : Paths.mustBeAbsolutePath(value);
       }
 
       /**

--- a/src/webapp-core/export/HostManager.js
+++ b/src/webapp-core/export/HostManager.js
@@ -130,7 +130,7 @@ export class HostManager extends TemplAggregateComponent('HostAggregate', BaseCo
      * @param {?IntfLogger} logger Logger to use, if any.
      */
     constructor(logger) {
-      this.#logger = IntfLogger.expectInstanceOrNull(logger);
+      this.#logger = IntfLogger.mustBeInstanceOrNull(logger);
     }
 
     /**

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -203,7 +203,7 @@ export class NetworkEndpoint extends BaseDispatched {
       _config_hostnames(value = '*') {
         return StringUtil.checkAndFreezeStrings(
           value,
-          (item) => HostUtil.checkHostname(item, true));
+          (item) => HostUtil.canonicalizeHostname(item, true));
       }
 
       /**

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -252,7 +252,7 @@ export class NetworkEndpoint extends BaseDispatched {
        * @returns {string} Accepted configuration value.
        */
       _config_protocol(value) {
-        return ProtocolWranglers.checkProtocol(value);
+        return ProtocolWranglers.mustBeProtocol(value);
       }
 
       /**

--- a/src/webapp-core/export/NetworkEndpoint.js
+++ b/src/webapp-core/export/NetworkEndpoint.js
@@ -189,7 +189,7 @@ export class NetworkEndpoint extends BaseDispatched {
        * @returns {string} Accepted configuration value.
        */
       _config_application(value) {
-        return Names.checkName(value);
+        return Names.mustBeName(value);
       }
 
       /**

--- a/src/webapp-core/export/NetworkHost.js
+++ b/src/webapp-core/export/NetworkHost.js
@@ -129,7 +129,7 @@ export class NetworkHost extends BaseComponent {
       _config_hostnames(value) {
         return StringUtil.checkAndFreezeStrings(
           value,
-          (item) => HostUtil.checkHostname(item, true));
+          (item) => HostUtil.canonicalizeHostname(item, true));
       }
 
       /**

--- a/src/webapp-core/export/NetworkHost.js
+++ b/src/webapp-core/export/NetworkHost.js
@@ -142,7 +142,7 @@ export class NetworkHost extends BaseComponent {
       _config_certificate(value = null) {
         return (value === null)
           ? null
-          : CertUtil.checkCertificateChain(NetworkHost.#bufferFilter(value));
+          : CertUtil.mustBeCertificateChain(NetworkHost.#bufferFilter(value));
       }
 
       /**
@@ -155,7 +155,7 @@ export class NetworkHost extends BaseComponent {
       _config_privateKey(value = null) {
         return (value === null)
           ? null
-          : CertUtil.checkPrivateKey(NetworkHost.#bufferFilter(value));
+          : CertUtil.mustBePrivateKey(NetworkHost.#bufferFilter(value));
       }
 
       /**

--- a/src/webapp-core/private/ServiceUseConfig.js
+++ b/src/webapp-core/private/ServiceUseConfig.js
@@ -27,8 +27,8 @@ export class ServiceUseConfig {
    */
   constructor(rawConfig) {
     for (const [role, name] of Object.entries(rawConfig)) {
-      Names.checkName(role);
-      Names.checkName(name);
+      Names.mustBeName(role);
+      Names.mustBeName(name);
 
       if (!ServiceUseConfig.#ROLES.has(role)) {
         throw new Error(`Invalid role: ${role}`);

--- a/src/webapp-util/export/BaseFileService.js
+++ b/src/webapp-util/export/BaseFileService.js
@@ -100,7 +100,7 @@ export class BaseFileService extends BaseService {
        * @returns {string} Accepted configuration value.
        */
       _config_path(value) {
-        return Paths.checkAbsolutePath(value);
+        return Paths.mustBeAbsolutePath(value);
       }
 
       /**

--- a/src/webapp-util/export/StaticFileResponder.js
+++ b/src/webapp-util/export/StaticFileResponder.js
@@ -500,7 +500,7 @@ export class StaticFileResponder {
      * @returns {?IntfLogger} Accepted configuration value.
      */
     _config_logger(value = null) {
-      return IntfLogger.expectInstanceOrNull(value);
+      return IntfLogger.mustBeInstanceOrNull(value);
     }
   };
 }

--- a/src/webapp-util/export/StaticFileResponder.js
+++ b/src/webapp-util/export/StaticFileResponder.js
@@ -305,7 +305,7 @@ export class StaticFileResponder {
    * @param {string} value Proposed configuration value.
    * @returns {string} Accepted configuration value.
    */
-  static checkBaseDirectory(value) {
+  static mustBeBaseDirectory(value) {
     return Paths.mustBeAbsolutePath(value);
   }
 
@@ -318,7 +318,7 @@ export class StaticFileResponder {
    * @param {?string|object} value Proposed configuration value.
    * @returns {?string} Accepted configuration value.
    */
-  static checkCacheControl(value) {
+  static mustBeCacheControl(value) {
     if (value === null) {
       return null;
     } else if (typeof value === 'string') {
@@ -337,7 +337,7 @@ export class StaticFileResponder {
    * @param {?object|true} value Proposed configuration value.
    * @returns {?object} Accepted configuration value.
    */
-  static checkEtag(value) {
+  static mustBeEtag(value) {
     if (value === null) {
       return null;
     } else if (value === true) {
@@ -359,7 +359,7 @@ export class StaticFileResponder {
    * @param {?string|string[]} value Proposed configuration value.
    * @returns {?string[]} Accepted configuration value.
    */
-  static checkIndexFile(value) {
+  static mustBeIndexFile(value) {
     if (value === null) {
       return null;
     } else if (typeof value === 'string') {
@@ -450,7 +450,7 @@ export class StaticFileResponder {
      * @returns {string} Accepted configuration value.
      */
     _config_baseDirectory(value) {
-      return StaticFileResponder.checkBaseDirectory(value);
+      return StaticFileResponder.mustBeBaseDirectory(value);
     }
 
     /**
@@ -463,7 +463,7 @@ export class StaticFileResponder {
      * @returns {?string} Accepted configuration value.
      */
     _config_cacheControl(value = null) {
-      return StaticFileResponder.checkCacheControl(value);
+      return StaticFileResponder.mustBeCacheControl(value);
     }
 
     /**
@@ -475,7 +475,7 @@ export class StaticFileResponder {
      * @returns {?object} Accepted configuration value.
      */
     _config_etag(value = null) {
-      return StaticFileResponder.checkEtag(value);
+      return StaticFileResponder.mustBeEtag(value);
     }
 
     /**
@@ -489,7 +489,7 @@ export class StaticFileResponder {
      * @returns {?string[]} Accepted configuration value.
      */
     _config_indexFile(value = null) {
-      return StaticFileResponder.checkIndexFile(value);
+      return StaticFileResponder.mustBeIndexFile(value);
     }
 
     /**

--- a/src/webapp-util/export/StaticFileResponder.js
+++ b/src/webapp-util/export/StaticFileResponder.js
@@ -306,7 +306,7 @@ export class StaticFileResponder {
    * @returns {string} Accepted configuration value.
    */
   static checkBaseDirectory(value) {
-    return Paths.checkAbsolutePath(value);
+    return Paths.mustBeAbsolutePath(value);
   }
 
   /**


### PR DESCRIPTION
This PR standardizes on `mustBe*()` as a method name prefix for methods which are checking that an argument is of a particular type (or type-ish thing). This replaces two "competing" prefixes that had evolved organically (`check*()` and `expect*()`) which _both_ ended up being in at least a little conflict with other uses of those prefixes (specifically in tests).