### PR TITLE
Node versions for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,9 @@ jobs:
     strategy:
       matrix:
         node: ['20.x', '22.x', '24.x']
+        include:
+          - node: '24.x'
+          - fullBuild: true
     name: Build with Node v${{ matrix.node }}
     steps:
       - name: Get Node v${{ matrix.node }}.
@@ -89,7 +92,7 @@ jobs:
           }
 
       - name: Ensure the cert creator still works.
-        if: matrix.node == env.MAIN_NODE_VERSION
+        if: matrix.fullBuild == true
         run: ./scripts/ubik make-localhost-cert
 
       - name: Tarball artifact.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
 
-# Workflow. Jobs run in parallel by default, but that is moot here: there's only
-# one job.
+# Workflow. Jobs run in parallel by default.
 jobs:
   # Check dependencies.
   check-dependencies:
@@ -52,12 +51,14 @@ jobs:
   # Build the project.
   build:
     runs-on: ubuntu-latest
+    env:
+      mainNode: '24.x' # Which version to use for the full build.
     strategy:
       matrix:
         node: ['20.x', '22.x', '24.x']
     name: Build with Node v${{ matrix.node }}
     steps:
-      - name: Get Node.
+      - name: Get Node v${{ matrix.node }}.
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
@@ -86,9 +87,11 @@ jobs:
           }
 
       - name: Ensure the cert creator still works.
+        if: ${{ matrix.node == mainNode }}
         run: ./scripts/ubik make-localhost-cert
 
       - name: Tarball artifact.
+        if: ${{ matrix.node == mainNode }}
         uses: actions/upload-artifact@v4
         with:
           name: distro
@@ -98,6 +101,7 @@ jobs:
           retention-days: 90
 
       - name: node_modules artifact.
+        if: ${{ matrix.node == mainNode }}
         uses: actions/upload-artifact@v4
         with:
           name: node_modules
@@ -109,6 +113,7 @@ jobs:
           retention-days: 90
 
       - name: Announcement.
+        if: ${{ matrix.node == mainNode }}
         run: |
           info="$(jq . out/lactoserv/product-info.json)"
           printf '::notice title=product-info::%s\n' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 # Copyright 2022-2025 the Lactoserv Authors (Dan Bornstein et alia).
 # SPDX-License-Identifier: Apache-2.0
 
-name: Lint / Build / Test
+name: Main
 
 # Controls when the workflow will run.
 on:
@@ -18,6 +18,7 @@ on:
 jobs:
   # Check dependencies.
   check-dependencies:
+    name: Check dependencies
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
         run: ./scripts/ubik run-tests --type=integration
 
       - name: Run the unit tests, with coverage reporting.
