### PR TITLE
Hostname canonicalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
-* None.
+* `webapp-builtins`:
+  * Removed `ignoreCase` option from `HostRouter`, because per RFC one is never
+    supposed to treat hostname case as significant.
 
 Other notable changes:
 * `net-util`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Breaking changes:
 * None.
 
 Other notable changes:
+* `net-util`:
+  * Tightened up `HostInfo`, and added a little more functionality.
 * `valvis`:
   * `BaseValueVisitor`:
     * New `static` convenience methods to cover a common use pattern.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,18 @@ versioning principles. Unstable releases do not.
 ### [Unreleased]
 
 Breaking changes:
+* `net-util`:
+  * Made hostname canonicalization always include both lowercasing of DNS names
+    and removal of brackets around IPv6 addresses.
+  * `HostInfo`:
+    * As a result of the change to canonicalization (above), removed the method
+      `toLowerCase()`.
 * `webapp-builtins`:
   * Removed `ignoreCase` option from `HostRouter`, because per RFC one is never
     supposed to treat hostname case as significant.
 
 Other notable changes:
-* `net-util`:
-  * Tightened up `HostInfo`, and added a little more functionality.
+  * Added a little more functionality to `HostInfo`.
 * `valvis`:
   * `BaseValueVisitor`:
     * New `static` convenience methods to cover a common use pattern.

--- a/doc/configuration/4-built-in-applications.md
+++ b/doc/configuration/4-built-in-applications.md
@@ -67,11 +67,6 @@ following configuration bindings:
   the _names_ of other applications as values. A wildcard only covers the prefix
   of a hostname and cannot be used for hostnames identified by numeric IP
   address.
-* `ignoreCase` &mdash; Optional boolean indicating whether (`true`) or not
-  (`false`) the case of hostnames should be ignored and always looked up as
-  lowercase. Default `true`, which is the generally-accepted behavior of
-  websites. **Note:** This setting does not affect the hostname as received by
-  applications.
 
 **Note:** Unlike `PathRouter`, this application does not do fallback to
 less-and-less specific routes; it just finds (at most) one to route to.

