### PR TITLE
Allow Node 25 in runner version check

### DIFF
--- a/scripts/lib/lactoserv/dev
+++ b/scripts/lib/lactoserv/dev
@@ -65,7 +65,7 @@ function target-build {
         && env-minimize \
         && lib node-project build-main-module \
             --out="${outDir}" --modules-dirs="${srcDir}" \
-            --runner-script=run --runner-versions[]='20 21 22 23 24' \
+            --runner-script=run --runner-versions[]='20 21 22 23 24 25' \
             lactoserv
     )
 }


### PR DESCRIPTION
## Summary
- Adds Node 25 to the allowed runner versions list in `scripts/lib/lactoserv/dev`
- Node 25 was released after the previous version list update
- The build prerequisite check (`_prereqs`) already allows Node 20-29 via regex

## Test plan
- [x] `ubik dev lint` passes
- [x] `ubik run-tests --do=build` passes (unit tests)
- [x] `ubik run-tests --type=integration` passes