-        if: matrix.node == env.MAIN_NODE_VERSION
+        if: matrix.fullBuild == true
         run: |
           ./scripts/ubik run-tests --type=unit-coverage || {
             echo 'Weird coverage-report failure (originally started happening'
@@ -96,7 +96,7 @@ jobs:
         run: ./scripts/ubik make-localhost-cert
 
       - name: Tarball artifact.
-        if: matrix.node == env.MAIN_NODE_VERSION
+        if: matrix.fullBuild == true
         uses: actions/upload-artifact@v4
         with:
           name: distro
@@ -106,7 +106,7 @@ jobs:
           retention-days: 90
 
       - name: node_modules artifact.
-        if: matrix.node == env.MAIN_NODE_VERSION
+        if: matrix.fullBuild == true
         uses: actions/upload-artifact@v4
         with:
           name: node_modules
@@ -118,7 +118,7 @@ jobs:
           retention-days: 90
 
       - name: Announcement.
-        if: matrix.node == env.MAIN_NODE_VERSION
+        if: matrix.fullBuild == true
         run: |
           info="$(jq . out/lactoserv/product-info.json)"
           printf '::notice title=product-info::%s\n' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         run: ./scripts/ubik run-tests --type=integration
 
       - name: Run the unit tests, with coverage reporting.
-        if: ${{ matrix.node == env.MAIN_NODE_VERSION }}
+        if: matrix.node == env.MAIN_NODE_VERSION
         run: |
           ./scripts/ubik run-tests --type=unit-coverage || {
             echo 'Weird coverage-report failure (originally started happening'
@@ -88,11 +88,11 @@ jobs:
           }
 
       - name: Ensure the cert creator still works.
-        if: ${{ matrix.node == env.MAIN_NODE_VERSION }}
+        if: matrix.node == env.MAIN_NODE_VERSION
         run: ./scripts/ubik make-localhost-cert
 
       - name: Tarball artifact.
-        if: ${{ matrix.node == env.MAIN_NODE_VERSION }}
+        if: matrix.node == env.MAIN_NODE_VERSION
         uses: actions/upload-artifact@v4
         with:
           name: distro
@@ -102,7 +102,7 @@ jobs:
           retention-days: 90
 
       - name: node_modules artifact.
-        if: ${{ matrix.node == env.MAIN_NODE_VERSION }}
+        if: matrix.node == env.MAIN_NODE_VERSION
         uses: actions/upload-artifact@v4
         with:
           name: node_modules
@@ -114,7 +114,7 @@ jobs:
           retention-days: 90
 
       - name: Announcement.
-        if: ${{ matrix.node == env.MAIN_NODE_VERSION }}
+        if: matrix.node == env.MAIN_NODE_VERSION
         run: |
           info="$(jq . out/lactoserv/product-info.json)"
           printf '::notice title=product-info::%s\n' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,11 +52,15 @@ jobs:
   # Build the project.
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['20.x', '22.x', '24.x']
+    name: Build with Node v${{ matrix.node }}
     steps:
       - name: Get Node.
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: ${{ matrix.node }}
 
       # Note: Checks out into `$GITHUB_WORKSPACE`, which is also the `$CWD`.
       - name: Clone repo.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,7 @@ jobs:
         run: ./scripts/ubik run-tests --type=integration
 
       - name: Run the unit tests, with coverage reporting.
+        if: ${{ matrix.node == env.MAIN_NODE_VERSION }}
         run: |
           ./scripts/ubik run-tests --type=unit-coverage || {
             echo 'Weird coverage-report failure (originally started happening'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      mainNode: '24.x' # Which version to use for the full build.
+      MAIN_NODE_VERSION: '24.x' # Which version to use for the full build.
     strategy:
       matrix:
         node: ['20.x', '22.x', '24.x']
@@ -87,11 +87,11 @@ jobs:
           }
 
       - name: Ensure the cert creator still works.
-        if: ${{ matrix.node == mainNode }}
+        if: ${{ matrix.node == env.MAIN_NODE_VERSION }}
         run: ./scripts/ubik make-localhost-cert
 
       - name: Tarball artifact.
-        if: ${{ matrix.node == mainNode }}
+        if: ${{ matrix.node == env.MAIN_NODE_VERSION }}
         uses: actions/upload-artifact@v4
         with:
           name: distro
@@ -101,7 +101,7 @@ jobs:
           retention-days: 90
 
       - name: node_modules artifact.
-        if: ${{ matrix.node == mainNode }}
+        if: ${{ matrix.node == env.MAIN_NODE_VERSION }}
         uses: actions/upload-artifact@v4
         with:
           name: node_modules
@@ -113,7 +113,7 @@ jobs:
           retention-days: 90
 
       - name: Announcement.
-        if: ${{ matrix.node == mainNode }}
+        if: ${{ matrix.node == env.MAIN_NODE_VERSION }}
         run: |
           info="$(jq . out/lactoserv/product-info.json)"
           printf '::notice title=product-info::%s\n' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         node: ['20.x', '22.x', '24.x']
         include:
           - node: '24.x'
-          - fullBuild: true
+            fullBuild: true
     name: Build with Node v${{ matrix.node }}
     steps:
       - name: Get Node v${{ matrix.node }}.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Breaking changes:
 * None.
 
 Other notable changes:
-* None.
+* Got CI set up to build and test with multiple versions of Node. As currently
+  configured, it uses Node v20, v22, and v24.
 
 ### v0.9.2 -- 2025-05-08 -- stable release
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To build:
   Windows, but if it does nobody has told anyone on the project.)
 * Recent-ish version of Bash (works with what macOS ships, which is about as
   old a version as you'll find on any up-to-date OS).
-* Node v20 or later (tested regularly on v20, v22, and v23).
+* Node v20 or later (tested regularly on v20, v22, v23, and v24).
 * Recent version of `jq` (v1.6 or later).
 
 To run (versions as above):


### PR DESCRIPTION
This PR makes CI do builds for multiple Node versions, with one being the "main" one in which to do a full build. For the other Node versions, the product is built and tests are run, but — for example — no artifacts are created.

As of this PR, Node v24 is the main one, with v20 and v22 as the non-main versions.