### PR TITLE
Convenience visitor methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Breaking changes:
 * None.
 
 Other notable changes:
-* None.
+* `valvis`:
+  * New `static` convenience methods to cover a common use case.
 
 ### v0.9.0 -- 2025-02-04
 

--- a/src/loggy-intf/export/LoggedValueEncoder.js
+++ b/src/loggy-intf/export/LoggedValueEncoder.js
@@ -177,9 +177,7 @@ export class LoggedValueEncoder extends BaseValueVisitor {
     const firstPass = encoder.visitSync();
 
     if (encoder.hasRefs()) {
-      const rewriter = new this.#DefRewriter(firstPass, encoder);
-      const result = rewriter.visitSync();
-      return result;
+      return this.#DefRewriter.visitSync(firstPass, encoder);
     } else {
       return firstPass;
     }

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -976,6 +976,45 @@ export class BaseValueVisitor {
   static #SYM_associatedVisitor = Symbol('BaseValueVisitor.associatedVisitor');
 
   /**
+   * Convenient shorthand for `new this(value).visitAsyncWrap()`, for use when
+   * only the visitor result is needed post-visit (and not access to the visitor
+   * itself). This is meant to be called on concrete visitor subclasses, and not
+   * directly on this (abstract base) class.
+   *
+   * @param {*} value Value to visit.
+   * @returns {*} Visitor result.
+   */
+  static async visitAsyncWrap(value) {
+    return new this(value).visitAsyncWrap();
+  }
+
+  /**
+   * Convenient shorthand for `new this(value).visitSync()`, for use when only
+   * the visitor result is needed post-visit (and not access to the visitor
+   * itself). This is meant to be called on concrete visitor subclasses, and not
+   * directly on this (abstract base) class.
+   *
+   * @param {*} value Value to visit.
+   * @returns {*} Visitor result.
+   */
+  static visitSync(value) {
+    return new this(value).visitSync();
+  }
+
+  /**
+   * Convenient shorthand for `new this(value).visitWrap()`, for use when only
+   * the visitor result is needed post-visit (and not access to the visitor
+   * itself). This is meant to be called on concrete visitor subclasses, and not
+   * directly on this (abstract base) class.
+   *
+   * @param {*} value Value to visit.
+   * @returns {*} Visitor result.
+   */
+  static visitWrap(value) {
+    return new this(value).visitWrap();
+  }
+
+  /**
    * Entry in a {@link #visitEntries} map.
    */
   static #VisitEntry = class VisitEntry {

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -976,42 +976,45 @@ export class BaseValueVisitor {
   static #SYM_associatedVisitor = Symbol('BaseValueVisitor.associatedVisitor');
 
   /**
-   * Convenient shorthand for `new this(value).visitAsyncWrap()`, for use when
-   * only the visitor result is needed post-visit (and not access to the visitor
-   * itself). This is meant to be called on concrete visitor subclasses, and not
-   * directly on this (abstract base) class.
+   * Convenient shorthand for `new this(value, ...).visitAsyncWrap()`, for use
+   * when only the visitor result is needed post-visit (and not access to the
+   * visitor itself). This is meant to be called on concrete visitor subclasses,
+   * and not directly on this (abstract base) class.
    *
    * @param {*} value Value to visit.
+   * @param {*[]} args Arbitrary other constructor arguments.
    * @returns {*} Visitor result.
    */
-  static async visitAsyncWrap(value) {
-    return new this(value).visitAsyncWrap();
+  static async visitAsyncWrap(value, ...args) {
+    return new this(value, ...args).visitAsyncWrap();
   }
 
   /**
-   * Convenient shorthand for `new this(value).visitSync()`, for use when only
-   * the visitor result is needed post-visit (and not access to the visitor
-   * itself). This is meant to be called on concrete visitor subclasses, and not
-   * directly on this (abstract base) class.
+   * Convenient shorthand for `new this(value, ...args).visitSync()`, for use
+   * when only the visitor result is needed post-visit (and not access to the
+   * visitor itself). This is meant to be called on concrete visitor subclasses,
+   * and not directly on this (abstract base) class.
    *
    * @param {*} value Value to visit.
+   * @param {*[]} args Arbitrary other constructor arguments.
    * @returns {*} Visitor result.
    */
-  static visitSync(value) {
-    return new this(value).visitSync();
+  static visitSync(value, ...args) {
+    return new this(value, ...args).visitSync();
   }
 
   /**
-   * Convenient shorthand for `new this(value).visitWrap()`, for use when only
-   * the visitor result is needed post-visit (and not access to the visitor
-   * itself). This is meant to be called on concrete visitor subclasses, and not
-   * directly on this (abstract base) class.
+   * Convenient shorthand for `new this(value, ...args).visitWrap()`, for use
+   * when only the visitor result is needed post-visit (and not access to the
+   * visitor itself). This is meant to be called on concrete visitor subclasses,
+   * and not directly on this (abstract base) class.
    *
    * @param {*} value Value to visit.
+   * @param {*[]} args Arbitrary other constructor arguments.
    * @returns {*} Visitor result.
    */
-  static visitWrap(value) {
-    return new this(value).visitWrap();
+  static visitWrap(value, ...args) {
+    return new this(value, ...args).visitWrap();
   }
 
   /**

--- a/src/valvis/export/BaseValueVisitor.js
+++ b/src/valvis/export/BaseValueVisitor.js
@@ -177,6 +177,17 @@ export class BaseValueVisitor {
   }
 
   /**
+   * Like {@link #visitWrap}, except that it always operates asynchronously.
+   *
+   * @returns {VisitResult} Whatever result was returned from the `_impl_*()`
+   *   method which processed the original `value`.
+   * @throws {Error} Thrown if there was trouble with the visit.
+   */
+  async visitAsyncWrap() {
+    return this.#visitRoot().extractAsync();
+  }
+
+  /**
    * Similar to {@link #visitWrap}, except (a) it will fail if the visit did not
    * finish synchronously; and (b) the result is not wrapped. Specifically with
    * respect to (b), if a promise is returned, it is only ever because an
@@ -221,17 +232,6 @@ export class BaseValueVisitor {
     return entry.isFinished()
       ? entry.extractSync(true)
       : entry.extractAsync();
-  }
-
-  /**
-   * Like {@link #visitWrap}, except that it always operates asynchronously.
-   *
-   * @returns {VisitResult} Whatever result was returned from the `_impl_*()`
-   *   method which processed the original `value`.
-   * @throws {Error} Thrown if there was trouble with the visit.
-   */
-  async visitAsyncWrap() {
-    return this.#visitRoot().extractAsync();
   }
 
   /**

--- a/src/valvis/tests/BaseValueVisitor.test.js
+++ b/src/valvis/tests/BaseValueVisitor.test.js
@@ -1494,40 +1494,6 @@ ${'visitSync'}      | ${false} | ${true}  | ${false}
 ${'visitWrap'}      | ${true}  | ${true}  | ${true}
 ${'visitAsyncWrap'} | ${true}  | ${false} | ${true}
 `('$methodName()', ({ methodName, isAsync, isSync, wraps }) => {
-  async function doTest(value, options = {}) {
-    const {
-      cls      = BaseValueVisitor,
-      check    = (got, visitor_unused) => { expect(got).toBe(value); },
-      runsSync = isSync && !isAsync
-    } = options;
-
-    if (isSync && !isAsync && !runsSync) {
-      // This unit test shouldn't have been called for this method.
-      throw new Error('Test should not have been run!');
-    }
-
-    const visitor = new cls(value);
-    const got     = visitor[methodName]();
-
-    const callCheck = (wrapperOrResult) => {
-      if (wraps) {
-        const wrapper = wrapperOrResult;
-        expect(wrapper).toBeInstanceOf(VisitResult);
-        check(wrapper.value, visitor);
-      } else {
-        const result = wrapperOrResult;
-        check(result, visitor);
-      }
-    };
-
-    if (runsSync && isSync) {
-      callCheck(got);
-    } else {
-      expect(got).toBeInstanceOf(Promise);
-      callCheck(await got);
-    }
-  }
-
   if (isSync) {
     test('works on a smoke-test-ish sync example', () => {
       class TestVisitor extends BaseValueVisitor {


### PR DESCRIPTION
This PR adds convenience `static` visitor methods to `BaseValueVisitor`, to make a common use pattern less boilerplatey.