--- a/etc/example-setup/config/config.mjs
+++ b/etc/example-setup/config/config.mjs
@@ -163,7 +163,6 @@ const applications = [
   {
     name:       'myHosts',
     class:      HostRouter,
-    ignoreCase: true,
     hosts: {
       '*':         'myPaths',
       '127.0.0.1': 'mySeries',

--- a/src/net-util/export/EndpointAddress.js
+++ b/src/net-util/export/EndpointAddress.js
@@ -62,7 +62,8 @@ export class EndpointAddress extends IntfDeconstructable {
   }
 
   /**
-   * @returns {?string} The IP address, or `null` if unknown.
+   * @returns {?string} The IP address, or `null` if unknown. In the case of an
+   * IPv6 address, this does _not_ include square brackets around the result.
    */
   get address() {
     return this.#address;

--- a/src/net-util/export/EndpointAddress.js
+++ b/src/net-util/export/EndpointAddress.js
@@ -6,10 +6,10 @@ import { MustBe } from '@this/typey';
 
 
 /**
- * The address of a network endpoint, consisting of an IP address and port. This
- * can be used for either the local or origin (remote) side of a network
- * connection. This class only accepts numerical IP addresses, not hostnames.
- * Instances of this class are immutable.
+ * The address of a network endpoint, consisting of an IP address (not a
+ * hostname) and port. This can be used for either the local or origin (remote)
+ * side of a network connection. This class only accepts numerical IP addresses,
+ * not hostnames. Instances of this class are immutable.
  *
  * **Note:** This class allows the details of instances to be "unknown." This is
  * unusual in practice, though it _can_ happen. Specifically, Node will report

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -73,8 +73,8 @@ export class HostInfo extends IntfDeconstructable {
     // Note: The regex is a bit lenient. TODO: Maybe it shouldn't be?
     this.#nameString = MustBe.string(nameString, /^[-_.:[\]a-zA-Z0-9]+$/);
 
-    this.#portNumber = AskIf.string(portNumber)
-      ? Number(MustBe.string(portNumber, /^[0-9]+$/))
+    this.#portNumber = AskIf.string(portNumber, /^[0-9]+$/)
+      ? Number(portNumber)
       : MustBe.number(portNumber);
 
     MustBe.number(this.#portNumber, {

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -51,13 +51,6 @@ export class HostInfo extends IntfDeconstructable {
   #nameKey = null;
 
   /**
-   * The result of {@link #toLowerCase}, or `null` if not yet calculated.
-   *
-   * @type {HostInfo}
-   */
-  #lowercaseVersion = null;
-
-  /**
    * Constructs an instance. **Note:** IPv6 addresses must _not_ include square
    * brackets.
    *
@@ -72,8 +65,10 @@ export class HostInfo extends IntfDeconstructable {
   constructor(nameString, portNumber) {
     super();
 
-    // Note: The regex is a bit lenient. TODO: Maybe it shouldn't be?
-    this.#nameString = MustBe.string(nameString, /^[-_.:a-zA-Z0-9]+$/);
+    // Note: The regex is a bit lenient, though notably it _does_ at least
+    // guarantee that there are no uppercase letters. TODO: Maybe it should be
+    // more restrictive?
+    this.#nameString = MustBe.string(nameString, /^[-_.:a-z0-9]+$/);
 
     this.#portNumber = AskIf.string(portNumber, /^0*[0-9]{1,5}$/)
       ? Number(portNumber)
@@ -158,26 +153,6 @@ export class HostInfo extends IntfDeconstructable {
     }
 
     return this.#nameIsIp;
-  }
-
-  /**
-   * Gets an instance of this class which is identical to `this` but with the
-   * name lowercased. If this instance's name is already all-lowercase, then
-   * this method returns `this`.
-   *
-   * @returns {HostInfo} The lowercased version.
-   */
-  toLowerCase() {
-    if (this.#lowercaseVersion === null) {
-      const name      = this.#nameString;
-      const lowerName = name.toLowerCase();
-
-      this.#lowercaseVersion = (name === lowerName)
-        ? this
-        : new HostInfo(lowerName, this.#portNumber);
-    }
-
-    return this.#lowercaseVersion;
   }
 
 

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -124,10 +124,9 @@ export class HostInfo extends IntfDeconstructable {
    */
   get namePortString() {
     if (!this.#namePortString) {
-      const nameString = this.#nameString;
+      const nameString = this.#nameWithBracketsIfNecessary();
       const portString = this.portString;
-      const namePart   = (this.nameType === 'ipv6') ? `[${nameString}]` : nameString;
-      this.#namePortString = `${namePart}:${portString}`;
+      this.#namePortString = `${nameString}:${portString}`;
     }
 
     return this.#namePortString;
@@ -195,7 +194,7 @@ export class HostInfo extends IntfDeconstructable {
    */
   getNamePortString(portToElide = null) {
     return (this.#portNumber === portToElide)
-      ? this.#nameString
+      ? this.#nameWithBracketsIfNecessary()
       : this.namePortString;
   }
 
@@ -206,6 +205,17 @@ export class HostInfo extends IntfDeconstructable {
    */
   nameIsIpAddress() {
     return this.nameType !== 'dns';
+  }
+
+  /**
+   * Gets the name string, but including brackets if it's an IPv6 address.
+   *
+   * @returns {string} The possibly-bracketed name string.
+   */
+  #nameWithBracketsIfNecessary() {
+    const nameString = this.#nameString;
+
+    return (this.nameType === 'ipv6') ? `[${nameString}]` : nameString;
   }
 
 

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -202,9 +202,10 @@ export class HostInfo extends IntfDeconstructable {
 
   /**
    * Constructs an instance of this class by parsing a string in the format used
-   * by the `Host` header of an HTTP-ish request. The local port number, if
-   * provided, is used when there is no explicit port number in `hostString`; if
-   * needed and not provided, it is treated as if it is `0`.
+   * by the `Host` header of an HTTP-ish request, that is, a hostname and port
+   * number separated by a colon (`:`). The local port number, if provided, is
+   * used when there is no explicit port number in `hostString`; if needed and
+   * not provided, it is treated as if it is `0`.
    *
    * @param {string} hostString The `Host` header string to parse.
    * @param {?number} [localPort] Local port being listened on, if known.
@@ -241,7 +242,7 @@ export class HostInfo extends IntfDeconstructable {
 
     // Basic top-level parse.
     const topParse =
-      hostString.match(/^(?<hostname>\[.{1,39}\]|[^:]{1,256})(?::(?<port>[0-9]{1,5}))?$/)?.groups;
+      hostString.match(/^(?<hostname>\[.{1,39}\]|[^:]{1,256})(?::(?<port>0*[0-9]{1,5}))?$/)?.groups;
 
     if (!topParse) {
       return null;

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -64,7 +64,8 @@ export class HostInfo extends IntfDeconstructable {
    * **Note:** You are probably better off constructing an instance using one of
    * the static methods on this class.
    *
-   * @param {string} nameString The name string.
+   * @param {string} nameString The name string, which is assumed to be
+   *   in canonicalized form.
    * @param {string|number} portNumber The port number, as either a number per
    *   se or a string.
    */

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -130,6 +130,19 @@ export class HostInfo extends IntfDeconstructable {
   }
 
   /**
+   * Indicates whether the given other instance is an instance of this class
+   * with the same information.
+   *
+   * @param {*} other Instance to compare.
+   * @returns {boolean} `true` iff this instance is equal to `other`.
+   */
+  equals(other) {
+    return (other instanceof HostInfo)
+      && (this.#nameString === other.#nameString)
+      && (this.#portNumber === other.#portNumber);
+  }
+
+  /**
    * Gets the name-and-port string, colon separated, except without the port if
    * it is equal to the given one.
    *

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -58,7 +58,8 @@ export class HostInfo extends IntfDeconstructable {
   #lowercaseVersion = null;
 
   /**
-   * Constructs an instance.
+   * Constructs an instance. **Note:** IPv6 addresses must _not_ include square
+   * brackets.
    *
    * **Note:** You are probably better off constructing an instance using one of
    * the static methods on this class.
@@ -71,7 +72,7 @@ export class HostInfo extends IntfDeconstructable {
     super();
 
     // Note: The regex is a bit lenient. TODO: Maybe it shouldn't be?
-    this.#nameString = MustBe.string(nameString, /^[-_.:[\]a-zA-Z0-9]+$/);
+    this.#nameString = MustBe.string(nameString, /^[-_.:a-zA-Z0-9]+$/);
 
     this.#portNumber = AskIf.string(portNumber, /^0*[0-9]{1,5}$/)
       ? Number(portNumber)

--- a/src/net-util/export/HostInfo.js
+++ b/src/net-util/export/HostInfo.js
@@ -73,7 +73,7 @@ export class HostInfo extends IntfDeconstructable {
     // Note: The regex is a bit lenient. TODO: Maybe it shouldn't be?
     this.#nameString = MustBe.string(nameString, /^[-_.:[\]a-zA-Z0-9]+$/);
 
-    this.#portNumber = AskIf.string(portNumber, /^[0-9]+$/)
+    this.#portNumber = AskIf.string(portNumber, /^0*[0-9]{1,5}$/)
       ? Number(portNumber)
       : MustBe.number(portNumber);
 

--- a/src/net-util/export/HostUtil.js
+++ b/src/net-util/export/HostUtil.js
@@ -39,7 +39,7 @@ export class HostUtil {
 
   /**
    * Checks that a given string can be used as a hostname, including non-"any"
-   * IP addresses.
+   * IP addresses. Returns the canonicalized version.
    *
    * @param {string} name Hostname to parse.
    * @param {boolean} [allowWildcard] Is a wildcard form allowed for `name`?

--- a/src/net-util/tests/HostInfo.test.js
+++ b/src/net-util/tests/HostInfo.test.js
@@ -273,6 +273,16 @@ describe('getNamePortString()', () => {
 
     expect(hi.getNamePortString(111)).toBe('bonk.boop');
   });
+
+  test('brackets an IPv6 address when the port is included', () => {
+    const hi = new HostInfo('7654::3210', 99);
+    expect(hi.getNamePortString()).toBe('[7654::3210]:99');
+  });
+
+  test('brackets an IPv6 address when the port is _not_ included', () => {
+    const hi = new HostInfo('7654::3210', 99);
+    expect(hi.getNamePortString(99)).toBe('[7654::3210]');
+  });
 });
 
 describe('nameIsIpAddress()', () => {

--- a/src/net-util/tests/HostInfo.test.js
+++ b/src/net-util/tests/HostInfo.test.js
@@ -124,10 +124,35 @@ describe('.nameString', () => {
 
 describe('.namePortString', () => {
   test('gets the name and port that were passed in the constructor', () => {
-    const name = 'floop.florp';
-    const hi   = new HostInfo(name, 123);
-
+    const hi = new HostInfo('floop.florp', 123);
     expect(hi.namePortString).toBe('floop.florp:123');
+  });
+
+  test('brackets IPv6 addresses', () => {
+    const hi = new HostInfo('12:34::ab:cd', 321);
+    expect(hi.namePortString).toBe('[12:34::ab:cd]:321');
+  });
+
+  test('does not bracket IPv4 addresses', () => {
+    const hi = new HostInfo('12.34.56.78', 90);
+    expect(hi.namePortString).toBe('12.34.56.78:90');
+  });
+});
+
+describe('.nameType', () => {
+  test('returns `ipv4` for an IPv4 address', () => {
+    const hi = new HostInfo('127.0.0.1', 1);
+    expect(hi.nameType).toBe('ipv4');
+  });
+
+  test('returns `ipv6` for an IPv6 address', () => {
+    const hi = new HostInfo('1234::5678:9:a', 1);
+    expect(hi.nameType).toBe('ipv6');
+  });
+
+  test('returns `dns` for a DNS name', () => {
+    const hi = new HostInfo('this.is.a.host', 1);
+    expect(hi.nameType).toBe('dns');
   });
 });
 

--- a/src/net-util/tests/HostInfo.test.js
+++ b/src/net-util/tests/HostInfo.test.js
@@ -34,12 +34,47 @@ describe('constructor', () => {
   ${0.5}
   ${65535.9}
   ${65536}
+
+  // Valid number-as-string but not a valid port number.
+  ${'111111'}
+  ${'0.5'}
+  ${'-1'}
+  ${'1e2'}
+  ${'65536'}
   `('fails when passing port as $arg', ({ arg }) => {
     expect(() => new HostInfo('host', arg)).toThrow();
   });
 
-  test('accepts a valid port number string', () => {
-    expect(() => new HostInfo('host', '123')).not.toThrow();
+  test.each`
+  arg
+  ${'0'}
+  ${'00'}
+  ${'00000000000'}
+  ${'1'}
+  ${'01'}
+  ${'000001'}
+  ${'99'}
+  ${'888'}
+  ${'7777'}
+  ${'12345'}
+  ${'65535'}
+  ${'065535'}
+  ${'0000000000065535'}
+  `('accepts valid port number string $arg', ({ arg }) => {
+    expect(() => new HostInfo('host', arg)).not.toThrow();
+  });
+
+  test.each`
+  arg
+  ${0}
+  ${1}
+  ${22}
+  ${333}
+  ${4444}
+  ${55555}
+  ${65535}
+  `('accepts valid port number $arg', ({ arg }) => {
+    expect(() => new HostInfo('host', arg)).not.toThrow();
   });
 });
 
@@ -93,7 +128,7 @@ describe('.portNumber', () => {
 
   test('gets the parsed port number-as-string that was passed in the constructor', () => {
     const port = 7771;
-    const hi   = new HostInfo('host', port.toString());
+    const hi   = new HostInfo('host', '0000' + port.toString());
 
     expect(hi.portNumber).toBe(port);
   });

--- a/src/net-util/tests/HostInfo.test.js
+++ b/src/net-util/tests/HostInfo.test.js
@@ -233,31 +233,6 @@ describe('nameIsIpAddress()', () => {
   });
 });
 
-describe('toLowerCase()', () => {
-  test('returns `this` if the name is already all-lowercase', () => {
-    const hi = new HostInfo('fleep.florp', 123);
-    expect(hi.toLowerCase()).toBe(hi);
-  });
-
-  test('returns a correct new instance if the name needs to be lowercased', () => {
-    const hi  = new HostInfo('fleEP.florp', 123);
-    const got = hi.toLowerCase();
-
-    expect(got).not.toBe(hi);
-    expect(got.portNumber).toBe(123);
-    expect(got.nameString).toBe('fleep.florp');
-  });
-
-  test('returns the same not-`this` result on subsequent calls', () => {
-    const hi   = new HostInfo('fleep.florP', 123);
-    const got1 = hi.toLowerCase();
-    const got2 = hi.toLowerCase();
-
-    expect(got1).not.toBe(hi);
-    expect(got2).toBe(got1);
-  });
-});
-
 
 //
 // Static members

--- a/src/net-util/tests/HostInfo.test.js
+++ b/src/net-util/tests/HostInfo.test.js
@@ -183,6 +183,50 @@ describe('deconstruct()', () => {
   });
 });
 
+describe('equals()', () => {
+  test.each`
+  arg
+  ${undefined}
+  ${null}
+  ${false}
+  ${123}
+  ${'1.2.3.4'}
+  ${[1, 2]}
+  ${{ a: 'x' }}
+  ${new Map()}
+  `('returns `false` when given non-`HostInfo`: $arg', ({ arg }) => {
+    const hi = new HostInfo('1.2.3.4', 5);
+    expect(hi.equals(arg)).toBeFalse();
+  });
+
+  test('returns `true` when passed `this`', () => {
+    const hi = new HostInfo('a.b', 123);
+
+    expect(hi.equals(hi)).toBeTrue();
+  });
+
+  test('returns `true` when passed an instance which was constructed with the same values', () => {
+    const hi1 = new HostInfo('a::b', 999);
+    const hi2 = new HostInfo('a::b', 999);
+
+    expect(hi1.equals(hi2)).toBeTrue();
+  });
+
+  test('returns `false` when passed an instance with a matching host but different port', () => {
+    const hi1 = new HostInfo('1.2.3.4', 999);
+    const hi2 = new HostInfo('1.2.3.4', 888);
+
+    expect(hi1.equals(hi2)).toBeFalse();
+  });
+
+  test('returns `false` when passed an instance with a matching port but different host', () => {
+    const hi1 = new HostInfo('1.2.3.4', 777);
+    const hi2 = new HostInfo('1:2::3:4', 777);
+
+    expect(hi1.equals(hi2)).toBeFalse();
+  });
+});
+
 describe('getNamePortString()', () => {
   test('does not skip the port if it does not match', () => {
     const name = 'bonk.boop';

--- a/src/net-util/tests/HostInfo.test.js
+++ b/src/net-util/tests/HostInfo.test.js
@@ -16,6 +16,7 @@ describe('constructor', () => {
   ${1}
   ${['x']}
   ${''}
+  ${'[a::b]'} // IPv6 addresses must not use brackets.
   `('fails when passing name as $arg', ({ arg }) => {
     expect(() => new HostInfo(arg, 123)).toThrow();
   });
@@ -75,6 +76,18 @@ describe('constructor', () => {
   ${65535}
   `('accepts valid port number $arg', ({ arg }) => {
     expect(() => new HostInfo('host', arg)).not.toThrow();
+  });
+
+  test.each`
+  arg
+  ${'host'}
+  ${'host.sub'}
+  ${'1.2.3.4'}
+  ${'01.02.03.04'}
+  ${'a:b::c:d'}
+  ${'0a:0123:0:0::987a'}
+  `('accepts valid host name $arg', ({ arg }) => {
+    expect(() => new HostInfo(arg, 1)).not.toThrow();
   });
 });
 
@@ -200,12 +213,9 @@ describe('nameIsIpAddress()', () => {
   });
 
   test('returns `true` given an IPv6 address for the name', () => {
-    const address = '1234:abcd::ef';
-    const hi1     = new HostInfo(address, 123);
-    const hi2     = new HostInfo(`[${address}]`, 123);
+    const hi = new HostInfo('1234:abcd::ef', 123);
 
-    expect(hi1.nameIsIpAddress()).toBeTrue();
-    expect(hi2.nameIsIpAddress()).toBeTrue();
+    expect(hi.nameIsIpAddress()).toBeTrue();
   });
 
   // Various `false` cases.

--- a/src/net-util/tests/HostUtil.test.js
+++ b/src/net-util/tests/HostUtil.test.js
@@ -94,7 +94,7 @@ ${'parseHostnameElseNull'}        | ${false} | ${'path'}
       } else {
         expect(got).toBe(canonicalName);
       }
-    } else if (returns == 'path') {
+    } else if (returns === 'path') {
       if (canonicalIp) {
         expect(got.wildcard).toBeFalse();
         expect(got.length).toBe(1);

--- a/src/net-util/tests/HostUtil.test.js
+++ b/src/net-util/tests/HostUtil.test.js
@@ -84,26 +84,32 @@ ${'parseHostnameElseNull'}        | ${false} | ${'path'}
   const checkAnswer = (hostname, got) => {
     expect(got).not.toBeNull();
 
-    const canonicalIp = EndpointAddress.canonicalizeAddressElseNull(hostname, false);
+    const canonicalIp   = EndpointAddress.canonicalizeAddressElseNull(hostname, false);
+    const canonicalName = canonicalIp ? null : hostname.toLowerCase();
 
     if (returns === 'string') {
       if (canonicalIp) {
         // Expect IP addresses to be canonicalized.
         expect(got).toBe(canonicalIp);
       } else {
-        expect(got).toBe(hostname);
+        expect(got).toBe(canonicalName);
       }
-    } else if (canonicalIp) {
-      expect(got.wildcard).toBeFalse();
-      expect(got.length).toBe(1);
-      expect(got.path[0]).toBe(canonicalIp);
-    } else {
-      const expectWildcard = hostname.startsWith('*');
-      const expectLength   = hostname.replace(/[^.]/g, '').length + Number(!expectWildcard);
+    } else if (returns == 'path') {
+      if (canonicalIp) {
+        expect(got.wildcard).toBeFalse();
+        expect(got.length).toBe(1);
+        expect(got.path[0]).toBe(canonicalIp);
+      } else {
+        const expectWildcard = canonicalName.startsWith('*');
+        const expectLength   = canonicalName.replace(/[^.]/g, '').length + Number(!expectWildcard);
 
-      expect(got.wildcard).toBe(expectWildcard);
-      expect(got.length).toBe(expectLength);
-      expect(HostUtil.hostnameStringFrom(got)).toBe(hostname);
+        expect(got.wildcard).toBe(expectWildcard);
+        expect(got.length).toBe(expectLength);
+        expect(HostUtil.hostnameStringFrom(got)).toBe(canonicalName);
+      }
+    } else {
+      // We forgot to add a case in this test.
+      throw new Error('Shouldn\'t happen.');
     }
   };
 

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -109,12 +109,15 @@ export class HostRouter extends BaseApplication {
       _config_hosts(value) {
         MustBe.plainObject(value);
 
+        const hosts = new TreeMap();
+
         for (const [host, name] of Object.entries(value)) {
           Names.mustBeName(name);
-          HostUtil.canonicalizeHostname(host, true);
+          const key = HostUtil.parseHostname(host, true);
+          hosts.add(key, name);
         }
 
-        return value;
+        return Object.freeze(hosts);
       }
 
       /**
@@ -126,24 +129,6 @@ export class HostRouter extends BaseApplication {
        */
       _config_ignoreCase(value = true) {
         return MustBe.boolean(value);
-      }
-
-      /** @override */
-      _impl_validate(config) {
-        // We can (and do) only create the `hosts` map here, after we know the
-        // value for `ignoreCase`. TODO: Not true anymore!
-
-        const { hosts: hostsObj } = config;
-        const hosts                           = new TreeMap();
-
-        for (const [host, name] of Object.entries(hostsObj)) {
-          const keyString = host.toLowerCase();
-          const key       = HostUtil.parseHostname(keyString, true);
-          hosts.add(key, name);
-        }
-        Object.freeze(hosts);
-
-        return { ...config, hosts };
       }
     };
   }

--- a/src/webapp-builtins/export/HostRouter.js
+++ b/src/webapp-builtins/export/HostRouter.js
@@ -14,13 +14,6 @@ import { BaseApplication } from '@this/webapp-core';
  */
 export class HostRouter extends BaseApplication {
   /**
-   * Same value as in the config object.
-   *
-   * @type {boolean}
-   */
-  #ignoreCase = null;
-
-  /**
    * Map which goes from a host prefix to a handler (typically a
    * {@link BaseApplication}) which should handle that prefix. Gets set in
    * {@link #_impl_start}.
@@ -66,7 +59,7 @@ export class HostRouter extends BaseApplication {
     // the case that all of the referenced apps have already been added when
     // that runs.
 
-    const { hosts, ignoreCase } = this.config;
+    const { hosts } = this.config;
 
     const appManager = this.root.applicationManager;
     const routeTree  = new TreeMap();
@@ -76,8 +69,7 @@ export class HostRouter extends BaseApplication {
       routeTree.add(host, app);
     }
 
-    this.#ignoreCase = ignoreCase;
-    this.#routeTree  = routeTree;
+    this.#routeTree = routeTree;
 
     await super._impl_start();
   }
@@ -90,7 +82,7 @@ export class HostRouter extends BaseApplication {
    *   match.
    */
   #applicationFromHost(host) {
-    const key   = this.#ignoreCase ? host.toLowerCase().nameKey : host.nameKey;
+    const key   = host.nameKey;
     const found = this.#routeTree.find(key);
 
     return found?.value ?? null;
@@ -139,13 +131,13 @@ export class HostRouter extends BaseApplication {
       /** @override */
       _impl_validate(config) {
         // We can (and do) only create the `hosts` map here, after we know the
-        // value for `ignoreCase`.
+        // value for `ignoreCase`. TODO: Not true anymore!
 
-        const { hosts: hostsObj, ignoreCase } = config;
+        const { hosts: hostsObj } = config;
         const hosts                           = new TreeMap();
 
         for (const [host, name] of Object.entries(hostsObj)) {
-          const keyString = ignoreCase ? host.toLowerCase() : host;
+          const keyString = host.toLowerCase();
           const key       = HostUtil.parseHostname(keyString, true);
           hosts.add(key, name);
         }

--- a/src/webapp-builtins/tests/HostRouter.test.js
+++ b/src/webapp-builtins/tests/HostRouter.test.js
@@ -17,13 +17,6 @@ describe('constructor', () => {
     })).not.toThrow();
   });
 
-  test('accepts a valid minimal configuration with `ignoreCase`', () => {
-    expect(() => new HostRouter({
-      hosts:      {},
-      ignoreCase: false
-    })).not.toThrow();
-  });
-
   test('accepts a valid configuration with several non-wildcard hosts', () => {
     expect(() => new HostRouter({
       hosts: {
@@ -60,9 +53,8 @@ describe('constructor', () => {
     })).not.toThrow();
   });
 
-  test('does not allow two names that differ only in case when `ignoreCase === true`', () => {
+  test('does not allow two names that differ only in case', () => {
     expect(() => new HostRouter({
-      ignoreCase: true,
       hosts: {
         'Boop.bop': 'app1',
         'booP.bop': 'app2'
@@ -70,30 +62,11 @@ describe('constructor', () => {
     })).toThrow();
 
     expect(() => new HostRouter({
-      ignoreCase: true,
       hosts: {
         '*.ZONK': 'app1',
         '*.ZoNK': 'app2'
       }
     })).toThrow();
-  });
-
-  test('allows two names that differ only in case when `ignoreCase === false`', () => {
-    expect(() => new HostRouter({
-      ignoreCase: false,
-      hosts: {
-        'Boop.bop': 'app1',
-        'booP.bop': 'app2'
-      }
-    })).not.toThrow();
-
-    expect(() => new HostRouter({
-      ignoreCase: false,
-      hosts: {
-        '*.ZONK': 'app1',
-        '*.ZoNK': 'app2'
-      }
-    })).not.toThrow();
   });
 
   test.each`
@@ -268,10 +241,9 @@ describe('_impl_handleRequest()', () => {
     await expectApp(hr, 'zorch.splat', 'mockApp1');
   });
 
-  test('routes to a case-folded DNS name when `ignoreCase === true`', async () => {
+  test('routes to a case-folded DNS name', async () => {
     const hr = await makeInstance(
       {
-        ignoreCase: true,
         hosts: {
           'splat':             'mockApp2',
           'ZORCH.splat':       'mockApp1',
@@ -284,10 +256,9 @@ describe('_impl_handleRequest()', () => {
     await expectApp(hr, 'zorch.SPLAT', 'mockApp1');
   });
 
-  test('routes to a case-folded name and not a wildcard, when `ignoreCase === true`', async () => {
+  test('routes to a matching case-folded DNS name and not a wildcard', async () => {
     const hr = await makeInstance(
       {
-        ignoreCase: true,
         hosts: {
           'splat':       'mockApp2',
           'ZORCH.splat': 'mockApp1',
@@ -299,21 +270,6 @@ describe('_impl_handleRequest()', () => {
     );
 
     await expectApp(hr, 'zorCH.splAT', 'mockApp1');
-  });
-
-  test('routes to a case-matched DNS name when `ignoreCase === false`', async () => {
-    const hr = await makeInstance(
-      {
-        ignoreCase: false,
-        hosts: {
-          'ZORCH.splat': 'mockApp1',
-          'zorch.SPLAT': 'mockApp2'
-        }
-      },
-      { appCount: 2 }
-    );
-
-    await expectApp(hr, 'zorch.SPLAT', 'mockApp2');
   });
 
   test('does not route to an exact-match DNS name as if it were a wildcard', async () => {


### PR DESCRIPTION
This PR cleans up hostname canonicalization, including making it so that hostnames are completely canonicalized once they're represented by instances of `HostInfo`. Notably, this means that they're always represented in lowercase form. As a result, both `HostInfo.toLowerCase()` and the `ignoreCase` option on `HostRouter` got removed, since they both became meaningless.
